### PR TITLE
Implement continuously running container for backend

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -60,4 +60,4 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 EXPOSE 8801
 
 # Run the application.
-CMD ["sh", "-c", "PYTHONPATH=/app/apps/iEasyHydroForecast python apps/backend/run_offline_mode.py"]
+CMD ["sh", "-c", "PYTHONPATH=/app/apps/iEasyHydroForecast python apps/backend/run_offline_mode.py && sleep 86400"]

--- a/apps/backend/run_offline_mode.py
+++ b/apps/backend/run_offline_mode.py
@@ -41,6 +41,13 @@ try:
 except FileNotFoundError:
     last_successful_run_date = datetime.date.today() - datetime.timedelta(days=1)
 
+# Check if the forecasts have already been run for today
+# If yes, exit the program
+# If no, run the forecasts for today
+if last_successful_run_date == datetime.date.today():
+    print("Forecasts have already been run for today. Exiting the program.")
+    sys.exit()
+
 # Set the start and end dates
 # Start date is the last successful run date + 1 day
 # End date is today

--- a/bat/backend/backend.bat
+++ b/bat/backend/backend.bat
@@ -1,0 +1,5 @@
+:: Stop the container if it is currently running. 
+:: Continue with the execution of the script even if the command fails
+docker stop backend || echo.
+:: Start backend again to run todays forecast
+docker start backend


### PR DESCRIPTION
Dockerfile: After all forecasts are produced, the backend will sleep for 24 hours.
.bat: stop the container before starting it again (need to make sure this does not coincide with the watchtower update once deployed.
.py: exit if forecasts for today are already available.