### PR TITLE
Hindcast file clearing script and torch requirements

### DIFF
--- a/apps/machine_learning/clean_hindcast_folder.py
+++ b/apps/machine_learning/clean_hindcast_folder.py
@@ -95,24 +95,26 @@ def clean_hindcast_folder():
 
     PATH_HINDCAST = os.path.join(PATH_FORECAST, 'hindcast', MODEL_TO_USE)
 
+    # check if the path exists
+    if not os.path.exists(PATH_HINDCAST):
+        raise ValueError(f'Path to the hindcast folder does not exist: {PATH_HINDCAST}, Cannot clean it.')
+
     logger.info(f'Path to the hindcast folder: {PATH_HINDCAST}')
 
     # --------------------------------------------------------------------
     # check how many files are in the hindcast folder
     # --------------------------------------------------------------------
     files_in_hindcast = os.listdir(PATH_HINDCAST)
-    num_files_in_hindcast = len(files_in_hindcast)
-    logger.info(f'Number of files in the hindcast folder before cleaning: {num_files_in_hindcast}')
 
     # check if they are csv files
     csv_files_in_hindcast = [f for f in files_in_hindcast if f.endswith('.csv')]
     num_csv_files_in_hindcast = len(csv_files_in_hindcast)
-    logger.info(f'Number of csv files in the hindcast folder before cleaning: {num_csv_files_in_hindcast}')
+    logger.info(f'Number of csv files in the hindcast folder: {num_csv_files_in_hindcast}')
 
     # the files must contain "hindcast" in their name
     hindcast_files_in_hindcast = [f for f in csv_files_in_hindcast if 'hindcast' in f]
     num_hindcast_files_in_hindcast = len(hindcast_files_in_hindcast)
-    logger.info(f'Number of hindcast csv files in the hindcast folder before cleaning: {num_hindcast_files_in_hindcast}')
+    logger.info(f'Number of hindcast csv files in the hindcast folder with "hindcast" in name: {num_hindcast_files_in_hindcast}')
 
     # --------------------------------------------------------------------
     # Remove all files csv in the hindcast folder

--- a/apps/machine_learning/requirements.txt
+++ b/apps/machine_learning/requirements.txt
@@ -1,4 +1,4 @@
 darts==0.35.0
 PE-Oudin>=0.3
 suntime>=1.3.2
-torch==2.7.0
+torch==2.8.0


### PR DESCRIPTION
# Clear Hindcast files
In the folder ../predictions/hindcast/MODEL_XY were hindcast .csv files stored - used as a temporary file for other scripts like fill_ml_gaps. Those files accumulate and take up a lot of storage. The script "clean_hindcast_folder.py" goes through this filder and deletes all files with "hindcast" in it and which end on ".csv". 

# Torch 2.8.0
Updated torch version - this should help with the torch vulnerabilities.