### PR TITLE
get docker image date bug fixed

### DIFF
--- a/apps/pipeline/src/pipeline_utils.py
+++ b/apps/pipeline/src/pipeline_utils.py
@@ -17,12 +17,16 @@ def get_docker_hub_image_creation_date(namespace, image_name):
     url = f"https://hub.docker.com//v2/namespaces/{namespace}/repositories/{image_name}/"
 
     # Get the docker image manifest data
-    response = requests.get(url)
-    if response.status_code == 200:
-        manifest_data = response.json()
-        return manifest_data['last_updated']  
-    else:
-        print(f"Failed to fetch image data from Docker Hub: {response.status_code}")
+    try:
+        response = requests.get(url, timeout=10)
+        if response.status_code == 200:
+            manifest_data = response.json()
+            return manifest_data.get('last_updated')  # Use .get() for safety
+        else:
+            print(f"Failed to fetch image data from Docker Hub: {response.status_code}")
+            return None
+    except requests.RequestException as e:
+        print(f"Failed to reach Docker Hub: {e}")
         return None
 
 def there_is_a_newer_image_on_docker_hub(client, repository, image_name, tag):
@@ -35,14 +39,15 @@ def there_is_a_newer_image_on_docker_hub(client, repository, image_name, tag):
             local_image_creation_date = local_image_creation_date.replace(tzinfo=pytz.UTC)
 
         # Get the Docker Hub image creation time
-        hub_image_creation_date = parse(get_docker_hub_image_creation_date(repository, image_name))
+        hub_image_creation_date_str = get_docker_hub_image_creation_date(repository, image_name)
+        if not hub_image_creation_date_str:
+            print("Failed to fetch the Docker Hub image creation date.")
+            return False
+
+        hub_image_creation_date = parse(hub_image_creation_date_str)
         # Ensure the Docker Hub image creation date is offset-aware
         if hub_image_creation_date.tzinfo is None or hub_image_creation_date.tzinfo.utcoffset(hub_image_creation_date) is None:
             hub_image_creation_date = hub_image_creation_date.replace(tzinfo=pytz.UTC)
-
-        if not hub_image_creation_date:
-            print("Failed to fetch the Docker Hub image creation date.")
-            return False
 
         if hub_image_creation_date > local_image_creation_date:
             print("The Docker Hub image is newer than the local image.")

--- a/apps/pipeline/tests/test_pipeline_utils.py
+++ b/apps/pipeline/tests/test_pipeline_utils.py
@@ -1,0 +1,61 @@
+import requests
+from dateutil.parser import parse
+
+
+def get_docker_hub_image_creation_date(namespace, image_name):
+    """Copy of the function for testing without docker dependency."""
+    url = f"https://hub.docker.com//v2/namespaces/{namespace}/repositories/{image_name}/"
+
+    try:
+        response = requests.get(url, timeout=10)
+        if response.status_code == 200:
+            manifest_data = response.json()
+            return manifest_data.get('last_updated')
+        else:
+            print(f"Failed to fetch image data from Docker Hub: {response.status_code}")
+            return None
+    except requests.RequestException as e:
+        print(f"Failed to reach Docker Hub: {e}")
+        return None
+
+
+def test_get_docker_hub_image_creation_date_sapphire_ml():
+    """Test that we get a valid image creation date for mabesa/sapphire-ml."""
+    namespace = "mabesa"
+    image_name = "sapphire-ml"
+
+    result = get_docker_hub_image_creation_date(namespace, image_name)
+
+    # Should not be None
+    assert result is not None, "Failed to fetch image creation date from Docker Hub"
+
+    # Should be a parseable date string
+    parsed_date = parse(result)
+    assert parsed_date is not None, "Failed to parse the returned date string"
+
+    # Should have timezone info (Docker Hub returns ISO format with timezone)
+    print(f"Image creation date: {result}")
+    print(f"Parsed date: {parsed_date}")
+
+
+def test_get_docker_hub_image_creation_date_nonexistent():
+    """Test that we get None for a non-existent image."""
+    namespace = "mabesa"
+    image_name = "this_image_does_not_exist_12345"
+
+    result = get_docker_hub_image_creation_date(namespace, image_name)
+
+    # Should be None for non-existent image
+    assert result is None, "Expected None for non-existent image"
+
+
+if __name__ == "__main__":
+    print("Testing get_docker_hub_image_creation_date with mabesa/sapphire-ml...")
+    test_get_docker_hub_image_creation_date_sapphire_ml()
+    print("✓ Test passed!\n")
+
+    print("Testing get_docker_hub_image_creation_date with non-existent image...")
+    test_get_docker_hub_image_creation_date_nonexistent()
+    print("✓ Test passed!\n")
+
+    print("All tests passed!")


### PR DESCRIPTION
Bug: When Docker Hub was unreachable or returned an error, the there_is_a_newer_image_on_docker_hub() function would crash because it tried to parse None as a date. Root cause: The code called parse(get_docker_hub_image_creation_date(...)) directly. If the API call failed, get_docker_hub_image_creation_date() returned None, and parse(None) threw a TypeError. The check for None came after the parsing attempt, which was too late. 

Fix:
Get the date string first, then check if it's None before parsing
Added timeout (10s) and exception handling to the Docker Hub API call
Used .get() for safer dictionary access
Now when Docker Hub is unreachable, the function gracefully returns False (keeping the existing local image) instead of crashing.