### PR TITLE
Fix security vulnerabilities in sapphire services dependencies

### DIFF
--- a/sapphire/services/api-gateway/requirements.txt
+++ b/sapphire/services/api-gateway/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.118.3
 uvicorn[standard]==0.37.0
 httpx==0.28.0
-python-multipart==0.0.20
+python-multipart==0.0.22
 pydantic==2.12.0
 pydantic-settings==2.11.0

--- a/sapphire/services/auth/requirements.txt
+++ b/sapphire/services/auth/requirements.txt
@@ -7,6 +7,6 @@ pydantic-settings==2.11.0
 passlib==1.7.4
 bcrypt==4.0.1
 python-jose[cryptography]==3.5.0
-python-multipart==0.0.21
+python-multipart==0.0.22
 httpx==0.28.0
 email-validator==2.3.0

--- a/sapphire/services/postprocessing/requirements.txt
+++ b/sapphire/services/postprocessing/requirements.txt
@@ -9,4 +9,4 @@ pytest==8.4.2
 pytest-cov==6.0.0
 httpx==0.28.0
 pandas==2.3.3
-requests==2.32.5
+requests==2.33.0

--- a/sapphire/services/preprocessing/requirements.txt
+++ b/sapphire/services/preprocessing/requirements.txt
@@ -9,4 +9,4 @@ pytest==8.4.2
 pytest-cov==6.0.0
 httpx==0.28.0
 pandas==2.3.3
-requests==2.32.5
+requests==2.33.0

--- a/sapphire/services/user/requirements.txt
+++ b/sapphire/services/user/requirements.txt
@@ -6,5 +6,5 @@ pydantic==2.12.0
 pydantic-settings==2.11.0
 passlib==1.7.4
 bcrypt==4.0.1
-python-multipart==0.0.21
+python-multipart==0.0.22
 email-validator==2.3.0


### PR DESCRIPTION
## Summary
Fixes two Dependabot security alerts across sapphire services:

**python-multipart → 0.0.22** (all versions < 0.0.22 vulnerable)
- `sapphire/services/user/requirements.txt`: 0.0.21 → 0.0.22
- `sapphire/services/auth/requirements.txt`: 0.0.21 → 0.0.22
- `sapphire/services/api-gateway/requirements.txt`: 0.0.20 → 0.0.22

**requests → 2.33.0** (all versions < 2.33.0 vulnerable)
- `sapphire/services/preprocessing/requirements.txt`: 2.32.5 → 2.33.0
- `sapphire/services/postprocessing/requirements.txt`: 2.32.5 → 2.33.0

## Test plan
- [ ] Verify all five services start correctly
- [ ] Verify API gateway routing still works
- [ ] Verify auth endpoints function correctly
- [ ] Verify preprocessing and postprocessing endpoints function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)