### PR TITLE
Fix maintenance pipeline: remove RunAllMLMaintenance WrapperTask

### DIFF
--- a/apps/pipeline/README
+++ b/apps/pipeline/README
@@ -78,9 +78,8 @@ RunDailyMaintenanceWorkflow
   └─ PostProcessingMaintenance
        ├─ LinRegMaintenance(PENTAD) → PrepRunoffMaintenance
        ├─ LinRegMaintenance(DECAD)  → PrepRunoffMaintenance
-       └─ RunAllMLMaintenance (if ML enabled)
-            └─ MLMaintenance(model, mode)  [resources: ml_memory=1]
-                 → [PrepRunoffMaintenance, GatewayMaintenance]
+       └─ MLMaintenance(model, mode) (if ML enabled)  [resources: ml_memory=1]
+            → [PrepRunoffMaintenance, GatewayMaintenance]
 ```
 
 Frontend update is handled on the host by `bin/daily_update_sapphire_frontend.sh`

--- a/apps/pipeline/pipeline_docker.py
+++ b/apps/pipeline/pipeline_docker.py
@@ -1828,17 +1828,6 @@ class MLMaintenance(DockerTaskBase):
         )
 
 
-class RunAllMLMaintenance(luigi.WrapperTask):
-    """Wrapper that yields MLMaintenance for each model x horizon."""
-
-    def requires(self):
-        models = env.get("ieasyhydroforecast_available_ML_models").split(",")
-        prediction_modes = ["PENTAD", "DECAD"]
-        for model in models:
-            for mode in prediction_modes:
-                yield MLMaintenance(model_type=model, prediction_mode=mode)
-
-
 class PostProcessingMaintenance(DockerTaskBase):
     """Run postprocessing in maintenance mode (gap-fill ensembles)."""
 
@@ -1854,7 +1843,10 @@ class PostProcessingMaintenance(DockerTaskBase):
             LinRegMaintenance(prediction_mode="DECAD"),
         ]
         if RUN_ML_MODELS == "True":
-            deps.append(RunAllMLMaintenance())
+            models = env.get("ieasyhydroforecast_available_ML_models").split(",")
+            for model in models:
+                for mode in ["PENTAD", "DECAD"]:
+                    deps.append(MLMaintenance(model_type=model, prediction_mode=mode))
         return deps
 
     def output(self):

--- a/apps/pipeline/tests/test_maintenance_tasks.py
+++ b/apps/pipeline/tests/test_maintenance_tasks.py
@@ -2,7 +2,7 @@
 
 Covers:
 - Preprocessing maintenance tasks (GatewayMaintenance, PrepRunoffMaintenance)
-- Forecasting maintenance tasks (LinRegMaintenance, MLMaintenance, RunAllMLMaintenance)
+- Forecasting maintenance tasks (LinRegMaintenance, MLMaintenance)
 - Postprocessing and frontend tasks
 - Workflow orchestrators (RunDailyMaintenanceWorkflow, RunPeriodicMaintenanceWorkflow)
 - Dependency chains
@@ -158,29 +158,6 @@ class TestMLMaintenance:
         assert "maintenance_ml_TIDE_DECAD_" in path
 
 
-class TestRunAllMLMaintenance:
-    """Test RunAllMLMaintenance wrapper task."""
-
-    def test_yields_all_model_horizon_combos(self, mock_env):
-        """Yields MLMaintenance for each model x horizon."""
-        from pipeline_docker import MLMaintenance, RunAllMLMaintenance
-
-        task = RunAllMLMaintenance()
-        deps = list(task.requires())
-
-        # Default: TFT,TIDE models x PENTAD,DECAD modes = 4 tasks
-        assert len(deps) == 4
-        for d in deps:
-            assert isinstance(d, MLMaintenance)
-
-        # Verify all combinations present
-        combos = {(d.model_type, d.prediction_mode) for d in deps}
-        assert ("TFT", "PENTAD") in combos
-        assert ("TFT", "DECAD") in combos
-        assert ("TIDE", "PENTAD") in combos
-        assert ("TIDE", "DECAD") in combos
-
-
 class TestPostProcessingMaintenance:
     """Test PostProcessingMaintenance task."""
 
@@ -200,24 +177,30 @@ class TestPostProcessingMaintenance:
         assert modes == {"PENTAD", "DECAD"}
 
     def test_includes_ml_when_enabled(self, mock_env, monkeypatch):
-        """Includes RunAllMLMaintenance when ML models are enabled."""
+        """Includes MLMaintenance tasks when ML models are enabled."""
         import pipeline_docker
 
         monkeypatch.setattr(pipeline_docker, "RUN_ML_MODELS", "True")
 
         task = pipeline_docker.PostProcessingMaintenance()
         deps = task.requires()
-        class_names = [type(d).__name__ for d in deps]
-        assert "RunAllMLMaintenance" in class_names
+        ml_tasks = [d for d in deps if isinstance(d, pipeline_docker.MLMaintenance)]
+        # TFT,TIDE x PENTAD,DECAD = 4 ML tasks
+        assert len(ml_tasks) == 4
+        combos = {(d.model_type, d.prediction_mode) for d in ml_tasks}
+        assert ("TFT", "PENTAD") in combos
+        assert ("TFT", "DECAD") in combos
+        assert ("TIDE", "PENTAD") in combos
+        assert ("TIDE", "DECAD") in combos
 
     def test_excludes_ml_when_disabled(self, mock_env):
         """Excludes ML tasks when ML models are disabled."""
-        from pipeline_docker import PostProcessingMaintenance
+        from pipeline_docker import MLMaintenance, PostProcessingMaintenance
 
         task = PostProcessingMaintenance()
         deps = task.requires()
-        class_names = [type(d).__name__ for d in deps]
-        assert "RunAllMLMaintenance" not in class_names
+        ml_tasks = [d for d in deps if isinstance(d, MLMaintenance)]
+        assert len(ml_tasks) == 0
 
     def test_output_uses_maintenance_marker(self, mock_env):
         """Output marker has maintenance_ prefix."""

--- a/doc/plans/issues/high_prio_gi_draft_pipeline_remove_wrapper_task.md
+++ b/doc/plans/issues/high_prio_gi_draft_pipeline_remove_wrapper_task.md
@@ -1,0 +1,139 @@
+# Remove RunAllMLMaintenance WrapperTask to fix unfulfilled dependencies
+
+**Priority**: High
+**Module**: pipeline
+**Status**: Draft
+
+## Problem
+
+`RunAllMLMaintenance` is a `luigi.WrapperTask` that aggregates 6
+`MLMaintenance` tasks. All 6 tasks complete successfully and write their
+marker files. But when Luigi's worker picks up the WrapperTask, it re-checks
+all dependency outputs from a different subprocess (`worker.py:195`). In the
+Docker multi-worker environment (`workers=6`), the marker files written by
+other worker subprocesses are not visible to this check, causing:
+
+```
+RuntimeError: Unfulfilled dependencies at run time:
+  MLMaintenance_None_TFT_PENTAD_... (/kyg_data_forecast_tools/.../maintenance_ml_TFT_PENTAD_2026-04-15.marker),
+  MLMaintenance_None_TFT_DECAD_... (/kyg_data_forecast_tools/.../maintenance_ml_TFT_DECAD_2026-04-15.marker),
+  ... (all 6 markers)
+```
+
+This is systematic — all 6 markers are reported missing, not just 1-2. The
+issue reproduces on every maintenance run.
+
+**Impact**: `PostProcessingMaintenance` and `RunDailyMaintenanceWorkflow`
+never run because they depend on `RunAllMLMaintenance`.
+
+## Root Cause
+
+Luigi's `WrapperTask` is a no-op task whose only purpose is dependency
+grouping. But the Luigi worker runs a safety check (`TaskProcess.run()` in
+`worker.py:195`) that verifies all dependency outputs exist before calling
+`run()`. This check runs in a NEW subprocess (forked via `multiprocessing`),
+and in the Docker volume environment, marker files written by other worker
+subprocesses are not visible to `os.path.exists()` at check time.
+
+## Fix
+
+Remove the `WrapperTask` indirection. Inline the ML dependency logic directly
+into `PostProcessingMaintenance.requires()`. This eliminates the intermediate
+subprocess dependency check entirely.
+
+**Before** (current DAG):
+```
+PostProcessingMaintenance
+  ├── LinRegMaintenance(PENTAD)
+  ├── LinRegMaintenance(DECAD)
+  └── RunAllMLMaintenance  <-- WrapperTask, no-op run(), dependency check fails
+        ├── MLMaintenance(TFT, PENTAD)
+        ├── MLMaintenance(TFT, DECAD)
+        ├── MLMaintenance(TIDE, PENTAD)
+        ├── MLMaintenance(TIDE, DECAD)
+        ├── MLMaintenance(TSMIXER, PENTAD)
+        └── MLMaintenance(TSMIXER, DECAD)
+```
+
+**After** (fixed DAG):
+```
+PostProcessingMaintenance
+  ├── LinRegMaintenance(PENTAD)
+  ├── LinRegMaintenance(DECAD)
+  ├── MLMaintenance(TFT, PENTAD)      <-- direct dependency
+  ├── MLMaintenance(TFT, DECAD)
+  ├── MLMaintenance(TIDE, PENTAD)
+  ├── MLMaintenance(TIDE, DECAD)
+  ├── MLMaintenance(TSMIXER, PENTAD)
+  └── MLMaintenance(TSMIXER, DECAD)
+```
+
+Same DAG edges, same execution order. Only the intermediate empty task is removed.
+
+## Implementation
+
+### `apps/pipeline/pipeline_docker.py`
+
+1. **Delete** `RunAllMLMaintenance` class (lines 1831-1839)
+
+2. **Modify** `PostProcessingMaintenance.requires()` — replace
+   `deps.append(RunAllMLMaintenance())` with direct ML task construction:
+
+   ```python
+   def requires(self):
+       deps = [
+           LinRegMaintenance(prediction_mode="PENTAD"),
+           LinRegMaintenance(prediction_mode="DECAD"),
+       ]
+       if RUN_ML_MODELS == "True":
+           models = env.get("ieasyhydroforecast_available_ML_models").split(",")
+           for model in models:
+               for mode in ["PENTAD", "DECAD"]:
+                   deps.append(MLMaintenance(model_type=model, prediction_mode=mode))
+       return deps
+   ```
+
+### `apps/pipeline/tests/test_maintenance_tasks.py`
+
+1. **Update** module docstring (line 5) — remove `RunAllMLMaintenance` mention
+
+2. **Delete** `TestRunAllMLMaintenance` class (lines 161-181)
+
+3. **Update** `test_includes_ml_when_enabled` (line 202) — check for
+   `MLMaintenance` instances directly instead of `RunAllMLMaintenance`.
+   Expect 4 ML tasks (mock env has `TFT,TIDE` x `PENTAD,DECAD`).
+
+4. **Update** `test_excludes_ml_when_disabled` (line 213) — check that no
+   `MLMaintenance` instances are in the dependency list (not
+   `RunAllMLMaintenance`)
+
+### `apps/pipeline/README` (line 81)
+
+Replace `RunAllMLMaintenance` wrapper with direct `MLMaintenance` tasks in
+the DAG diagram.
+
+## Verification
+
+1. `SAPPHIRE_TEST_ENV=True bash apps/run_tests.sh pipeline` — all tests pass
+2. `grep -r "RunAllMLMaintenance" apps/pipeline/` — zero matches
+3. Deploy to server and run daily maintenance — `PostProcessingMaintenance`
+   should complete without unfulfilled dependencies error
+
+## Risk Assessment
+
+**Safe**: The WrapperTask's `run()` was a no-op. Inlining the same
+`MLMaintenance` tasks directly into `PostProcessingMaintenance.requires()`
+produces the exact same DAG edges. Luigi still serializes ML tasks via
+`resources = {"ml_memory": 1}` and waits for all of them before running
+postprocessing.
+
+**No behavioral change**: Same tasks, same order, same concurrency. Only the
+empty intermediate task is removed.
+
+## Note: Operational pipeline `RunAllMLModels`
+
+`RunAllMLModels` (line 761) is also a `luigi.WrapperTask` with the same
+pattern. It is defined but NOT used as a dependency anywhere in the current
+pipeline code (only referenced in a message string and tests). If it were
+used as a dependency, it could have the same issue. Out of scope for this
+fix — the operational pipeline uses direct task yields, not the wrapper.


### PR DESCRIPTION
## Summary

- Remove `RunAllMLMaintenance` WrapperTask that causes systematic `RuntimeError: Unfulfilled dependencies at run time` on every maintenance run with `--workers 6`
- Inline ML task construction directly into `PostProcessingMaintenance.requires()`, matching the proven pattern used by `PostProcessingForecasts` and `RunPentadalWorkflow`
- The maintenance pipeline has never run to completion — first blocked by an invalid `--resources` CLI flag (fixed in a704eea), now blocked by this WrapperTask issue

## Changes

| File | Change |
|---|---|
| `apps/pipeline/pipeline_docker.py` | Delete `RunAllMLMaintenance` class, inline ML loop into `PostProcessingMaintenance.requires()` |
| `apps/pipeline/tests/test_maintenance_tasks.py` | Remove wrapper test class, update ML enable/disable assertions to check `MLMaintenance` instances directly |
| `apps/pipeline/README` | Update DAG diagram |
| `doc/plans/issues/high_prio_gi_draft_pipeline_remove_wrapper_task.md` | Issue plan with root cause analysis |

Net: -26 lines (19 added, 45 removed in code files)

## Test plan

- [x] `SAPPHIRE_TEST_ENV=True bash apps/run_tests.sh pipeline` — 170 passed, 0 skipped
- [x] `grep -r "RunAllMLMaintenance" apps/pipeline/` — zero matches in source
- [x] Focused DAG chain tests (14 tests) verify correct dependency structure
- [ ] Deploy to server and run `bin/run_daily_maintenance.sh` — `PostProcessingMaintenance` should complete without unfulfilled dependencies error

🤖 Generated with [Claude Code](https://claude.com/claude-code)