### PR TITLE
Fix doubled hindcast subprocess path in Docker

### DIFF
--- a/apps/machine_learning/add_new_station.py
+++ b/apps/machine_learning/add_new_station.py
@@ -72,14 +72,8 @@ def call_hindcast_script(
     env["ieasyhydroforecast_NEW_STATIONS"] = codes_hindcast
 
     # Prepare the command
-    if os.getenv("IN_DOCKER") == "True":
-        command = ["python", "apps/machine_learning/hindcast_ML_models.py"]
-        print("Running in Docker, calling command:", command)
-        logger.info("Running in Docker, calling command: %s", command)
-    else:
-        command = [sys.executable, "hindcast_ML_models.py"]
-        print("Running locally, calling command:", command)
-        logger.info("Running locally, calling command: %s", command)
+    command = [sys.executable, "hindcast_ML_models.py"]
+    logger.info("Running hindcast command: %s", command)
 
     # Call the script
     result = subprocess.run(command, capture_output=True, text=True, env=env)

--- a/apps/machine_learning/fill_ml_gaps.py
+++ b/apps/machine_learning/fill_ml_gaps.py
@@ -85,14 +85,8 @@ def call_hindcast_script(
     env["ieasyhydroforecast_NEW_STATIONS"] = "None"
 
     # Prepare the command
-    if os.getenv("IN_DOCKER") == "True":
-        command = ["python", "apps/machine_learning/hindcast_ML_models.py"]
-        print("Running in Docker, calling command:", command)
-        logger.info("Running in Docker, calling command: %s", command)
-    else:
-        command = [sys.executable, "hindcast_ML_models.py"]
-        print("Running locally, calling command:", command)
-        logger.info("Running locally, calling command: %s", command)
+    command = [sys.executable, "hindcast_ML_models.py"]
+    logger.info("Running hindcast command: %s", command)
 
     # Call the script
     result = subprocess.run(command, capture_output=True, text=True, env=env)

--- a/apps/machine_learning/recalculate_nan_forecasts.py
+++ b/apps/machine_learning/recalculate_nan_forecasts.py
@@ -86,14 +86,8 @@ def call_hindcast_script(
     env["ieasyhydroforecast_NEW_STATIONS"] = codes_hindcast
 
     # Prepare the command
-    if os.getenv("IN_DOCKER") == "True":
-        command = ["python", "apps/machine_learning/hindcast_ML_models.py"]
-        print("Running in Docker, calling command:", command)
-        logger.info("Running in Docker, calling command: %s", command)
-    else:
-        command = [sys.executable, "hindcast_ML_models.py"]
-        print("Running locally, calling command:", command)
-        logger.info("Running locally, calling command: %s", command)
+    command = [sys.executable, "hindcast_ML_models.py"]
+    logger.info("Running hindcast command: %s", command)
 
     # Call the script
     result = subprocess.run(command, capture_output=True, text=True, env=env)


### PR DESCRIPTION
## Summary
- The uv migration (Dec 2025) changed the ML Dockerfile `WORKDIR` from `/app` to `/app/apps/machine_learning`, but three maintenance scripts still used the old relative path `apps/machine_learning/hindcast_ML_models.py` in their `IN_DOCKER` branch
- This produced the doubled path `/app/apps/machine_learning/apps/machine_learning/hindcast_ML_models.py`, causing hindcast subprocess calls to fail with `FileNotFoundError` in Docker
- Removed the `IN_DOCKER` branch entirely — `sys.executable` with the short path `hindcast_ML_models.py` works in both local and Docker contexts since the WORKDIR is now the script's own directory

## Files changed
- `apps/machine_learning/fill_ml_gaps.py`
- `apps/machine_learning/recalculate_nan_forecasts.py`
- `apps/machine_learning/add_new_station.py`

## Test plan
- [x] `SAPPHIRE_TEST_ENV=True bash run_tests.sh machine_learning` — 110 passed
- [x] `bash apps/run_locally.sh maintenance:machine_learning` — all 3 models (TFT, TIDE, TSMIXER) pass
- [ ] Deploy to server and verify ML maintenance containers no longer show the doubled path error

🤖 Generated with [Claude Code](https://claude.com/claude-code)