### PR TITLE
Fix year guard firing for current in-progress pentad

### DIFF
--- a/apps/forecast_dashboard/src/vizualization.py
+++ b/apps/forecast_dashboard/src/vizualization.py
@@ -3875,7 +3875,7 @@ def select_and_plot_data(_, dm, wm, linreg_predictor, station_widget, pentad_sel
             forecast_date = dt.date(year, month, boundary_day)
             # Year guard: if the computed date is in the future, the user is
             # viewing the previous year's data.
-            year_guard_fired = forecast_date > dt.date.today()
+            year_guard_fired = forecast_date > dt.date.today() + dt.timedelta(days=31)
             if year_guard_fired:
                 year -= 1
                 if period_in_month == periods_per_month:

--- a/apps/forecast_dashboard/tests/test_boundary_date.py
+++ b/apps/forecast_dashboard/tests/test_boundary_date.py
@@ -104,7 +104,7 @@ def compute_boundary_date_with_year_guard(horizon_value, horizon):
         else:
             boundary_day = period_in_month * 10
     forecast_date = dt.date(year, month, boundary_day)
-    if forecast_date > dt.date.today():
+    if forecast_date > dt.date.today() + dt.timedelta(days=31):
         year -= 1
         if period_in_month == periods_per_month:
             boundary_day = calendar.monthrange(year, month)[1]
@@ -366,7 +366,7 @@ class TestBoundaryDateFromHorizonValue:
         period_in_month = (horizon_value - 1) % periods_per_month + 1  # 6
         boundary_day = calendar.monthrange(year, month)[1]  # 31
         forecast_date = dt.date(year, month, boundary_day)  # 2027-12-31
-        if forecast_date > fake_today:
+        if forecast_date > fake_today + dt.timedelta(days=31):
             year -= 1  # 2026
             boundary_day = calendar.monthrange(year, month)[1]  # 31
             forecast_date = dt.date(year, month, boundary_day)  # 2026-12-31
@@ -383,10 +383,29 @@ class TestBoundaryDateFromHorizonValue:
         period_in_month = (horizon_value - 1) % periods_per_month + 1  # 1
         boundary_day = period_in_month * 5  # 5
         forecast_date = dt.date(year, month, boundary_day)  # 2026-03-05
-        if forecast_date > fake_today:
+        if forecast_date > fake_today + dt.timedelta(days=31):
             year -= 1
             forecast_date = dt.date(year, month, boundary_day)
         assert forecast_date == dt.date(2026, 3, 5)
+
+    def test_year_guard_current_in_progress_pentad_no_rollback(self):
+        """horizon_value=20 (Apr 10) with today=2026-04-08 → no rollback.
+
+        The current pentad boundary is only 2 days ahead, well within the
+        31-day grace window. The year guard must NOT fire.
+        """
+        fake_today = dt.date(2026, 4, 8)
+        horizon_value = 20
+        year = fake_today.year
+        periods_per_month = 6
+        month = (horizon_value - 1) // periods_per_month + 1  # 4
+        period_in_month = (horizon_value - 1) % periods_per_month + 1  # 2
+        boundary_day = period_in_month * 5  # 10
+        forecast_date = dt.date(year, month, boundary_day)  # 2026-04-10
+        if forecast_date > fake_today + dt.timedelta(days=31):
+            year -= 1
+            forecast_date = dt.date(year, month, boundary_day)
+        assert forecast_date == dt.date(2026, 4, 10)
 
     # ── Feb last-of-month ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- The year guard in `save_to_database` rolled back to the previous year when the pentad boundary was even 1 day in the future (e.g. Apr 10 when today is Apr 8), causing containers to write forecasts under 2025 instead of 2026
- Add a 31-day grace window so the guard only fires for pentads that are clearly from a different season (e.g. December viewed in January)
- One-line production code change + updated tests

## Root cause
Confirmed via D10/D14 debug logs from PRs #320/#321:
- D10: `year_guard_fired=True, forecast_date=2025-04-10, today=2026-04-08`
- D14: API returns data up to `max_date=2026-04-05`, the 2025-04-10 data was outside the displayed range

## Test plan
- [x] All 155 boundary date tests pass
- [x] All forecast_dashboard unit tests pass (197 passed)
- [ ] Deploy to server, Save Changes for pentad 20 → D10 shows `year_guard_fired=False, forecast_date=2026-04-10`
- [ ] Browser reload shows updated forecasts in summary table

🤖 Generated with [Claude Code](https://claude.com/claude-code)