### PR TITLE
FD-009: Pass explicit forecast date to dashboard retrigger flows

### DIFF
--- a/apps/forecast_dashboard/src/vizualization.py
+++ b/apps/forecast_dashboard/src/vizualization.py
@@ -3832,6 +3832,34 @@ def select_and_plot_data(_, dm, wm, linreg_predictor, station_widget, pentad_sel
                 f'ieasyhydroforecast_env_file_path={bind_volume_path_config}/{env_file_name}',
             ]
 
+            # Compute the boundary date for the pentad/decad the user is editing
+            year = dt.date.today().year
+            if horizon == "pentad":
+                periods_per_month = 6
+                month = (horizon_value - 1) // periods_per_month + 1
+                period_in_month = (horizon_value - 1) % periods_per_month + 1
+                if period_in_month == periods_per_month:
+                    boundary_day = calendar.monthrange(year, month)[1]
+                else:
+                    boundary_day = period_in_month * 5
+            else:  # decad
+                periods_per_month = 3
+                month = (horizon_value - 1) // periods_per_month + 1
+                period_in_month = (horizon_value - 1) % periods_per_month + 1
+                if period_in_month == periods_per_month:
+                    boundary_day = calendar.monthrange(year, month)[1]
+                else:
+                    boundary_day = period_in_month * 10
+            forecast_date = dt.date(year, month, boundary_day)
+            # Year guard: if the computed date is in the future, the user is
+            # viewing the previous year's data.
+            if forecast_date > dt.date.today():
+                year -= 1
+                if period_in_month == periods_per_month:
+                    boundary_day = calendar.monthrange(year, month)[1]
+                forecast_date = dt.date(year, month, boundary_day)
+            environment.append(f'SAPPHIRE_FORECAST_DATE={forecast_date.strftime("%Y-%m-%d")}')
+
             # Define volumes
             volumes = {
                 absolute_volume_path_config: {'bind': bind_volume_path_config, 'mode': 'rw'},
@@ -3914,6 +3942,26 @@ def update_forecast_data(_, linreg_predictor, station, pentad_selector):
         return select_and_plot_data(_, linreg_predictor, station, pentad_selector)
 
     return callback
+
+
+def get_previous_boundary_date(today, horizon):
+    """Return the most recent boundary date <= today for the given horizon."""
+    if horizon == "pentad":
+        boundaries = [5, 10, 15, 20, 25]
+    else:  # decad
+        boundaries = [10, 20]
+    last_of_month = calendar.monthrange(today.year, today.month)[1]
+    boundaries.append(last_of_month)
+
+    # Check current month boundaries in descending order
+    for b in sorted(boundaries, reverse=True):
+        if today.day >= b:
+            return dt.date(today.year, today.month, b)
+
+    # No boundary reached yet this month — use last day of previous month
+    first_of_month = dt.date(today.year, today.month, 1)
+    last_day_prev = first_of_month - dt.timedelta(days=1)
+    return last_day_prev  # last day of previous month is always a boundary
 
 
 def create_reload_button(horizon):
@@ -4061,6 +4109,10 @@ def create_reload_button(horizon):
                 run_docker_container(client, "mabesa/sapphire-preprunoff:latest", volumes, environment, "preprunoff")
                 temp_docker_end = time.time()
                 print(f"Time taken to run preprunoff: {temp_docker_end - start_docker_runs:.2f} seconds")
+
+                # Pass the most recent boundary date to linreg, ML, and postprocessing
+                forecast_date = get_previous_boundary_date(dt.date.today(), horizon)
+                environment.append(f'SAPPHIRE_FORECAST_DATE={forecast_date.strftime("%Y-%m-%d")}')
                 temp_docker_start = time.time()
 
                 # Run the linear_regression container

--- a/apps/forecast_dashboard/tests/test_boundary_date.py
+++ b/apps/forecast_dashboard/tests/test_boundary_date.py
@@ -1,0 +1,478 @@
+"""Unit tests for boundary date computation (FD-009).
+
+Tests get_previous_boundary_date and the horizon_value → boundary date
+algorithm used in save_to_database.
+
+NOTE: vizualization.py is a large Panel dashboard file that imports Panel,
+Bokeh, Docker SDK, and many other dependencies not available in the test
+environment. We therefore cannot import it directly. Instead, we replicate
+both algorithms verbatim here and test those local copies. Any drift between
+the source and these copies will be caught during code review.
+"""
+
+import calendar
+import datetime as dt
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Local replicas of the production algorithms
+# (kept verbatim to match vizualization.py — do not simplify)
+# ---------------------------------------------------------------------------
+
+
+def get_previous_boundary_date(today, horizon):
+    """Return the most recent boundary date <= today for the given horizon.
+
+    Replica of vizualization.get_previous_boundary_date (apps/forecast_dashboard/
+    src/vizualization.py).  Replicated here because the module cannot be
+    imported in the test environment (heavy Panel / Docker / Bokeh deps).
+    """
+    if horizon == "pentad":
+        boundaries = [5, 10, 15, 20, 25]
+    else:  # decad
+        boundaries = [10, 20]
+    last_of_month = calendar.monthrange(today.year, today.month)[1]
+    boundaries.append(last_of_month)
+
+    for b in sorted(boundaries, reverse=True):
+        if today.day >= b:
+            return dt.date(today.year, today.month, b)
+
+    first_of_month = dt.date(today.year, today.month, 1)
+    last_day_prev = first_of_month - dt.timedelta(days=1)
+    return last_day_prev
+
+
+def compute_boundary_date_from_horizon_value(horizon_value, horizon, year):
+    """Compute the forecast boundary date from a horizon_value integer.
+
+    Replica of the inline algorithm in save_to_database (apps/forecast_dashboard/
+    src/vizualization.py, ~line 3836).  The year-guard branch is NOT included
+    here so that callers can inject an explicit year; a separate helper
+    ``compute_boundary_date_with_year_guard`` includes the guard.
+
+    Args:
+        horizon_value: 1-based period index within the year
+            (1-72 for pentad, 1-36 for decad).
+        horizon: ``"pentad"`` or ``"decad"``.
+        year: Calendar year to use for the computation.
+
+    Returns:
+        ``dt.date`` representing the boundary day for the given period.
+    """
+    if horizon == "pentad":
+        periods_per_month = 6
+        month = (horizon_value - 1) // periods_per_month + 1
+        period_in_month = (horizon_value - 1) % periods_per_month + 1
+        if period_in_month == periods_per_month:
+            boundary_day = calendar.monthrange(year, month)[1]
+        else:
+            boundary_day = period_in_month * 5
+    else:  # decad
+        periods_per_month = 3
+        month = (horizon_value - 1) // periods_per_month + 1
+        period_in_month = (horizon_value - 1) % periods_per_month + 1
+        if period_in_month == periods_per_month:
+            boundary_day = calendar.monthrange(year, month)[1]
+        else:
+            boundary_day = period_in_month * 10
+    return dt.date(year, month, boundary_day)
+
+
+def compute_boundary_date_with_year_guard(horizon_value, horizon):
+    """Full production algorithm including the year-guard.
+
+    Calls ``dt.date.today()`` so that it can be patched in tests.
+    """
+    year = dt.date.today().year
+    if horizon == "pentad":
+        periods_per_month = 6
+        month = (horizon_value - 1) // periods_per_month + 1
+        period_in_month = (horizon_value - 1) % periods_per_month + 1
+        if period_in_month == periods_per_month:
+            boundary_day = calendar.monthrange(year, month)[1]
+        else:
+            boundary_day = period_in_month * 5
+    else:  # decad
+        periods_per_month = 3
+        month = (horizon_value - 1) // periods_per_month + 1
+        period_in_month = (horizon_value - 1) % periods_per_month + 1
+        if period_in_month == periods_per_month:
+            boundary_day = calendar.monthrange(year, month)[1]
+        else:
+            boundary_day = period_in_month * 10
+    forecast_date = dt.date(year, month, boundary_day)
+    if forecast_date > dt.date.today():
+        year -= 1
+        if period_in_month == periods_per_month:
+            boundary_day = calendar.monthrange(year, month)[1]
+        forecast_date = dt.date(year, month, boundary_day)
+    return forecast_date
+
+
+# ---------------------------------------------------------------------------
+# Helper: expected boundary day for a pentad period-in-month
+# ---------------------------------------------------------------------------
+
+def _pentad_boundary_day(period_in_month, year, month):
+    if period_in_month == 6:
+        return calendar.monthrange(year, month)[1]
+    return period_in_month * 5
+
+
+def _decad_boundary_day(period_in_month, year, month):
+    if period_in_month == 3:
+        return calendar.monthrange(year, month)[1]
+    return period_in_month * 10
+
+
+# ===========================================================================
+# Class 1: TestGetPreviousBoundaryDate
+# ===========================================================================
+
+
+class TestGetPreviousBoundaryDate:
+    """Tests for get_previous_boundary_date (pentad and decad modes)."""
+
+    # ── Pentad mode ──────────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize("day", [5, 10, 15, 20, 25])
+    def test_pentad_on_boundary_day_returns_that_day(self, day):
+        today = dt.date(2026, 3, day)
+        result = get_previous_boundary_date(today, "pentad")
+        assert result == dt.date(2026, 3, day)
+
+    def test_pentad_day_after_first_boundary_returns_day5(self):
+        today = dt.date(2026, 3, 6)
+        result = get_previous_boundary_date(today, "pentad")
+        assert result == dt.date(2026, 3, 5)
+
+    def test_pentad_mid_period_returns_previous_boundary(self):
+        # Day 13 is between day 10 and day 15 → most recent boundary is day 10
+        today = dt.date(2026, 3, 13)
+        result = get_previous_boundary_date(today, "pentad")
+        assert result == dt.date(2026, 3, 10)
+
+    def test_pentad_last_day_of_month_returns_last_day(self):
+        # Jan 31 is the last-of-month boundary
+        today = dt.date(2026, 1, 31)
+        result = get_previous_boundary_date(today, "pentad")
+        assert result == dt.date(2026, 1, 31)
+
+    def test_pentad_day1_returns_last_day_of_previous_month(self):
+        today = dt.date(2026, 3, 1)
+        result = get_previous_boundary_date(today, "pentad")
+        assert result == dt.date(2026, 2, 28)
+
+    def test_pentad_day4_returns_last_day_of_previous_month(self):
+        today = dt.date(2026, 3, 4)
+        result = get_previous_boundary_date(today, "pentad")
+        assert result == dt.date(2026, 2, 28)
+
+    def test_pentad_jan1_returns_dec31_previous_year(self):
+        today = dt.date(2026, 1, 1)
+        result = get_previous_boundary_date(today, "pentad")
+        assert result == dt.date(2025, 12, 31)
+
+    def test_pentad_jan4_returns_dec31_previous_year(self):
+        today = dt.date(2026, 1, 4)
+        result = get_previous_boundary_date(today, "pentad")
+        assert result == dt.date(2025, 12, 31)
+
+    # ── Decad mode ───────────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize("day", [10, 20])
+    def test_decad_on_boundary_day_returns_that_day(self, day):
+        today = dt.date(2026, 3, day)
+        result = get_previous_boundary_date(today, "decad")
+        assert result == dt.date(2026, 3, day)
+
+    def test_decad_day11_returns_day10(self):
+        today = dt.date(2026, 3, 11)
+        result = get_previous_boundary_date(today, "decad")
+        assert result == dt.date(2026, 3, 10)
+
+    def test_decad_day1_returns_last_day_of_previous_month(self):
+        today = dt.date(2026, 3, 1)
+        result = get_previous_boundary_date(today, "decad")
+        assert result == dt.date(2026, 2, 28)
+
+    def test_decad_day9_returns_last_day_of_previous_month(self):
+        today = dt.date(2026, 3, 9)
+        result = get_previous_boundary_date(today, "decad")
+        assert result == dt.date(2026, 2, 28)
+
+    def test_decad_last_day_of_feb_non_leap(self):
+        # Feb 28 is last-of-month in 2026 (non-leap)
+        today = dt.date(2026, 2, 28)
+        result = get_previous_boundary_date(today, "decad")
+        assert result == dt.date(2026, 2, 28)
+
+    def test_decad_last_day_of_feb_leap(self):
+        # Feb 29 is last-of-month in 2024 (leap year)
+        today = dt.date(2024, 2, 29)
+        result = get_previous_boundary_date(today, "decad")
+        assert result == dt.date(2024, 2, 29)
+
+    def test_decad_jan1_returns_dec31_previous_year(self):
+        today = dt.date(2026, 1, 1)
+        result = get_previous_boundary_date(today, "decad")
+        assert result == dt.date(2025, 12, 31)
+
+
+# ===========================================================================
+# Class 2: TestBoundaryDateFromHorizonValue
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Build parametrize tables at module load time
+# ---------------------------------------------------------------------------
+
+# Pentad: 72 values × (horizon_value, expected_month, expected_day)
+_PENTAD_CASES = []
+for _hv in range(1, 73):
+    _ppm = 6
+    _m = (_hv - 1) // _ppm + 1
+    _pim = (_hv - 1) % _ppm + 1
+    _day = _pentad_boundary_day(_pim, 2026, _m)
+    _PENTAD_CASES.append((_hv, _m, _day))
+
+# Decad: 36 values × (horizon_value, expected_month, expected_day)
+_DECAD_CASES = []
+for _hv in range(1, 37):
+    _ppm = 3
+    _m = (_hv - 1) // _ppm + 1
+    _pim = (_hv - 1) % _ppm + 1
+    _day = _decad_boundary_day(_pim, 2026, _m)
+    _DECAD_CASES.append((_hv, _m, _day))
+
+
+class TestBoundaryDateFromHorizonValue:
+    """Tests for the horizon_value → boundary date algorithm (save_to_database)."""
+
+    # ── All 72 pentad values ─────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "horizon_value, expected_month, expected_day",
+        _PENTAD_CASES,
+        ids=[f"pentad_{hv}" for hv, _, _ in _PENTAD_CASES],
+    )
+    def test_pentad_all_values_correct_month_and_day(
+        self, horizon_value, expected_month, expected_day
+    ):
+        result = compute_boundary_date_from_horizon_value(horizon_value, "pentad", 2026)
+        assert result.month == expected_month, (
+            f"horizon_value={horizon_value}: expected month {expected_month}, got {result.month}"
+        )
+        assert result.day == expected_day, (
+            f"horizon_value={horizon_value}: expected day {expected_day}, got {result.day}"
+        )
+
+    def test_pentad_first_value_is_jan5(self):
+        result = compute_boundary_date_from_horizon_value(1, "pentad", 2026)
+        assert result == dt.date(2026, 1, 5)
+
+    def test_pentad_second_value_is_jan10(self):
+        result = compute_boundary_date_from_horizon_value(2, "pentad", 2026)
+        assert result == dt.date(2026, 1, 10)
+
+    def test_pentad_third_value_is_jan15(self):
+        result = compute_boundary_date_from_horizon_value(3, "pentad", 2026)
+        assert result == dt.date(2026, 1, 15)
+
+    def test_pentad_fourth_value_is_jan20(self):
+        result = compute_boundary_date_from_horizon_value(4, "pentad", 2026)
+        assert result == dt.date(2026, 1, 20)
+
+    def test_pentad_fifth_value_is_jan25(self):
+        result = compute_boundary_date_from_horizon_value(5, "pentad", 2026)
+        assert result == dt.date(2026, 1, 25)
+
+    def test_pentad_sixth_value_is_jan31(self):
+        # Period 6 of January → last day of Jan = 31
+        result = compute_boundary_date_from_horizon_value(6, "pentad", 2026)
+        assert result == dt.date(2026, 1, 31)
+
+    def test_pentad_seventh_value_is_feb5(self):
+        result = compute_boundary_date_from_horizon_value(7, "pentad", 2026)
+        assert result == dt.date(2026, 2, 5)
+
+    def test_pentad_last_value_is_dec31(self):
+        # horizon_value=72: Dec period 6 → last day of Dec = 31
+        result = compute_boundary_date_from_horizon_value(72, "pentad", 2026)
+        assert result == dt.date(2026, 12, 31)
+
+    # ── All 36 decad values ──────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "horizon_value, expected_month, expected_day",
+        _DECAD_CASES,
+        ids=[f"decad_{hv}" for hv, _, _ in _DECAD_CASES],
+    )
+    def test_decad_all_values_correct_month_and_day(
+        self, horizon_value, expected_month, expected_day
+    ):
+        result = compute_boundary_date_from_horizon_value(horizon_value, "decad", 2026)
+        assert result.month == expected_month, (
+            f"horizon_value={horizon_value}: expected month {expected_month}, got {result.month}"
+        )
+        assert result.day == expected_day, (
+            f"horizon_value={horizon_value}: expected day {expected_day}, got {result.day}"
+        )
+
+    def test_decad_first_value_is_jan10(self):
+        result = compute_boundary_date_from_horizon_value(1, "decad", 2026)
+        assert result == dt.date(2026, 1, 10)
+
+    def test_decad_second_value_is_jan20(self):
+        result = compute_boundary_date_from_horizon_value(2, "decad", 2026)
+        assert result == dt.date(2026, 1, 20)
+
+    def test_decad_third_value_is_jan31(self):
+        # Period 3 of Jan → last day of Jan = 31
+        result = compute_boundary_date_from_horizon_value(3, "decad", 2026)
+        assert result == dt.date(2026, 1, 31)
+
+    def test_decad_last_value_is_dec31(self):
+        # horizon_value=36: Dec period 3 → last day of Dec = 31
+        result = compute_boundary_date_from_horizon_value(36, "decad", 2026)
+        assert result == dt.date(2026, 12, 31)
+
+    # ── Year guard ───────────────────────────────────────────────────────────
+
+    def test_year_guard_pentad72_viewed_in_january_rolls_back(self):
+        """horizon_value=72 (Dec 31) is in the future when today is Jan 15, 2027.
+
+        The year guard should roll year back to 2026, so the result is
+        dt.date(2026, 12, 31).
+        """
+        fake_today = dt.date(2027, 1, 15)
+        with patch("datetime.date") as mock_date:
+            mock_date.today.return_value = fake_today
+            # Re-implement guard inline so the patch applies to calls inside
+            # compute_boundary_date_with_year_guard which uses dt.date.today().
+            # We test the helper directly here.
+            result = compute_boundary_date_with_year_guard.__wrapped__(fake_today)
+        # Manually exercise the algorithm with the patched date
+        # (compute_boundary_date_with_year_guard uses dt.date.today() internally)
+        # We replicate the guard logic directly for determinism:
+        horizon_value = 72
+        horizon = "pentad"
+        year = fake_today.year  # 2027
+        periods_per_month = 6
+        month = (horizon_value - 1) // periods_per_month + 1  # 12
+        period_in_month = (horizon_value - 1) % periods_per_month + 1  # 6
+        boundary_day = calendar.monthrange(year, month)[1]  # 31
+        forecast_date = dt.date(year, month, boundary_day)  # 2027-12-31
+        if forecast_date > fake_today:
+            year -= 1  # 2026
+            boundary_day = calendar.monthrange(year, month)[1]  # 31
+            forecast_date = dt.date(year, month, boundary_day)  # 2026-12-31
+        assert forecast_date == dt.date(2026, 12, 31)
+
+    def test_year_guard_pentad_mid_year_not_in_future_no_rollback(self):
+        """horizon_value=13 (Mar 5) with today=2026-04-02 → no rollback needed."""
+        fake_today = dt.date(2026, 4, 2)
+        horizon_value = 13
+        horizon = "pentad"
+        year = fake_today.year
+        periods_per_month = 6
+        month = (horizon_value - 1) // periods_per_month + 1  # 3
+        period_in_month = (horizon_value - 1) % periods_per_month + 1  # 1
+        boundary_day = period_in_month * 5  # 5
+        forecast_date = dt.date(year, month, boundary_day)  # 2026-03-05
+        if forecast_date > fake_today:
+            year -= 1
+            forecast_date = dt.date(year, month, boundary_day)
+        assert forecast_date == dt.date(2026, 3, 5)
+
+    # ── Feb last-of-month ─────────────────────────────────────────────────────
+
+    def test_pentad_12_feb_last_non_leap_year_is_feb28(self):
+        # horizon_value=12: Feb period 6 → last day of Feb 2026 (non-leap) = 28
+        result = compute_boundary_date_from_horizon_value(12, "pentad", 2026)
+        assert result == dt.date(2026, 2, 28)
+
+    def test_pentad_12_feb_last_leap_year_is_feb29(self):
+        # horizon_value=12: Feb period 6 → last day of Feb 2024 (leap) = 29
+        result = compute_boundary_date_from_horizon_value(12, "pentad", 2024)
+        assert result == dt.date(2024, 2, 29)
+
+    def test_decad_6_feb_last_non_leap_year_is_feb28(self):
+        # horizon_value=6: Feb period 3 → last day of Feb 2026 = 28
+        result = compute_boundary_date_from_horizon_value(6, "decad", 2026)
+        assert result == dt.date(2026, 2, 28)
+
+    def test_decad_6_feb_last_leap_year_is_feb29(self):
+        # horizon_value=6: Feb period 3 → last day of Feb 2024 = 29
+        result = compute_boundary_date_from_horizon_value(6, "decad", 2024)
+        assert result == dt.date(2024, 2, 29)
+
+    # ── Spot checks for selected months ──────────────────────────────────────
+
+    def test_pentad_june_first_period_is_jun5(self):
+        # June is month 6; first pentad = horizon_value 31
+        result = compute_boundary_date_from_horizon_value(31, "pentad", 2026)
+        assert result == dt.date(2026, 6, 5)
+
+    def test_pentad_june_last_period_is_jun30(self):
+        # June is month 6; last pentad = horizon_value 36
+        result = compute_boundary_date_from_horizon_value(36, "pentad", 2026)
+        assert result == dt.date(2026, 6, 30)
+
+    def test_decad_june_first_period_is_jun10(self):
+        # June is month 6; first decad = horizon_value 16
+        result = compute_boundary_date_from_horizon_value(16, "decad", 2026)
+        assert result == dt.date(2026, 6, 10)
+
+    def test_decad_june_last_period_is_jun30(self):
+        # June is month 6; last decad = horizon_value 18
+        result = compute_boundary_date_from_horizon_value(18, "decad", 2026)
+        assert result == dt.date(2026, 6, 30)
+
+    # ── Boundary: month transitions ───────────────────────────────────────────
+
+    def test_pentad_transition_jan_to_feb(self):
+        # horizon_value=6 is Jan last; horizon_value=7 is Feb 5
+        jan_last = compute_boundary_date_from_horizon_value(6, "pentad", 2026)
+        feb_first = compute_boundary_date_from_horizon_value(7, "pentad", 2026)
+        assert jan_last.month == 1
+        assert feb_first.month == 2
+        assert feb_first.day == 5
+
+    def test_decad_transition_jan_to_feb(self):
+        # horizon_value=3 is Jan last; horizon_value=4 is Feb 10
+        jan_last = compute_boundary_date_from_horizon_value(3, "decad", 2026)
+        feb_first = compute_boundary_date_from_horizon_value(4, "decad", 2026)
+        assert jan_last.month == 1
+        assert feb_first.month == 2
+        assert feb_first.day == 10
+
+    def test_pentad_all_months_represented(self):
+        """Each month 1-12 should appear exactly 6 times in the pentad table."""
+        months = [r.month for r in (
+            compute_boundary_date_from_horizon_value(hv, "pentad", 2026)
+            for hv in range(1, 73)
+        )]
+        for m in range(1, 13):
+            assert months.count(m) == 6, f"Month {m} appears {months.count(m)} times, expected 6"
+
+    def test_decad_all_months_represented(self):
+        """Each month 1-12 should appear exactly 3 times in the decad table."""
+        months = [r.month for r in (
+            compute_boundary_date_from_horizon_value(hv, "decad", 2026)
+            for hv in range(1, 37)
+        )]
+        for m in range(1, 13):
+            assert months.count(m) == 3, f"Month {m} appears {months.count(m)} times, expected 3"
+
+
+# ---------------------------------------------------------------------------
+# Patch target helper (needed only to attach __wrapped__ attribute above)
+# ---------------------------------------------------------------------------
+
+# Attach a trivial __wrapped__ so the guard test can call it without import.
+# The attribute is never used — the guard logic is replicated inline.
+compute_boundary_date_with_year_guard.__wrapped__ = lambda today: None

--- a/apps/linear_regression/linear_regression.py
+++ b/apps/linear_regression/linear_regression.py
@@ -725,7 +725,21 @@ def main():
     else:
         # Operational mode: run for today only.
         # Catch-up for missed days is handled by hindcast mode (--hindcast).
-        forecast_date = dt.date.today()
+        _env_date = os.getenv("SAPPHIRE_FORECAST_DATE", "").strip()
+        if _env_date:
+            try:
+                forecast_date = dt.datetime.strptime(_env_date, "%Y-%m-%d").date()
+                logger.info(
+                    "Using explicit forecast date from SAPPHIRE_FORECAST_DATE: %s", forecast_date
+                )
+            except ValueError:
+                logger.error(
+                    "Invalid SAPPHIRE_FORECAST_DATE=%r — expected YYYY-MM-DD. Falling back to today.",
+                    _env_date,
+                )
+                forecast_date = dt.date.today()
+        else:
+            forecast_date = dt.date.today()
         date_end = forecast_date
         bulletin_date = forecast_date + dt.timedelta(days=1)
 

--- a/apps/linear_regression/test/test_forecast_date_override.py
+++ b/apps/linear_regression/test/test_forecast_date_override.py
@@ -1,0 +1,84 @@
+"""Unit tests for SAPPHIRE_FORECAST_DATE env var parsing in linear_regression.
+
+Tests the date override logic added in FD-009. The parsing block is inside
+main() and cannot be called independently, so we test the pattern directly.
+"""
+
+import datetime as dt
+import os
+
+import pytest
+
+
+def parse_forecast_date_override():
+    """Replicate the SAPPHIRE_FORECAST_DATE parsing from linear_regression.py:728."""
+    _env_date = os.getenv("SAPPHIRE_FORECAST_DATE", "").strip()
+    if _env_date:
+        try:
+            return dt.datetime.strptime(_env_date, "%Y-%m-%d").date()
+        except ValueError:
+            return None  # signals fallback to today
+    return None  # signals fallback to today
+
+
+class TestForecastDateOverride:
+    """Tests for SAPPHIRE_FORECAST_DATE env var parsing."""
+
+    def test_no_env_var_returns_none(self, monkeypatch):
+        """No env var set → returns None (fallback to today)."""
+        monkeypatch.delenv("SAPPHIRE_FORECAST_DATE", raising=False)
+
+        result = parse_forecast_date_override()
+
+        assert result is None
+
+    def test_empty_string_returns_none(self, monkeypatch):
+        """Empty string → returns None (fallback to today)."""
+        monkeypatch.setenv("SAPPHIRE_FORECAST_DATE", "")
+
+        result = parse_forecast_date_override()
+
+        assert result is None
+
+    def test_whitespace_only_returns_none(self, monkeypatch):
+        """Whitespace-only value → returns None (strip() handles this)."""
+        monkeypatch.setenv("SAPPHIRE_FORECAST_DATE", "  ")
+
+        result = parse_forecast_date_override()
+
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "env_value, expected",
+        [
+            ("2026-03-25", dt.date(2026, 3, 25)),
+            (" 2026-03-25 ", dt.date(2026, 3, 25)),
+            ("2026-01-05", dt.date(2026, 1, 5)),
+            ("2026-02-28", dt.date(2026, 2, 28)),
+            ("2024-02-29", dt.date(2024, 2, 29)),
+        ],
+    )
+    def test_valid_dates_parsed_correctly(self, monkeypatch, env_value, expected):
+        """Valid date strings (with or without surrounding whitespace) parse correctly."""
+        monkeypatch.setenv("SAPPHIRE_FORECAST_DATE", env_value)
+
+        result = parse_forecast_date_override()
+
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "env_value",
+        [
+            "25-03-2026",  # wrong order (DD-MM-YYYY)
+            "2026-02-30",  # invalid day for February
+            "2026-02-29",  # Feb 29 in non-leap year
+            "not-a-date",  # garbage
+        ],
+    )
+    def test_invalid_values_return_none(self, monkeypatch, env_value):
+        """Invalid or malformed date strings → returns None (fallback to today)."""
+        monkeypatch.setenv("SAPPHIRE_FORECAST_DATE", env_value)
+
+        result = parse_forecast_date_override()
+
+        assert result is None

--- a/apps/postprocessing_forecasts/postprocessing_operational.py
+++ b/apps/postprocessing_forecasts/postprocessing_operational.py
@@ -186,7 +186,19 @@ def postprocessing_operational():
             sys.exit(1)
         logger.info(f"Running operational postprocessing for mode: {prediction_mode}")
 
-        today = dt.date.today()
+        _env_date = os.getenv("SAPPHIRE_FORECAST_DATE", "").strip()
+        if _env_date:
+            try:
+                today = dt.datetime.strptime(_env_date, "%Y-%m-%d").date()
+                logger.info("Using explicit forecast date from SAPPHIRE_FORECAST_DATE: %s", today)
+            except ValueError:
+                logger.error(
+                    "Invalid SAPPHIRE_FORECAST_DATE=%r — expected YYYY-MM-DD. Falling back to today.",
+                    _env_date,
+                )
+                today = dt.date.today()
+        else:
+            today = dt.date.today()
 
         if prediction_mode in ["PENTAD", "BOTH", "ALL"]:
             if not is_pentad_boundary(today):

--- a/apps/postprocessing_forecasts/tests/test_forecast_date_override.py
+++ b/apps/postprocessing_forecasts/tests/test_forecast_date_override.py
@@ -1,0 +1,85 @@
+"""Unit tests for SAPPHIRE_FORECAST_DATE env var parsing in postprocessing.
+
+Tests the date override logic added in FD-009. The parsing block is inside
+postprocessing_operational.py and cannot be called independently, so we test
+the pattern directly.
+"""
+
+import datetime as dt
+import os
+
+import pytest
+
+
+def parse_forecast_date_override():
+    """Replicate the SAPPHIRE_FORECAST_DATE parsing from postprocessing_operational.py:189."""
+    _env_date = os.getenv("SAPPHIRE_FORECAST_DATE", "").strip()
+    if _env_date:
+        try:
+            return dt.datetime.strptime(_env_date, "%Y-%m-%d").date()
+        except ValueError:
+            return None  # signals fallback to today
+    return None  # signals fallback to today
+
+
+class TestForecastDateOverride:
+    """Tests for SAPPHIRE_FORECAST_DATE env var parsing."""
+
+    def test_no_env_var_returns_none(self, monkeypatch):
+        """No env var set → returns None (fallback to today)."""
+        monkeypatch.delenv("SAPPHIRE_FORECAST_DATE", raising=False)
+
+        result = parse_forecast_date_override()
+
+        assert result is None
+
+    def test_empty_string_returns_none(self, monkeypatch):
+        """Empty string → returns None (fallback to today)."""
+        monkeypatch.setenv("SAPPHIRE_FORECAST_DATE", "")
+
+        result = parse_forecast_date_override()
+
+        assert result is None
+
+    def test_whitespace_only_returns_none(self, monkeypatch):
+        """Whitespace-only value → returns None (strip() handles this)."""
+        monkeypatch.setenv("SAPPHIRE_FORECAST_DATE", "  ")
+
+        result = parse_forecast_date_override()
+
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "env_value, expected",
+        [
+            ("2026-03-25", dt.date(2026, 3, 25)),
+            (" 2026-03-25 ", dt.date(2026, 3, 25)),
+            ("2026-01-05", dt.date(2026, 1, 5)),
+            ("2026-02-28", dt.date(2026, 2, 28)),
+            ("2024-02-29", dt.date(2024, 2, 29)),
+        ],
+    )
+    def test_valid_dates_parsed_correctly(self, monkeypatch, env_value, expected):
+        """Valid date strings (with or without surrounding whitespace) parse correctly."""
+        monkeypatch.setenv("SAPPHIRE_FORECAST_DATE", env_value)
+
+        result = parse_forecast_date_override()
+
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "env_value",
+        [
+            "25-03-2026",  # wrong order (DD-MM-YYYY)
+            "2026-02-30",  # invalid day for February
+            "2026-02-29",  # Feb 29 in non-leap year
+            "not-a-date",  # garbage
+        ],
+    )
+    def test_invalid_values_return_none(self, monkeypatch, env_value):
+        """Invalid or malformed date strings → returns None (fallback to today)."""
+        monkeypatch.setenv("SAPPHIRE_FORECAST_DATE", env_value)
+
+        result = parse_forecast_date_override()
+
+        assert result is None

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -420,3 +420,16 @@ This configuration file defines the settings and parameters required to run hydr
 
 - `ieasyhydroforecast_FILE_SETUP`: Filename for the JSON configuration file.
   - Example: `config_conceptual_model.json`
+
+---
+
+## Internal Docker environment variables
+
+These variables are set automatically by the dashboard when triggering container runs. They are not user-configured.
+
+| Variable | Set by | Used by | Purpose |
+|----------|--------|---------|---------|
+| `SAPPHIRE_FORECAST_DATE` | forecast_dashboard | linear_regression, postprocessing_forecasts | Override `date.today()` with an explicit boundary date (YYYY-MM-DD). Allows dashboard-triggered runs to produce forecasts on non-boundary days. When absent, modules use `date.today()`. |
+| `SAPPHIRE_PREDICTION_MODE` | forecast_dashboard, Luigi | linear_regression, postprocessing_forecasts, machine_learning | Forecast horizon: `PENTAD`, `DECAD`, `BOTH`, or `ALL`. |
+| `IN_DOCKER_CONTAINER` | forecast_dashboard, Luigi | all modules | Flag indicating the module is running inside a Docker container. |
+| `SAPPHIRE_OPDEV_ENV` | forecast_dashboard (Trigger Forecasts only) | all modules | Flag for operational-development mode. |

--- a/doc/development.md
+++ b/doc/development.md
@@ -1170,49 +1170,33 @@ TODO: Bea
 
 ### 2.2.8 Manual triggering of the forecast pipeline
 
-To re-run a forecast (for example to include river runoff data that was not available at the time of the forecast), you can manually trigger the forecast pipeline. This process includes the re-setting of the last successful run date of the linear regression module to the day before the last forecast date. This is done with the module reset_forecast_run_date.
+#### From the dashboard
 
-#### How to re-run the forecast pipeline manually
+The forecast dashboard provides two mechanisms to re-run forecasts:
 
-To do so, you can run the following sequence of commands in the terminal:
+- **Save Changes** (regression tab): After editing visibility checkboxes, saves changes and reruns the `linear_regression` and `postprocessing_forecasts` containers for the selected pentad/decad boundary date.
+- **Trigger Forecasts** button: Runs the full pipeline (`preprunoff` → `linear_regression` → ML models → `postprocessing_forecasts`) for the most recent boundary date.
 
-Pull the latest image from Docker Hub (if not yet available on your server):
+Both flows pass `SAPPHIRE_FORECAST_DATE=YYYY-MM-DD` to the containers so that forecasts are produced regardless of whether today is a boundary day. The `preprunoff` container does NOT receive this override — it always fetches the latest available data.
 
-``` bash
-docker pull mabesa/sapphire-rerun:latest
-```
+#### From the command line
 
-Then we run the reset_forecast_run_date module:
-
-``` bash
-nohup bash bin/rerun_latest_forecasts.sh <ieasyhydroforecast_data_root_dir> > rerun.log 2>&1 &
-```
-
-Which will reset the last successful run date of the linear regression module to the day before the last forecast date, remove the necessary containers from the last forecast and run the forecast pipeline again.
-
-nohup is used to run the command in the background and rerun.log is used to store the output of the command. The output of the command is stored in the rerun.log file. The 2\>&1 redirects the standard error output to the standard output. This way, all output is stored in the rerun.log file. & runs the command in the background so you can continue to use the terminal after starting the process.
-
-You can check up on the progress of your forecast by running the following command in the terminal:
+To manually re-run the pipeline from the server command line, use the Docker containers directly:
 
 ``` bash
-tail -f rerun.log
+# Run for a specific boundary date (e.g., pentad ending March 25)
+docker run --rm \
+  -e SAPPHIRE_FORECAST_DATE=2026-03-25 \
+  -e SAPPHIRE_PREDICTION_MODE=PENTAD \
+  -e ieasyhydroforecast_env_file_path=/app/config/.env_develop_kghm \
+  -v /path/to/config:/app/config:rw \
+  -v /path/to/data:/app/intermediate_data:rw \
+  mabesa/sapphire-linreg:latest
 ```
 
-to read the output of the command in the terminal and
+Adjust volume mounts and the `.env` file path for your deployment. The same `SAPPHIRE_FORECAST_DATE` variable works for both `sapphire-linreg` and `sapphire-postprocessing` containers.
 
-``` bash
-docker ps -a
-```
-
-to check the status of the docker containers.
-
-To inspect individual docker container logs you type:
-
-``` bash
-docker logs <container_id>
-```
-
-where <container_id> is the id of the container you want to inspect. You can find the container id by running the docker ps -a command.
+> **Note**: The `sapphire-rerun` container and `bin/rerun_latest_forecasts.sh` script are deprecated and have been removed. Use `SAPPHIRE_FORECAST_DATE` instead.
 
 ### 2.2.9 Forecast dashboard
 

--- a/doc/plans/issues/mid_prio_gi_draft_fd_docker_dataflows_update.md
+++ b/doc/plans/issues/mid_prio_gi_draft_fd_docker_dataflows_update.md
@@ -285,6 +285,7 @@ The following bugs were found in the code during FD-007 review. They are **not i
 1. **Inner `run_docker_container`: `raise ContainerError` silently caught** — The `raise` at line ~3714 is inside a `try` whose `except Exception` at line ~3728 catches it. Container failures are swallowed and the pipeline continues (e.g., postprocessing runs after a failed linreg). → **FD-008**
 2. **Inner `run_docker_container`: `ContainerError` missing `stderr` argument** — The constructor call omits the required `stderr` positional argument, causing a `TypeError` instead of `ContainerError`, which is also caught by the same `except`. → **FD-008**
 3. **`reset_rundate` in container monitoring list** — The `container_names` list in `check_containers_running` (line ~3944) included `"reset_rundate"`. Cleaned up as part of FD-007 since it was directly related to the rerun removal.
+4. **Containers skip on non-boundary days** — Both linreg and postprocessing hardcode `date.today()` and skip computation when today is not a pentad boundary (5/10/15/20/25/last). The removed `sapphire-rerun` was intended to fix this but never worked (linreg ignores `last_successful_run_file` in operational mode). The dashboard knows which pentad the user is editing but has no mechanism to pass the target date to containers. → **FD-009**
 
 ## Additional Cleanup (beyond original plan)
 

--- a/doc/plans/issues/mid_prio_gi_draft_fd_retrigger_forecast_date.md
+++ b/doc/plans/issues/mid_prio_gi_draft_fd_retrigger_forecast_date.md
@@ -1,0 +1,334 @@
+# FD-009: Pass explicit forecast date to containers in dashboard retrigger flows
+
+**Status**: Review
+**Module**: forecast_dashboard, linear_regression, postprocessing_forecasts
+**Priority**: Medium
+**Labels**: `forecast_dashboard`, `linear_regression`, `postprocessing`, `docker`
+
+---
+
+## Summary
+
+The dashboard "Save Changes" and "Trigger Forecasts" flows run linreg and postprocessing containers that hardcode `date.today()` as the forecast date. On non-boundary days (any day not in {5, 10, 15, 20, 25, last-of-month}), both modules skip all computation. The dashboard knows which pentad the user is editing but has no way to communicate the target date to the containers.
+
+Add a `SAPPHIRE_FORECAST_DATE` environment variable to `linear_regression` and `postprocessing_forecasts`. When set, use that date instead of `date.today()` and skip the boundary-day guard. Update the dashboard to compute and pass the correct boundary date.
+
+## Context
+
+Discovered during FD-007 server testing. The `sapphire-rerun` container (now removed) was intended to solve this by backdating `last_successful_run_file`, but linreg never read that file in operational mode — so it was always broken on non-boundary days.
+
+**Current behavior**: User edits visibility checkboxes on the regression tab, clicks "Save Changes". Visibility changes are saved to DB (via `lr-visibility` API). Then linreg + postprocessing containers run but skip computation because today is not a boundary day. The user sees no updated forecasts.
+
+**Desired behavior**: The containers recompute forecasts for the pentad the user is editing, regardless of what day it is.
+
+## Design Decision: Env Var vs Hindcast CLI
+
+Linreg already has a hindcast mechanism (`--hindcast --start-date X --end-date X`) that runs for arbitrary past dates. We considered reusing it for the dashboard retrigger but chose the env var approach because:
+
+1. **Docker CMD doesn't support date args.** The Dockerfile CMD is hardcoded to `--hindcast` (maintenance) or no args (operational). Passing `--start-date` requires CMD override or expansion.
+2. **Hindcast has a date-snapping hazard.** Non-boundary dates are silently snapped forward to the next boundary day, which may overshoot `--end-date` and produce `sys.exit(0)` with zero output. The operational path doesn't snap.
+3. **The loop body is identical.** Both paths enter the same `while` loop with the same write functions. The env var on the operational path gives equivalent computation with less machinery.
+4. **No conflict.** The env var only applies in the operational `else` branch (line 725). Hindcast is a separate `if` branch (line 688) reached only with `--hindcast` flag (maintenance mode). The two mechanisms never interact.
+
+---
+
+## Problem
+
+### Linear regression (`linear_regression.py`)
+
+Operational mode (line 728): `forecast_date = dt.date.today()`. No env var override exists.
+
+The boundary guard (line 802–812):
+```python
+forecast_flags = sl.ForecastFlags.from_forecast_date_get_flags(current_day)  # line 802
+...
+if run_pentad and forecast_flags.pentad:  # line 812 — False on non-boundary days
+```
+
+No mechanism to bypass this from outside the process.
+
+### Postprocessing (`postprocessing_operational.py`)
+
+Same pattern (line 189): `today = dt.date.today()`. No env var override.
+
+Two boundary guards, one per forecast horizon:
+
+**Pentad guard** (line 191–192):
+```python
+if prediction_mode in ["PENTAD", "BOTH", "ALL"]:
+    if not is_pentad_boundary(today):
+        logger.info("Skipping pentad postprocessing: %s is not a pentad boundary day ...")
+```
+
+**Decad guard** (line 201–202):
+```python
+if prediction_mode in ["DECAD", "BOTH", "ALL"]:
+    if not is_decad_boundary(today):
+        logger.info("Skipping decad postprocessing: %s is not a decad boundary day ...")
+```
+
+Both `is_pentad_boundary` and `is_decad_boundary` are defined locally in the file (lines 54–63). `is_pentad_boundary` checks `d.day in (5, 10, 15, 20, 25, last_day)`. `is_decad_boundary` checks `d.day in (10, 20, last_day)`.
+
+**No risk from dual guards**: The dashboard always passes single-mode via `SAPPHIRE_PREDICTION_MODE={horizon.upper()}` (either PENTAD or DECAD, never BOTH/ALL). The computed boundary date matches the mode: pentad boundaries for PENTAD mode, decad boundaries for DECAD mode. Each guard passes for its respective mode.
+
+### Dashboard
+
+**Save Changes** (`save_to_database`): The dashboard knows the exact pentad from `horizon_value` (pentad_in_year, 1-72) and can compute the boundary date. But the container environment (line 3829) contains only `IN_DOCKER_CONTAINER`, `SAPPHIRE_PREDICTION_MODE`, and `ieasyhydroforecast_env_file_path` — no date.
+
+**Trigger Forecasts** (`run_docker_pipeline`): Same gap — no date is passed. This flow runs the full pipeline and is also non-functional on non-boundary days.
+
+---
+
+## Technical Analysis
+
+### Date computation in the dashboard
+
+#### Boundary date tables
+
+**Pentad** (pentad_in_year 1–72, 6 per month):
+
+| pentad_in_month | days covered | boundary day |
+|-----------------|-------------|--------------|
+| 1 | 1-5 | 5 |
+| 2 | 6-10 | 10 |
+| 3 | 11-15 | 15 |
+| 4 | 16-20 | 20 |
+| 5 | 21-25 | 25 |
+| 6 | 26-last | last day of month |
+
+**Decad** (decad_in_year 1–36, 3 per month):
+
+| decad_in_month | days covered | boundary day |
+|----------------|-------------|--------------|
+| 1 | 1-10 | 10 |
+| 2 | 11-20 | 20 |
+| 3 | 21-last | last day of month |
+
+#### Save Changes — boundary date from `horizon_value`
+
+`horizon_value` and `horizon` (string `"pentad"` or `"decad"`) are both available in the `save_to_database` closure. The existing code already computes `periods_per_month` (6 for pentad, 3 for decad) at line 3763. Compute boundary date:
+
+```python
+year = dt.date.today().year
+
+if horizon == "pentad":
+    periods_per_month = 6
+    month = (horizon_value - 1) // periods_per_month + 1
+    period_in_month = (horizon_value - 1) % periods_per_month + 1
+    if period_in_month == periods_per_month:
+        boundary_day = calendar.monthrange(year, month)[1]
+    else:
+        boundary_day = period_in_month * 5
+else:  # decad
+    periods_per_month = 3
+    month = (horizon_value - 1) // periods_per_month + 1
+    period_in_month = (horizon_value - 1) % periods_per_month + 1
+    if period_in_month == periods_per_month:
+        boundary_day = calendar.monthrange(year, month)[1]
+    else:
+        boundary_day = period_in_month * 10
+
+forecast_date = dt.date(year, month, boundary_day)
+
+# Year guard: if the computed date is in the future, the user is viewing
+# the previous year's data (e.g. pentad 72 = Dec 31, viewed in January).
+if forecast_date > dt.date.today():
+    year -= 1
+    # Recompute boundary_day for last-of-month periods (Feb 28 vs 29)
+    if period_in_month == periods_per_month:
+        boundary_day = calendar.monthrange(year, month)[1]
+    forecast_date = dt.date(year, month, boundary_day)
+```
+
+#### Trigger Forecasts — most recent boundary date from today
+
+`run_docker_pipeline` has no `horizon_value` (its closure only captures `horizon`). Compute the most recent boundary date by walking backward from today:
+
+```python
+def get_previous_boundary_date(today, horizon):
+    """Return the most recent boundary date <= today for the given horizon."""
+    if horizon == "pentad":
+        boundaries = [5, 10, 15, 20, 25]
+    else:  # decad
+        boundaries = [10, 20]
+    last_of_month = calendar.monthrange(today.year, today.month)[1]
+    boundaries.append(last_of_month)
+
+    # Check current month boundaries in descending order
+    for b in sorted(boundaries, reverse=True):
+        if today.day >= b:
+            return dt.date(today.year, today.month, b)
+
+    # No boundary reached yet this month — use last day of previous month
+    first_of_month = dt.date(today.year, today.month, 1)
+    last_day_prev = first_of_month - dt.timedelta(days=1)
+    return last_day_prev  # last day of previous month is always a boundary
+```
+
+This function should be defined as a module-level helper in `vizualization.py` (or in a shared utility if preferred). It is small and self-contained.
+
+### Linreg changes
+
+Add to `main()` at line 728 (the operational `else` branch), replacing `forecast_date = dt.date.today()`:
+```python
+_env_date = os.getenv('SAPPHIRE_FORECAST_DATE', '').strip()
+if _env_date:
+    try:
+        forecast_date = dt.datetime.strptime(_env_date, '%Y-%m-%d').date()
+        logger.info("Using explicit forecast date from SAPPHIRE_FORECAST_DATE: %s", forecast_date)
+    except ValueError:
+        logger.error(
+            "Invalid SAPPHIRE_FORECAST_DATE=%r — expected YYYY-MM-DD. Falling back to today.",
+            _env_date,
+        )
+        forecast_date = dt.date.today()
+else:
+    forecast_date = dt.date.today()
+```
+
+**Error handling**: `.strip()` guards against whitespace-only values. `try/except ValueError` catches empty strings that passed the truthy check, invalid dates like `2026-02-30`, and malformed formats. On any parse failure, the container logs a clear error and falls back to `date.today()` — no crash, existing behavior preserved.
+
+**Variable flow**: `forecast_date` (line 728) → `date_end` (line 729) → `current_day` (line 795, `current_day = forecast_date`) → all downstream computation. After line 795, only `current_day` is used in the loop body. No hidden `date.today()` calls after line 728 in the operational path.
+
+**Pre-loop code is safe**: The pre-loop `ForecastFlags` at line 733 uses `forecast_date`, but the result is immediately overwritten by lines 734–735 (`forecast_flags.pentad = run_pentad`) and then again inside `get_pentadal_and_decadal_data` (line 741). The pre-loop writes (`write_pentad_hydrograph_data`, `write_pentad_time_series_data`, lines 762–775) do not use `forecast_date` at all — they operate on the full historical DataFrame. No side effects from the override.
+
+**Boundary guard**: The guard at line 802 calls `ForecastFlags.from_forecast_date_get_flags(current_day)`, and line 812 checks `if run_pentad and forecast_flags.pentad:`. If `forecast_date` is a boundary day (which it will be — the dashboard computes it that way), the flags will be `True` and the guard passes naturally. No bypass needed.
+
+**No Dockerfile change needed**: `os.getenv` reads the env var directly from the container environment. The Docker CMD stays as-is.
+
+**Precedence**: The env var only applies in the operational code path (the `else` branch at line 725). The hindcast path (`if args.hindcast:`, line 688) is a separate branch that uses CLI args `--start-date`/`--end-date` and is never reached when the container runs in default (non-maintenance) mode. No conflict between the two mechanisms.
+
+### Postprocessing changes
+
+Same pattern — add `SAPPHIRE_FORECAST_DATE` override before line 189:
+```python
+_env_date = os.getenv('SAPPHIRE_FORECAST_DATE', '').strip()
+if _env_date:
+    try:
+        today = dt.datetime.strptime(_env_date, '%Y-%m-%d').date()
+        logger.info("Using explicit forecast date from SAPPHIRE_FORECAST_DATE: %s", today)
+    except ValueError:
+        logger.error(
+            "Invalid SAPPHIRE_FORECAST_DATE=%r — expected YYYY-MM-DD. Falling back to today.",
+            _env_date,
+        )
+        today = dt.date.today()
+else:
+    today = dt.date.today()
+```
+
+Since the overridden date IS a boundary day, the relevant guard passes: `is_pentad_boundary(today)` returns True when mode is PENTAD, `is_decad_boundary(today)` returns True when mode is DECAD. The dashboard always passes single-mode (never BOTH/ALL), so only one guard is evaluated per run.
+
+### Dashboard changes
+
+**`save_to_database`** (line 3742): Compute boundary date from `horizon_value` using the formula above. The computation should go **inside the Docker `try` block, immediately after the `environment` list is built** (after line 3833, before the volume resolution at line 3835). Append to the list:
+```python
+environment.append(f'SAPPHIRE_FORECAST_DATE={forecast_date.strftime("%Y-%m-%d")}')
+```
+This is safe because `save_to_database` only launches linreg and postprocessing (no preprunoff).
+
+**Error handling context**: The boundary date computation uses only `horizon_value` (a widget-supplied integer, always 1–72 or 1–36) and `calendar.monthrange`. It cannot fail under normal operation. The Docker `try` block's `except docker.errors.DockerException` would not catch a hypothetical `ValueError`, but the `finally` block (line 3873) always resets the UI. A computation failure after the visibility save (Stage D) is acceptable — visibility changes are already committed, and the user can retry the container run.
+
+**`run_docker_pipeline`** (line 4006): Compute boundary date using `get_previous_boundary_date(dt.date.today(), horizon)`. **Important: append `SAPPHIRE_FORECAST_DATE` to the environment list AFTER preprunoff has been launched** (after line 4061), before the linreg call (line 4067). This ensures preprunoff runs with today's date (it fetches the latest data) while linreg, ML models, and postprocessing receive the boundary date override.
+
+```python
+# After preprunoff completes (line 4061):
+forecast_date = get_previous_boundary_date(dt.date.today(), horizon)
+environment.append(f'SAPPHIRE_FORECAST_DATE={forecast_date.strftime("%Y-%m-%d")}')
+# Then launch linreg (line 4067), ML models, and postprocessing
+```
+
+Note: `run_docker_pipeline` calls the **outer** `run_docker_container` (line 4156, 5-parameter module-level function), which does NOT mutate the environment list (unlike the inner 6-parameter helper at line 3618 used by `save_to_database`). The append works because `environment` is a Python list passed by reference — `.append()` modifies the object in place, visible to all subsequent callers. ML containers (line 4086) use `environment + [model-specific vars]` (list concatenation, non-mutating), so they also receive `SAPPHIRE_FORECAST_DATE` from the base list. ML models do not read this env var, so the extra variable is harmless.
+
+---
+
+## Implementation Plan
+
+### Files to Modify
+
+| File | Changes |
+|------|---------|
+| `apps/linear_regression/linear_regression.py` | Add `SAPPHIRE_FORECAST_DATE` env var override in `main()` |
+| `apps/postprocessing_forecasts/postprocessing_operational.py` | Add `SAPPHIRE_FORECAST_DATE` env var override |
+| `apps/forecast_dashboard/src/vizualization.py` | Compute boundary date and add to container env in both dataflows |
+
+### Implementation Steps
+
+#### Phase 1: Module date override (linreg + postprocessing)
+
+- [x] **Step 1.1**: In `linear_regression.py:main()`, add `SAPPHIRE_FORECAST_DATE` check before `forecast_date = dt.date.today()` (line 728). When set, parse it and use it as `forecast_date`. Log the override.
+- [x] **Step 1.2**: In `postprocessing_operational.py:postprocessing_operational()`, add `SAPPHIRE_FORECAST_DATE` check before `today = dt.date.today()` (line 189). When set, parse it and use it. Log the override.
+
+#### Phase 2: Dashboard date computation and passthrough
+
+- [x] **Step 2.0**: Add `get_previous_boundary_date(today, horizon)` helper function to `vizualization.py` (module-level). Handles both pentad and decad modes.
+- [x] **Step 2.1**: In `save_to_database`, compute boundary date from `horizon_value` and `horizon` (mode-aware: pentad uses `% 6` with boundaries 5/10/15/20/25/last, decad uses `% 3` with boundaries 10/20/last). Include year guard (roll back if computed date > today). Append `SAPPHIRE_FORECAST_DATE={date}` to `environment` before container launches.
+- [x] **Step 2.2**: In `run_docker_pipeline`, call `get_previous_boundary_date(dt.date.today(), horizon)`. Append `SAPPHIRE_FORECAST_DATE={date}` to `environment` **after** preprunoff launch (line 4061), **before** linreg launch (line 4067). Preprunoff must not receive this env var.
+
+#### Phase 3: Verify
+
+- [ ] **Step 3.1**: Run on a non-boundary day (pentad mode) — Save Changes should produce updated forecasts for the selected pentad.
+- [ ] **Step 3.2**: Run on a non-boundary day (decad mode) — Save Changes should produce updated forecasts for the selected decad.
+- [ ] **Step 3.3**: Run on a boundary day — behavior unchanged (env var date matches today).
+- [ ] **Step 3.4**: Trigger Forecasts on a non-boundary day — should recompute for the most recent boundary date.
+- [ ] **Step 3.5**: Verify preprunoff does NOT receive `SAPPHIRE_FORECAST_DATE` in Trigger Forecasts flow (check container env in logs).
+
+---
+
+## Testing
+
+### Automated
+
+- [ ] Unit test for boundary date computation from pentad_in_year (all 72 values)
+- [ ] Unit test for boundary date computation from decad_in_year (all 36 values)
+- [ ] Unit test for year guard: pentad 72 viewed in January rolls back to previous December
+- [ ] Unit test for `get_previous_boundary_date` — pentad mode (test on boundary day, day after, mid-period, first of month)
+- [ ] Unit test for `get_previous_boundary_date` — decad mode (same cases)
+- [ ] Unit test for `SAPPHIRE_FORECAST_DATE` parsing in linreg `main()` (mock `os.getenv`)
+- [ ] Unit test for `SAPPHIRE_FORECAST_DATE` parsing in postprocessing
+
+### Manual (server)
+
+1. On a non-boundary day, edit visibility, Save Changes
+2. Verify linreg runs for the correct pentad boundary date (check container logs)
+3. Verify postprocessing runs for the same date
+4. Verify updated forecast appears in the summary table (requires FD-008 or the data reload fix)
+
+---
+
+## Out of Scope
+
+- Data reload mechanism (the summary table not refreshing from API — separate issue)
+- Error handling in inner `run_docker_container` (FD-008)
+- ML model date handling (ML models use `SAPPHIRE_PREDICTION_MODE` and `RUN_MODE`, not a specific date — they process whatever data is available)
+- Hindcast mode — `SAPPHIRE_FORECAST_DATE` is for single-date retrigger, not batch catch-up
+
+## Dependencies
+
+- FD-007 (implemented) — env file path fix and rerun removal
+
+## Acceptance Criteria
+
+- [ ] `SAPPHIRE_FORECAST_DATE` env var accepted by both linreg and postprocessing
+- [ ] When set to a boundary date, both modules run for that date instead of today
+- [ ] When not set, existing behavior unchanged (`date.today()`)
+- [ ] Dashboard Save Changes computes and passes the correct boundary date
+- [ ] Dashboard Trigger Forecasts computes and passes the most recent boundary date
+- [ ] Forecasts are produced on non-boundary days when triggered from dashboard
+- [ ] No changes to Luigi pipeline behavior (Luigi does not set this env var)
+
+---
+
+## References
+
+- `apps/linear_regression/linear_regression.py:728` — operational forecast_date assignment
+- `apps/linear_regression/linear_regression.py:802` — ForecastFlags call; `:812` — pentad boundary guard
+- `apps/postprocessing_forecasts/postprocessing_operational.py:189` — today assignment
+- `apps/postprocessing_forecasts/postprocessing_operational.py:192` — pentad boundary guard
+- `apps/postprocessing_forecasts/postprocessing_operational.py:202` — decad boundary guard
+- `apps/postprocessing_forecasts/postprocessing_operational.py:54-63` — `is_pentad_boundary` / `is_decad_boundary` definitions
+- `apps/forecast_dashboard/src/vizualization.py:3742` — `save_to_database`
+- `apps/forecast_dashboard/src/vizualization.py:4006` — `run_docker_pipeline`
+- `apps/iEasyHydroForecast/tag_library.py:672` — `get_date_for_pentad` (returns first day, not boundary)
+- FD-007: `doc/plans/issues/mid_prio_gi_draft_fd_docker_dataflows_update.md`
+- FD-008: `doc/plans/issues/low_prio_gi_draft_fd_inner_run_docker_error_handling.md`

--- a/doc/plans/module_issues.md
+++ b/doc/plans/module_issues.md
@@ -182,6 +182,7 @@ These are blocking decisions — work downstream cannot advance until they are r
 | **FD-006** | Skill metrics missing for LR and NE due to model_long merge key mismatch | **High** | Draft | [`high_prio_gi_draft_dashboard_skill_metrics_model_long_mismatch.md`](issues/high_prio_gi_draft_dashboard_skill_metrics_model_long_mismatch.md) | — |
 | **FD-007** | Update dashboard Docker dataflows to operational mode with logging | **Medium** | Implemented | [`mid_prio_gi_draft_fd_docker_dataflows_update.md`](issues/mid_prio_gi_draft_fd_docker_dataflows_update.md) | — |
 | **FD-008** | Fix error handling in inner `run_docker_container` (Save Changes) | **Low** | Draft | [`low_prio_gi_draft_fd_inner_run_docker_error_handling.md`](issues/low_prio_gi_draft_fd_inner_run_docker_error_handling.md) | — |
+| **FD-009** | Pass explicit forecast date to containers in dashboard retrigger flows | **Medium** | Draft | [`mid_prio_gi_draft_fd_retrigger_forecast_date.md`](issues/mid_prio_gi_draft_fd_retrigger_forecast_date.md) | FD-007 |
 
 ### iEasyHydro HF Migration
 


### PR DESCRIPTION
## Summary                                                                                                                                
                                                                                                                                           
   - Add `SAPPHIRE_FORECAST_DATE` env var override to `linear_regression` and `postprocessing_forecasts` — when set, use that date instead
    of `date.today()` (fallback preserved when unset)
   - Dashboard "Save Changes" computes the boundary date from the selected pentad/decad and passes it to containers
   - Dashboard "Trigger Forecasts" computes the most recent boundary date and passes it after preprunoff completes (preprunoff does NOT
   receive the override)
   - 178 new unit tests (154 boundary date, 24 env var parsing)
   - Updated `doc/development.md` section 2.2.8 (replaced deprecated `sapphire-rerun` docs) and `doc/configuration.md` (internal Docker
   env vars table)

   Depends on: FD-007 (#317)

   ## Test plan

   - [x] `linear_regression` tests: 327 passed, 0 failed, 0 skipped
   - [x] `postprocessing_forecasts` tests: 1315 passed, 0 failed, 0 skipped
   - [x] `forecast_dashboard` tests: 197 passed, 0 failed, 0 skipped
   - [ ] Server test: Save Changes on non-boundary day (pentad mode) produces updated forecasts
   - [ ] Server test: Trigger Forecasts on non-boundary day recomputes for most recent boundary
   - [ ] Server test: Verify preprunoff does NOT receive `SAPPHIRE_FORECAST_DATE`