### PR TITLE
Add D10/D14 debug logs for forecast date year guard diagnosis

### DIFF
--- a/apps/forecast_dashboard/src/db.py
+++ b/apps/forecast_dashboard/src/db.py
@@ -396,6 +396,14 @@ def get_forecasts_all(horizon, station=None) -> pd.DataFrame:
 
     # Union of columns, missing columns will become NaN
     combined = pd.concat([df_ml, df_lr], ignore_index=True, sort=False)
+    if code == "15013" and not combined.empty:
+        logger.warning(
+            "D14 get_forecasts_all code=15013: rows=%d, max_date=%s, "
+            "unique_dates=%s, models=%s",
+            len(combined), combined["date"].max(),
+            sorted(combined["date"].dropna().dt.date.unique()),
+            list(combined["model_short"].unique()),
+        )
     return _convert_na_to_nan(combined.sort_values("Date"))
 
 @_timed

--- a/apps/forecast_dashboard/src/vizualization.py
+++ b/apps/forecast_dashboard/src/vizualization.py
@@ -3875,12 +3875,20 @@ def select_and_plot_data(_, dm, wm, linreg_predictor, station_widget, pentad_sel
             forecast_date = dt.date(year, month, boundary_day)
             # Year guard: if the computed date is in the future, the user is
             # viewing the previous year's data.
-            if forecast_date > dt.date.today():
+            year_guard_fired = forecast_date > dt.date.today()
+            if year_guard_fired:
                 year -= 1
                 if period_in_month == periods_per_month:
                     boundary_day = calendar.monthrange(year, month)[1]
                 forecast_date = dt.date(year, month, boundary_day)
             environment.append(f'SAPPHIRE_FORECAST_DATE={forecast_date.strftime("%Y-%m-%d")}')
+            logger.warning(
+                "D10 save_to_database: horizon=%s, horizon_value=%d, "
+                "month=%d, period_in_month=%d, boundary_day=%d, "
+                "year_guard_fired=%s, forecast_date=%s, today=%s",
+                horizon, horizon_value, month, period_in_month, boundary_day,
+                year_guard_fired, forecast_date, dt.date.today(),
+            )
 
             # Define volumes
             volumes = {


### PR DESCRIPTION
## Summary
- **D10** (`vizualization.py`): Logs the `SAPPHIRE_FORECAST_DATE` computation in `save_to_database`, including whether the year guard fired — suspected root cause of "Save Changes" writing to wrong year
- **D14** (`db.py`): Logs what `get_forecasts_all` returns for station 15013 (unique dates, models, max date) to confirm whether container-written data is visible to the dashboard query

## Context
Server testing confirmed both containers write successfully to the API (D8/D9 from PR #320). However, browser reload still shows old forecasts. Analysis suggests the year guard at `vizualization.py:3878` incorrectly falls back to the previous year for the current in-progress pentad (e.g. pentad ending Apr 10 when today is Apr 8), causing forecasts to be written with date=2025 while the dashboard displays date=2026 data.

These two logs will confirm the diagnosis on the next server test before we fix the year guard.

## Test plan
- [x] Pre-commit hooks pass (ruff, integration tests)
- [ ] Deploy to server, trigger "Save Changes" for station 15013
- [ ] Check D10 log: expect `year_guard_fired=True, forecast_date=2025-04-10`
- [ ] Check D14 log after reload: expect both 2025 and 2026 dates present

🤖 Generated with [Claude Code](https://claude.com/claude-code)