### PR TITLE
Fix ML API timeout, add scoped skill recalc, fix pickle crash

### DIFF
--- a/apps/config/.env_develop
+++ b/apps/config/.env_develop
@@ -1,94 +1,114 @@
-# .env
-# Access to iEasyHydro Database & configuration of file and folder paths for the
-# SAPPHIRE Forecast Tools.
+# Reference .env for a MINIMAL SAPPHIRE deployment.
+# Mirrors the "Minimal deployment profile" block in doc/configuration.md.
+# Copy to <data_folder>/config/.env_develop_<country>, replace <...> placeholders.
+# This profile runs linear regression against manual sites only: no iEH HF,
+# no Data Gateway, no ML, no conceptual models, no long-term forecasts.
+# For add-ons (iEH HF, gateway, ML, long-term, SMTP alerts), see the
+# commented blocks at the bottom and doc/configuration.md#add-ons.
 
-# Configuration of iEasyHydro Pyton SDK
-# Note that host.docker.internal is used on Mac and Windows to access the host
-# machine from within the Docker container. On Linux, use the IP address of the
-# host machine instead (e.g. 178.15.0.1). You will have to make sure port that
-# port 9000 is open.
-# Note further that you will require to have a user account on the iEasyHydro
-# platform if you wish to use these software tools to supplement iEasyHydro
-# for operational hydrological forecasting. You can request access at
-# https://ieasyhydro.org.
+# --- Identity and mode ---
+ieasyhydroforecast_organization=demo
+ieasyhydroforecast_connect_to_iEH=False
+ieasyhydroforecast_run_ML_models=false
+ieasyhydroforecast_run_CM_models=false
 
-# Locally running the linear regression app on Mac, outside a docker container
-IEASYHYDRO_HOST=http://localhost:9000
-
-# Running the app in Docker or building image on Windows
-#IEASYHYDRO_HOST=http://host.docker.internal:9000
-IEASYHYDRO_USERNAME=<user_name>
-IEASYHYDRO_PASSWORD=<password>
-ORGANIZATION_ID=1
-
-# Configuration of I/O
-## Path to station and output configuration files
-# These files are read by all tools
-# Only the forecast configuration dashboard writes to
-# ieasyforecast_config_file_station_selection and to
-# ieasyforecast_config_file_output.
-ieasyforecast_configuration_path=../config
+# --- Station + output config files (kept under <data_folder>/config) ---
+ieasyforecast_configuration_path=../../../<data_folder>/config
 ieasyforecast_config_file_all_stations=config_all_stations_library.json
 ieasyforecast_config_file_station_selection=config_station_selection.json
 ieasyforecast_config_file_output=config_output.json
+ieasyforecast_restrict_stations_file=null
 
-## Path to output data files.
-# These are intermediate results produced by the backend tool and used by the
-# forecast dashboard.
-ieasyforecast_intermediate_data_path=../internal_data
-ieasyforecast_hydrograph_day_file=hydrograph_day.csv
-ieasyforecast_hydrograph_pentad_file=hydrograph_pentad.csv
-ieasyforecast_results_file=forecasts_pentad.csv
-
-## Logging date of last successful run
-# This file is stored under ieasyforecast_intermediate_data_path and is used to
-# determine from which date the forecast should be run. It is updated by the
-# backend.
+# --- Intermediate data + last-run marker ---
+ieasyforecast_intermediate_data_path=../../../<data_folder>/intermediate_data
 ieasyforecast_last_successful_run_file=last_successful_run.txt
 
-## Configuration of iEasyReports
-# iEasyReports is a python package used to generate the forecast bulletins.
-# It is available at github.com/hydrosolutions/iEasyReports. Its input and
-# output files are configured here.
-# Forecast bulletins (ieasyforecast_bulletin_file_name) are always written, the
-# forecast sheets (ieasyforecast_sheet_file_name) are only written if the
-# write_excel parameter in the output configuration file is set to True. This
-# is done by the forecast configuration dashboard.
-# Path where the templates fore the forecast bulletins are stored
-ieasyreports_templates_directory_path=../../data/templates
+# --- Bulletin templates and report output ---
+ieasyreports_templates_directory_path=../../../<data_folder>/templates
 ieasyforecast_template_pentad_bulletin_file=pentad_forecast_bulletin_template.xlsx
 ieasyforecast_template_pentad_sheet_file=short_term_trad_sheet_template.xlsx
-# Path where the forecast bulletins are written to in operational mode
-ieasyreports_report_output_path=../../data/reports
+ieasyreports_report_output_path=../../../<data_folder>/reports
 ieasyforecast_bulletin_file_name=pentadal_forecast_bulletin.xlsx
 ieasyforecast_sheet_file_name=pentadal_forecast_sheet.xlsx
 
-# Configuration of the assets for the station selection/configuration dashboard
-ieasyforecast_gis_directory_path=../../data/GIS
-ieasyforecast_country_borders_file_name=gadm41_CHE_shp/gadm41_CHE_1.shp
+# --- Dashboard map + daily discharge excel files ---
+ieasyforecast_gis_directory_path=../../../<data_folder>/GIS
+ieasyforecast_country_borders_file_name=<adm_boundaries>.shp
+ieasyforecast_daily_discharge_path=../../../<data_folder>/daily_runoff
 
-# Paths of files with daily discharge data
-# Not all daily data is currently in the iEasyHydro Database. Intermediately, the
-# data is stored in Excel files. The paths to these files are configured here.
-# Note that the excel file names must start with the station code, followed by
-# an underscore and then any name. The format of the excel files is one sheet
-# per year with dates in the first column and discharge values in m3/s in the
-# second column.
-ieasyforecast_daily_discharge_path=../../data/daily_runoff
-
-# Path for localization of forecast dashboard
-# Here you can switch between the available languages when running the forecast
-# dashboard locally. For deployment choose one language.
-ieasyforecast_locale_dir=../config/locale
-# Set the locale for the dashboard. Available locales are ru_KG and en_CH.
-ieasyforecast_locale=en_CH #ru_KG
-
-# Configuration of error and message logging.
+# --- Localization + logging ---
+ieasyforecast_locale_dir=../../../<data_folder>/config/locale
+ieasyforecast_locale=en_CH
 log_file=./forecast_logs.txt
-log_level=DEBUG
+log_level=INFO
 
-# Configuration used during the development of the forecast tools
-# In case, the forecast method is not yet tested for multiple stations, you can
-# restrict the stations codes. Put these stations in the following file (same
-# format as the config_station_selection.json file).
-ieasyforecast_restrict_stations_file=config_development_restrict_station_selection.json
+# --- SAPPHIRE services (must point at the running API gateway) ---
+SAPPHIRE_API_ENABLED=true
+SAPPHIRE_API_URL=http://localhost:8000
+POSTGRES_USER=<db_user>
+POSTGRES_PASSWORD=<db_password>
+PREPROCESSING_DB=preprocessing_db
+POSTPROCESSING_DB=postprocessing_db
+USER_DB=user_db
+AUTH_DB=auth_db
+JWT_SECRET_KEY=<generate_strong_random_secret>
+
+# =============================================================================
+# Optional add-on blocks below. Leave commented out for a minimal deployment.
+# See doc/configuration.md#add-ons--what-to-flip-on-when-you-need-more.
+# =============================================================================
+
+# --- Optional: connect to iEasyHydro HF (preprocessing_runoff) ---
+# Flip ieasyhydroforecast_connect_to_iEH=True above, then set:
+#IEASYHYDROHF_HOST=http://host.docker.internal:5555/api/v1/
+#IEASYHYDROHF_USERNAME=<iEH_HF_user>
+#IEASYHYDROHF_PASSWORD=<iEH_HF_password>
+#ieasyhydroforecast_ssh_to_iEH=False
+
+# --- Optional: legacy iEasyHydro SDK (backend module only) ---
+#IEASYHYDRO_HOST=http://localhost:9000
+#IEASYHYDRO_USERNAME=<user_name>
+#IEASYHYDRO_PASSWORD=<password>
+#ORGANIZATION_ID=1
+
+# --- Optional: spot-check validation of iEH HF data ---
+# Comma-separated list of site codes. Use dummy codes, not real ones.
+#IEASYHYDRO_SPOTCHECK_SITES=19999,19998
+
+# --- Optional: manual-site ingestion from Google Sheets ---
+#GOOGLE_SHEETS_ENABLED=false
+#GOOGLE_SHEETS_DISCHARGE_ID=<spreadsheet_id>
+#GOOGLE_SHEETS_CREDENTIALS_PATH=<path_to_service_account.json>
+#GOOGLE_SHEETS_SITE_CODES=19999,19998
+
+# --- Optional: SAPPHIRE Data Gateway (required before ML or CM) ---
+#ieasyhydroforecast_API_KEY_GATEAWAY=<gateway_api_key>
+#SAPPHIRE_DG_HOST=<gateway_base_url>
+#ieasyhydroforecast_HRU_CONTROL_MEMBER=<hru_id>
+#ieasyhydroforecast_models_and_scalers_path=../../../<data_folder>/models_and_scalers
+
+# --- Optional: enable ML forecasts (see doc/configuration.md add-ons) ---
+# Flip ieasyhydroforecast_run_ML_models=true above, then set:
+#ieasyhydroforecast_available_ML_models=TFT,TIDE,TSMIXER
+#ieasyhydroforecast_config_hydroposts_available_for_ml_forecasts=<path_to_hydroposts.json>
+#ieasyhydroforecast_ml_hru_models=<path_to_mapping.json>
+#ieasyhydroforecast_ECMWF_IFS_lead_time=10
+
+# --- Optional: long-term (monthly/seasonal) forecasts ---
+#ieasyhydroforecast_ml_long_term_configuration=<path_to_lt_config.json>
+#ieasyhydroforecast_ml_long_term_output_path=long_term
+#ieasyhydroforecast_ml_long_term_path_to_static=<path_to_static_features.csv>
+#ieasyhydroforecast_ml_long_term_supported_modes=month_1,seasonal
+
+# --- Optional: email alerts on pipeline failure ---
+#SAPPHIRE_PIPELINE_SMTP_SERVER=smtp.example.com
+#SAPPHIRE_PIPELINE_SMTP_PORT=587
+#SAPPHIRE_PIPELINE_SMTP_USERNAME=<smtp_user>
+#SAPPHIRE_PIPELINE_SMTP_PASSWORD=<smtp_password>
+#SAPPHIRE_PIPELINE_SENDER_EMAIL=<sender@example.com>
+#SAPPHIRE_PIPELINE_EMAIL_RECIPIENTS=<recipient1@example.com,recipient2@example.com>
+
+# --- Optional: filename overrides (defaults are usually fine) ---
+#ieasyforecast_hydrograph_day_file=hydrograph_day.csv
+#ieasyforecast_hydrograph_pentad_file=hydrograph_pentad.csv
+#ieasyforecast_pentad_results_file=forecasts_pentad.csv

--- a/apps/forecast_dashboard/forecast_dashboard.py
+++ b/apps/forecast_dashboard/forecast_dashboard.py
@@ -45,6 +45,25 @@ cfg = config.init_dashboard(pn)
 
 # ─── 2. Station metadata & DataManager ──────────────────────────────
 all_stations, station_dict = processing.get_all_stations_from_file()
+if not station_dict:
+    logger.warning(
+        "Station cache unavailable — fetching from iEasyHydro HF "
+        "(may take up to 30 s)"
+    )
+    from concurrent.futures import ThreadPoolExecutor
+    executor = ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(processing.get_all_stations_from_iehhf)
+    try:
+        all_stations, station_dict = future.result(timeout=30)
+    except Exception as e:  # includes TimeoutError, ImportError, etc.
+        logger.error("HF fetch failed or timed out: %s", e)
+        all_stations, station_dict = None, None
+    finally:
+        executor.shutdown(wait=False)
+if not station_dict:
+    raise RuntimeError(
+        "Cannot start dashboard: no station data from cache or iEasyHydro HF"
+    )
 horizon = "pentad"
 
 dm = DataManager(all_stations=all_stations)

--- a/apps/forecast_dashboard/src/processing.py
+++ b/apps/forecast_dashboard/src/processing.py
@@ -921,7 +921,7 @@ def load_stations_from_file(filename):
     try:
         with open(filename, "rb") as f:
             return pickle.load(f)
-    except (FileNotFoundError, pickle.PickleError):
+    except (FileNotFoundError, pickle.PickleError, EOFError):
         return None
 
 

--- a/apps/forecast_dashboard/src/processing.py
+++ b/apps/forecast_dashboard/src/processing.py
@@ -1065,6 +1065,10 @@ def get_all_stations_from_file():
     # Cast all stations attributes to a dataframe
     all_stations = sapphire_sites_to_dataframe(all_stations)
 
+    if all_stations.empty:
+        logger.warning("No station data available (pickle missing or corrupt)")
+        return None, None
+
     all_stations['code'] = all_stations['code'].astype(str)
     all_stations.rename(columns={'name': 'station_labels'}, inplace=True)
 

--- a/apps/forecast_dashboard/src/processing.py
+++ b/apps/forecast_dashboard/src/processing.py
@@ -1,12 +1,16 @@
+import contextlib
 import logging
 import os
-import sys
-import pandas as pd
-import numpy as np
-import param
-import re
 import pickle
+import re
+import shutil
+import sys
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pandas as pd
+import param
 
 logger = logging.getLogger(__name__)
 
@@ -967,8 +971,20 @@ def _create_manual_sites() -> list:
 
 
 def save_stations_to_file(stations, filename):
-    with open(filename, "wb") as f:
-        pickle.dump(stations, f)
+    """Atomically write stations to pickle using temp file + rename."""
+    target_dir = os.path.dirname(filename) or "."
+    temp_fd, temp_path = tempfile.mkstemp(suffix=".tmp", dir=target_dir)
+    try:
+        os.close(temp_fd)
+        with open(temp_path, "wb") as f:
+            pickle.dump(stations, f)
+        os.chmod(temp_path, 0o644)
+        shutil.move(temp_path, filename)
+    except Exception:
+        if os.path.exists(temp_path):
+            with contextlib.suppress(OSError):
+                os.remove(temp_path)
+        raise
 
 
 def get_all_stations_from_iehhf():

--- a/apps/forecast_dashboard/src/vizualization.py
+++ b/apps/forecast_dashboard/src/vizualization.py
@@ -3678,7 +3678,7 @@ def select_and_plot_data(_, dm, wm, linreg_predictor, station_widget, pentad_sel
     progress_bar = pn.indicators.Progress(name="Progress", value=0, width=300, visible=False)
     progress_message = pn.pane.Alert(_("Processing..."), alert_type="info", visible=False)
 
-    def run_docker_container(client, full_image_name, volumes, environment, container_name, progress_bar):
+    def run_docker_container(client, full_image_name, volumes, environment, container_name, progress_bar, command=None):
         """
         Runs a Docker container and blocks until it completes.
 
@@ -3693,6 +3693,7 @@ def select_and_plot_data(_, dm, wm, linreg_predictor, station_widget, pentad_sel
         Raises:
             docker.errors.ContainerError: If the container exits with a non-zero status.
         """
+        environment = list(environment)  # avoid mutating caller's list
         # Define network_name at the function level so it's accessible everywhere
         network_name = 'ssh-tunnel-network'
 
@@ -3741,6 +3742,7 @@ def select_and_plot_data(_, dm, wm, linreg_predictor, station_widget, pentad_sel
                 # Now run the new container
                 container = client.containers.run(
                     full_image_name,
+                    command=command,
                     detach=True,
                     environment=environment,
                     volumes=volumes,
@@ -3959,6 +3961,28 @@ def select_and_plot_data(_, dm, wm, linreg_predictor, station_widget, pentad_sel
                                  "postprocessing", progress_bar)
             temp_docker_end = time.time()
             print(f"Time taken to run postprocessing: {temp_docker_end - temp_docker_start:.2f} seconds")
+
+            # Recalculate skill metrics for this station only.
+            # Non-fatal: if this fails, the data reload still proceeds
+            # with the pre-existing skill metrics.
+            try:
+                temp_docker_start = time.time()
+                run_docker_container(
+                    client,
+                    "mabesa/sapphire-postprocessing:latest",
+                    volumes,
+                    environment + [
+                        f"SAPPHIRE_RECALC_STATION_CODE={station_code}",
+                    ],
+                    "skill_recalc",
+                    progress_bar,
+                    command=["uv", "run", "recalculate_skill_metrics.py"],
+                )
+                temp_docker_end = time.time()
+                print(f"Time taken to run skill_recalc: {temp_docker_end - temp_docker_start:.2f} seconds")
+            except Exception as e:
+                logger.warning("Skill metric recalculation failed (non-fatal): %s", e)
+
             overall_time = temp_docker_end - start_docker_runs
             print(f"Overall time taken to run all containers: {overall_time:.2f} seconds")
 

--- a/apps/forecast_dashboard/tests/test_pickle_recovery.py
+++ b/apps/forecast_dashboard/tests/test_pickle_recovery.py
@@ -1,0 +1,190 @@
+"""Tests for pickle crash recovery (atomic write + startup fallback).
+
+Covers:
+- Atomic pickle write succeeds and content matches
+- Atomic pickle write crash safety (original file untouched)
+- Startup fallback to HF fetch when pickle is unavailable
+- Startup fallback timeout raises RuntimeError
+"""
+
+import os
+import pickle
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+# ---------------------------------------------------------------------------
+# sys.path: make src/ importable (follows the pattern in conftest.py)
+# ---------------------------------------------------------------------------
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "..", "..", "iEasyHydroForecast"),
+)
+
+from src import processing  # noqa: E402  (must come after sys.path setup)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeStation:
+    """Minimal picklable stand-in for a station object."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _FakeStation) and self.code == other.code
+
+
+def _make_mock_station(code: str) -> _FakeStation:
+    """Return a picklable fake station with a .code attribute."""
+    return _FakeStation(code)
+
+
+def _tmp_files(directory) -> list[str]:
+    """Return all .tmp files in directory."""
+    return [f for f in os.listdir(directory) if f.endswith(".tmp")]
+
+
+# ===========================================================================
+# Test 1: Atomic write succeeds and content matches
+# ===========================================================================
+
+
+class TestAtomicWriteSucceeds:
+    def test_atomic_write_succeeds(self, tmp_path):
+        """save_stations_to_file writes correct content and leaves no temp files."""
+        filepath = tmp_path / "all_stations.pkl"
+        stations = [_make_mock_station("19999"), _make_mock_station("19998")]
+
+        processing.save_stations_to_file(stations, str(filepath))
+
+        # File must exist
+        assert filepath.exists(), "pickle file was not created"
+
+        # Content must round-trip correctly
+        with open(filepath, "rb") as f:
+            loaded = pickle.load(f)
+
+        assert len(loaded) == 2
+        assert loaded[0].code == "19999"
+        assert loaded[1].code == "19998"
+
+        # No leftover .tmp files
+        assert _tmp_files(str(tmp_path)) == [], "leftover .tmp files found"
+
+
+# ===========================================================================
+# Test 2: Atomic write crash safety — original file untouched on failure
+# ===========================================================================
+
+
+class TestAtomicWriteCrashSafety:
+    def test_atomic_write_crash_safety(self, tmp_path):
+        """When pickle.dump raises, the original file is untouched and no .tmp lingers."""
+        filepath = tmp_path / "all_stations.pkl"
+
+        # Write a valid file first so there is an original to protect
+        original_stations = [_make_mock_station("19999")]
+        processing.save_stations_to_file(original_stations, str(filepath))
+
+        new_stations = [_make_mock_station("19997"), _make_mock_station("19996")]
+
+        # Simulate a mid-write failure
+        with patch("pickle.dump", side_effect=OSError("disk full")):
+            with pytest.raises(OSError, match="disk full"):
+                processing.save_stations_to_file(new_stations, str(filepath))
+
+        # Original file must still be intact
+        assert filepath.exists(), "original pickle file was destroyed"
+        with open(filepath, "rb") as f:
+            loaded = pickle.load(f)
+        assert len(loaded) == 1
+        assert loaded[0].code == "19999", "original file content was corrupted"
+
+        # No leftover .tmp files
+        assert _tmp_files(str(tmp_path)) == [], "leftover .tmp files found after crash"
+
+
+# ===========================================================================
+# Test 3: Startup fallback called on missing pickle
+# ===========================================================================
+
+
+class TestStartupFallbackCalledOnMissingPickle:
+    def test_startup_fallback_called_on_missing_pickle(self):
+        """When get_all_stations_from_file returns (None, None), the HF fetch is called."""
+        valid_df = pd.DataFrame(
+            {
+                "code": ["19999"],
+                "station_labels": ["19999 - Test River"],
+                "basin": ["TestBasin"],
+            }
+        )
+        valid_station_dict = {"TestBasin": ["19999 - Test River"]}
+
+        with patch.object(
+            processing, "get_all_stations_from_file", return_value=(None, None)
+        ) as mock_file, patch.object(
+            processing,
+            "get_all_stations_from_iehhf",
+            return_value=(valid_df, valid_station_dict),
+        ) as mock_hf:
+            # --- Replicate the startup fallback logic from forecast_dashboard.py lines 47-62 ---
+            all_stations, station_dict = processing.get_all_stations_from_file()
+            if not station_dict:
+                executor = ThreadPoolExecutor(max_workers=1)
+                future = executor.submit(processing.get_all_stations_from_iehhf)
+                try:
+                    all_stations, station_dict = future.result(timeout=30)
+                except Exception:
+                    all_stations, station_dict = None, None
+                finally:
+                    executor.shutdown(wait=False)
+            # ---
+
+        mock_file.assert_called_once()
+        mock_hf.assert_called_once()
+
+        # Result should be the valid data returned by the HF fetch
+        assert all_stations is not None
+        assert station_dict == valid_station_dict
+        assert "19999 - Test River" in station_dict["TestBasin"]
+
+
+# ===========================================================================
+# Test 4: Startup fallback timeout raises Exception, result stays (None, None)
+# ===========================================================================
+
+
+class TestStartupFallbackTimeout:
+    def test_startup_fallback_timeout(self):
+        """When the HF fetch blocks longer than the timeout, a TimeoutError is raised."""
+        def _slow_fetch():
+            time.sleep(5)
+            return pd.DataFrame(), {}
+
+        with patch.object(
+            processing, "get_all_stations_from_file", return_value=(None, None)
+        ), patch.object(processing, "get_all_stations_from_iehhf", side_effect=_slow_fetch):
+            all_stations, station_dict = processing.get_all_stations_from_file()
+            if not station_dict:
+                executor = ThreadPoolExecutor(max_workers=1)
+                future = executor.submit(processing.get_all_stations_from_iehhf)
+                try:
+                    with pytest.raises(Exception):
+                        future.result(timeout=1)
+                    all_stations, station_dict = None, None
+                finally:
+                    executor.shutdown(wait=False)
+
+        assert all_stations is None
+        assert station_dict is None

--- a/apps/machine_learning/add_new_station.py
+++ b/apps/machine_learning/add_new_station.py
@@ -46,6 +46,7 @@ from scr.utils_ml_forecast import (
     SAPPHIRE_API_AVAILABLE,
     _read_ml_forecasts_from_api,
     _write_ml_forecast_to_api,
+    get_permitted_station_codes,
 )
 
 
@@ -168,17 +169,41 @@ def main():
 
     # --------------------------------------------------------------------
     # Read in the decad and pentad forecast files (API-primary, CSV fallback)
+    # Per-code reads — no date filter so stale stations are still found
+    # (prevents daily re-triggering of hindcasts for inactive stations).
+    # Invariant: rivers_to_predict (below) is always a subset of
+    # permitted_codes because rivers_to_predict = (pentad_selection UNION
+    # decad_selection) INTERSECT ml_available, and permitted_codes =
+    # pentad_selection UNION decad_selection.
     # --------------------------------------------------------------------
+    permitted_codes = get_permitted_station_codes()
 
-    # Try API first to get date range and full forecasts
-    decad_api = _read_ml_forecasts_from_api(
-        model_type=MODEL_TO_USE,
-        horizon_type="decade",
-    )
-    pentad_api = _read_ml_forecasts_from_api(
-        model_type=MODEL_TO_USE,
-        horizon_type="pentad",
-    )
+    def _read_scoped(horizon_type: str) -> pd.DataFrame:
+        """Read ML forecasts per-code to avoid full-table scan timeouts."""
+        if permitted_codes is not None and len(permitted_codes) > 0:
+            frames = []
+            for code in sorted(permitted_codes):
+                df = _read_ml_forecasts_from_api(
+                    model_type=MODEL_TO_USE,
+                    horizon_type=horizon_type,
+                    code=code,
+                )
+                if not df.empty:
+                    frames.append(df)
+            return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+        else:
+            logger.warning(
+                "add_new_station: org config unavailable — falling back to "
+                "all-codes read with extended timeout"
+            )
+            return _read_ml_forecasts_from_api(
+                model_type=MODEL_TO_USE,
+                horizon_type=horizon_type,
+                timeout=120,
+            )
+
+    decad_api = _read_scoped("decade")
+    pentad_api = _read_scoped("pentad")
 
     if not decad_api.empty and not pentad_api.empty:
         decad_forecast = decad_api

--- a/apps/machine_learning/scr/utils_ml_forecast.py
+++ b/apps/machine_learning/scr/utils_ml_forecast.py
@@ -553,6 +553,7 @@ def _read_ml_forecasts_from_api(
     start_date: str | None = None,
     end_date: str | None = None,
     code: str | None = None,
+    timeout: int = 30,
 ) -> pd.DataFrame:
     """Read ML forecasts from the SAPPHIRE postprocessing API.
 
@@ -569,6 +570,7 @@ def _read_ml_forecasts_from_api(
         start_date: ISO date string for forecast_date (issue date) filter
         end_date: ISO date string for forecast_date (issue date) filter
         code: station code to filter; None means all codes
+        timeout: Request timeout in seconds per API call (default: 30)
     """
     if not SAPPHIRE_API_AVAILABLE:
         logger.warning("sapphire-api-client not installed; cannot read ML forecasts from API")
@@ -579,7 +581,7 @@ def _read_ml_forecasts_from_api(
         return pd.DataFrame()
 
     api_url = os.getenv("SAPPHIRE_API_URL", "http://localhost:8000")
-    client = SapphirePostprocessingClient(base_url=api_url)
+    client = SapphirePostprocessingClient(base_url=api_url, timeout=timeout)
 
     try:
         if not client.readiness_check():

--- a/apps/machine_learning/test/test_add_new_station.py
+++ b/apps/machine_learning/test/test_add_new_station.py
@@ -1,0 +1,318 @@
+"""Tests for add_new_station.py per-code API read refactor.
+
+Covers:
+- Per-code reads when org config is available
+- Fallback with extended timeout when config is unavailable
+- Stale stations not treated as new
+- Genuinely new stations trigger hindcast
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+# Mock heavy dependencies before importing add_new_station
+sys.modules["darts"] = MagicMock()
+sys.modules["darts.TimeSeries"] = MagicMock()
+sys.modules["darts.concatenate"] = MagicMock()
+sys.modules["darts.utils"] = MagicMock()
+sys.modules["darts.utils.timeseries_generation"] = MagicMock()
+sys.modules["darts.models"] = MagicMock()
+sys.modules["pytorch_lightning"] = MagicMock()
+sys.modules["pytorch_lightning.callbacks"] = MagicMock()
+sys.modules["torch"] = MagicMock()
+sys.modules["pe_oudin"] = MagicMock()
+sys.modules["pe_oudin.PE_Oudin"] = MagicMock()
+sys.modules["suntime"] = MagicMock()
+
+_mock_sl = MagicMock()
+_mock_sl.load_environment = MagicMock()
+sys.modules["setup_library"] = _mock_sl
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scr"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "iEasyHydroForecast"))
+
+import add_new_station  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_forecast_df(codes=None, n_days=5):
+    """Build a minimal forecast DataFrame for testing.
+
+    Args:
+        codes: List of station codes. Defaults to ["19999"].
+        n_days: Number of consecutive forecast dates per code.
+
+    Returns:
+        DataFrame matching the expected forecast schema.
+    """
+    if codes is None:
+        codes = ["19999"]
+    rows = []
+    for code in codes:
+        for i in range(n_days):
+            rows.append(
+                {
+                    "code": str(code),
+                    "forecast_date": pd.Timestamp("2024-01-01") + pd.Timedelta(days=i),
+                    "date": pd.Timestamp("2024-01-06") + pd.Timedelta(days=i),
+                    "flag": 0,
+                    "Q5": 50.0,
+                    "Q25": 80.0,
+                    "Q50": 100.0,
+                    "Q75": 120.0,
+                    "Q95": 150.0,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _make_hydroposts_df(codes, model="TFT"):
+    """Build a minimal hydroposts_available_for_ml_forecasting DataFrame.
+
+    Args:
+        codes: List of station codes to include.
+        model: Which model column to set True. All columns are set True for
+            simplicity — the model parameter is kept for API compatibility.
+
+    Returns:
+        DataFrame with code and model flag columns.
+    """
+    return pd.DataFrame(
+        {
+            "code": [str(c) for c in codes],
+            "TFT": [True] * len(codes),
+            "TIDE": [True] * len(codes),
+            "TSMIXER": [True] * len(codes),
+            "ARIMA": [True] * len(codes),
+        }
+    )
+
+
+_BASE_ENV = {
+    "SAPPHIRE_MODEL_TO_USE": "TFT",
+    "ieasyforecast_intermediate_data_path": "/tmp/test_add_station",
+    "ieasyhydroforecast_OUTPUT_PATH_DISCHARGE": "output",
+    "ieasyhydroforecast_OUTPUT_PATH_REANALYSIS": "reanalysis",
+}
+
+# ---------------------------------------------------------------------------
+# Test class: Per-code read behavior
+# ---------------------------------------------------------------------------
+
+
+class TestPerCodeReadBehavior:
+    """Tests for per-code API reads in add_new_station.main()."""
+
+    @patch.dict(os.environ, _BASE_ENV, clear=False)
+    @patch("add_new_station.SAPPHIRE_API_AVAILABLE", True)
+    @patch("add_new_station._write_ml_forecast_to_api")
+    @patch("add_new_station.call_hindcast_script")
+    @patch("add_new_station._read_ml_forecasts_from_api")
+    @patch("add_new_station.get_permitted_station_codes")
+    @patch("add_new_station.utils_ml_forecast.get_hydroposts_for_pentadal_and_decadal_forecasts")
+    @patch("add_new_station.sl")
+    @patch("os.listdir", return_value=["some_file.nc"])
+    @patch("os.path.exists", return_value=True)
+    def test_per_code_reads_called_with_code_kwarg(
+        self,
+        mock_exists,
+        mock_listdir,
+        mock_sl,
+        mock_get_hydroposts,
+        mock_permitted,
+        mock_read_api,
+        mock_hindcast,
+        mock_write_api,
+    ):
+        """When org config is available, each read uses code= kwarg and
+        no start_date filter is applied. No hindcast should be triggered
+        when all ML-capable codes are already in the forecast.
+        """
+        mock_sl.load_environment.return_value = None
+        mock_permitted.return_value = {"19999"}
+
+        # Only 19999 is ML-capable — no new codes expected
+        hydroposts_df = _make_hydroposts_df(["19999"])
+        mock_get_hydroposts.return_value = (["19999"], ["19999"], hydroposts_df)
+        mock_read_api.return_value = _make_forecast_df(codes=["19999"])
+
+        add_new_station.main()
+
+        # 2 codes x 2 horizon types = at least 2 calls (1 code x 2 here)
+        assert mock_read_api.call_count >= 2, (
+            f"Expected at least 2 API read calls, got {mock_read_api.call_count}"
+        )
+        # Each call must use code= keyword arg and must NOT filter by start_date
+        for c in mock_read_api.call_args_list:
+            assert "code" in c.kwargs, f"Each call must specify code=, got kwargs={c.kwargs}"
+            assert c.kwargs.get("start_date") is None, (
+                f"Must not filter by date, got start_date={c.kwargs.get('start_date')}"
+            )
+        # No new codes -> no hindcast
+        mock_hindcast.assert_not_called()
+
+    @patch.dict(os.environ, _BASE_ENV, clear=False)
+    @patch("add_new_station.SAPPHIRE_API_AVAILABLE", True)
+    @patch("add_new_station._write_ml_forecast_to_api")
+    @patch("add_new_station.call_hindcast_script")
+    @patch("add_new_station._read_ml_forecasts_from_api")
+    @patch("add_new_station.get_permitted_station_codes")
+    @patch("add_new_station.utils_ml_forecast.get_hydroposts_for_pentadal_and_decadal_forecasts")
+    @patch("add_new_station.sl")
+    @patch("os.listdir", return_value=["some_file.nc"])
+    @patch("os.path.exists", return_value=True)
+    def test_fallback_uses_extended_timeout(
+        self,
+        mock_exists,
+        mock_listdir,
+        mock_sl,
+        mock_get_hydroposts,
+        mock_permitted,
+        mock_read_api,
+        mock_hindcast,
+        mock_write_api,
+    ):
+        """When org config is unavailable (permitted_codes=None), the fallback
+        all-codes read must use timeout=120.
+        """
+        mock_sl.load_environment.return_value = None
+        # Config unavailable
+        mock_permitted.return_value = None
+
+        hydroposts_df = _make_hydroposts_df(["19999"])
+        mock_get_hydroposts.return_value = (["19999"], ["19999"], hydroposts_df)
+        mock_read_api.return_value = _make_forecast_df(codes=["19999"])
+
+        add_new_station.main()
+
+        # All calls should use timeout=120 (fallback path)
+        for c in mock_read_api.call_args_list:
+            assert c.kwargs.get("timeout") == 120, (
+                f"Fallback must use timeout=120, got timeout={c.kwargs.get('timeout')} in call {c}"
+            )
+        mock_hindcast.assert_not_called()
+
+    @patch.dict(os.environ, _BASE_ENV, clear=False)
+    @patch("add_new_station.SAPPHIRE_API_AVAILABLE", True)
+    @patch("add_new_station._write_ml_forecast_to_api")
+    @patch("add_new_station.call_hindcast_script")
+    @patch("add_new_station._read_ml_forecasts_from_api")
+    @patch("add_new_station.get_permitted_station_codes")
+    @patch("add_new_station.utils_ml_forecast.get_hydroposts_for_pentadal_and_decadal_forecasts")
+    @patch("add_new_station.sl")
+    @patch("os.listdir", return_value=["some_file.nc"])
+    @patch("os.path.exists", return_value=True)
+    def test_stale_station_not_treated_as_new(
+        self,
+        mock_exists,
+        mock_listdir,
+        mock_sl,
+        mock_get_hydroposts,
+        mock_permitted,
+        mock_read_api,
+        mock_hindcast,
+        mock_write_api,
+    ):
+        """A station with old (stale) forecast data must NOT trigger a hindcast.
+
+        The stale-station guard must treat the station as "already covered"
+        regardless of how old its forecast dates are.
+        """
+        mock_sl.load_environment.return_value = None
+        mock_permitted.return_value = {"19999"}
+
+        hydroposts_df = _make_hydroposts_df(["19999"])
+        mock_get_hydroposts.return_value = (["19999"], ["19999"], hydroposts_df)
+
+        # Return forecast data with old dates (2022) — station exists but is stale
+        rows = []
+        for i in range(5):
+            rows.append(
+                {
+                    "code": "19999",
+                    "forecast_date": pd.Timestamp("2022-01-01") + pd.Timedelta(days=i),
+                    "date": pd.Timestamp("2022-01-06") + pd.Timedelta(days=i),
+                    "flag": 0,
+                    "Q5": 50.0,
+                    "Q25": 80.0,
+                    "Q50": 100.0,
+                    "Q75": 120.0,
+                    "Q95": 150.0,
+                }
+            )
+        stale_forecast = pd.DataFrame(rows)
+        mock_read_api.return_value = stale_forecast
+
+        add_new_station.main()
+
+        # Station already has forecasts (even stale ones) — must NOT trigger hindcast
+        mock_hindcast.assert_not_called()
+
+    @patch("pandas.DataFrame.to_csv")
+    @patch.dict(os.environ, _BASE_ENV, clear=False)
+    @patch("add_new_station.SAPPHIRE_API_AVAILABLE", True)
+    @patch("add_new_station._write_ml_forecast_to_api")
+    @patch("add_new_station.call_hindcast_script")
+    @patch("add_new_station._read_ml_forecasts_from_api")
+    @patch("add_new_station.get_permitted_station_codes")
+    @patch("add_new_station.utils_ml_forecast.get_hydroposts_for_pentadal_and_decadal_forecasts")
+    @patch("add_new_station.sl")
+    @patch("os.listdir", return_value=["some_file.nc"])
+    @patch("os.path.exists", return_value=True)
+    def test_genuinely_new_station_triggers_hindcast(
+        self,
+        mock_exists,
+        mock_listdir,
+        mock_sl,
+        mock_get_hydroposts,
+        mock_permitted,
+        mock_read_api,
+        mock_hindcast,
+        mock_write_api,
+        mock_to_csv,
+    ):
+        """A station with no existing forecasts must trigger a hindcast call.
+
+        Station "19999" has existing forecasts. Station "19998" has no
+        forecasts at all. The hindcast must be called for "19998".
+        """
+        mock_sl.load_environment.return_value = None
+        mock_permitted.return_value = {"19999", "19998"}
+
+        # Both 19999 and 19998 are ML-capable
+        hydroposts_df = _make_hydroposts_df(["19999", "19998"])
+        mock_get_hydroposts.return_value = (
+            ["19999", "19998"],
+            ["19999", "19998"],
+            hydroposts_df,
+        )
+
+        # 19999 has forecasts; 19998 has none
+        def read_side_effect(**kwargs):
+            if kwargs.get("code") == "19999":
+                return _make_forecast_df(codes=["19999"])
+            return pd.DataFrame()
+
+        mock_read_api.side_effect = read_side_effect
+
+        # Hindcast returns a valid DataFrame for 19998
+        mock_hindcast.return_value = _make_forecast_df(codes=["19998"])
+        mock_write_api.return_value = True
+
+        add_new_station.main()
+
+        # New station must trigger hindcast
+        mock_hindcast.assert_called()
+
+        # "19998" must appear somewhere in the hindcast call args
+        hindcast_calls = mock_hindcast.call_args_list
+        assert any("19998" in str(c) for c in hindcast_calls), (
+            f"Expected '19998' in hindcast call args, got: {hindcast_calls}"
+        )

--- a/apps/postprocessing_forecasts/recalculate_skill_metrics.py
+++ b/apps/postprocessing_forecasts/recalculate_skill_metrics.py
@@ -103,6 +103,11 @@ def _read_station_codes(config):
     Returns:
         list[str]: Station codes for the given horizon.
     """
+    override = os.getenv("SAPPHIRE_RECALC_STATION_CODE", "").strip()
+    if override:
+        logger.info("Scoped recalculation for station %s (%s)", override, config.name)
+        return [override]
+
     config_path = os.path.join(
         os.getenv("ieasyforecast_configuration_path", ""),
         os.getenv(config.station_selection_env, ""),
@@ -124,7 +129,25 @@ def _run_short_term_recalc(config, skill_metrics_year, errors, timing_stats_, co
             config.name,
             codes=codes,
         )
-        modelled = sl.calculate_virtual_stations_data(modelled)
+        if observed.empty and modelled.empty:
+            logger.warning(
+                "No observed or modelled data for %s codes=%s — skipping skill recalc",
+                config.name,
+                codes,
+            )
+            return timing_stats_
+        if observed.empty:
+            logger.warning("No observed data for %s codes=%s — skipping", config.name, codes)
+            return timing_stats_
+        if modelled.empty:
+            logger.warning("No modelled data for %s codes=%s — skipping", config.name, codes)
+            return timing_stats_
+
+        # Skip virtual station computation for scoped recalcs — the
+        # scoped DataFrame lacks the other contributing stations, so
+        # calculate_virtual_stations_data would produce incorrect partial sums.
+        if not os.getenv("SAPPHIRE_RECALC_STATION_CODE", "").strip():
+            modelled = sl.calculate_virtual_stations_data(modelled)
         modelled = config.neural_ensemble_func(modelled)
 
     with timer(timing_stats_, f"calculating skill metrics {config.name}"):

--- a/apps/postprocessing_forecasts/tests/test_integration_postprocessing.py
+++ b/apps/postprocessing_forecasts/tests/test_integration_postprocessing.py
@@ -2953,22 +2953,22 @@ class TestRecalculateSkillMetricsIntegration:
                 "src.data_reader.read_observed_and_modelled_data",
                 return_value=(
                     pd.DataFrame(
-                        columns=[
-                            "code",
-                            "date",
-                            "discharge_avg",
-                            "delta",
-                        ]
+                        {
+                            "code": ["19999"],
+                            "date": [pd.Timestamp("2024-01-05")],
+                            "discharge_avg": [100.0],
+                            "delta": [0.1],
+                        }
                     ),
                     pd.DataFrame(
-                        columns=[
-                            "code",
-                            "date",
-                            "pentad_in_year",
-                            "pentad_in_month",
-                            "forecasted_discharge",
-                            "model_short",
-                        ]
+                        {
+                            "code": ["19999"],
+                            "date": [pd.Timestamp("2024-01-05")],
+                            "pentad_in_year": [1],
+                            "pentad_in_month": [1],
+                            "forecasted_discharge": [95.0],
+                            "model_short": ["LR"],
+                        }
                     ),
                 ),
             ) as mock_read,
@@ -3030,22 +3030,22 @@ class TestRecalculateSkillMetricsIntegration:
                 "src.data_reader.read_observed_and_modelled_data",
                 return_value=(
                     pd.DataFrame(
-                        columns=[
-                            "code",
-                            "date",
-                            "discharge_avg",
-                            "delta",
-                        ]
+                        {
+                            "code": ["19999"],
+                            "date": [pd.Timestamp("2024-01-05")],
+                            "discharge_avg": [100.0],
+                            "delta": [0.1],
+                        }
                     ),
                     pd.DataFrame(
-                        columns=[
-                            "code",
-                            "date",
-                            "pentad_in_year",
-                            "pentad_in_month",
-                            "forecasted_discharge",
-                            "model_short",
-                        ]
+                        {
+                            "code": ["19999"],
+                            "date": [pd.Timestamp("2024-01-05")],
+                            "pentad_in_year": [1],
+                            "pentad_in_month": [1],
+                            "forecasted_discharge": [95.0],
+                            "model_short": ["LR"],
+                        }
                     ),
                 ),
             ),

--- a/apps/postprocessing_forecasts/tests/test_scoped_skill_recalc.py
+++ b/apps/postprocessing_forecasts/tests/test_scoped_skill_recalc.py
@@ -1,0 +1,230 @@
+"""Tests for scoped skill metric recalculation (SAPPHIRE_RECALC_STATION_CODE).
+
+Covers:
+- _read_station_codes env var override
+- _run_short_term_recalc empty DataFrame guard
+- _run_short_term_recalc virtual station skip
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+import src.horizon_config as _real_horizon_config
+
+SCRIPT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, SCRIPT_DIR)
+
+
+def _load_recalc_module(mocks):
+    """Load recalculate_skill_metrics with the given sys.modules mocks in place."""
+    # Prevent stale cached module from leaking between tests
+    sys.modules.pop("recalculate_skill_metrics", None)
+    sys.modules.pop("recalculate_skill_metrics_module", None)
+
+    spec = importlib.util.spec_from_file_location(
+        "recalculate_skill_metrics_module",
+        os.path.join(SCRIPT_DIR, "recalculate_skill_metrics.py"),
+    )
+    module = importlib.util.module_from_spec(spec)
+
+    # Build a src package mock whose attributes match the sub-module mocks.
+    # `from src import data_reader` resolves via the src package object, NOT
+    # via sys.modules["src.data_reader"], so the attributes must be set here.
+    mock_src = MagicMock()
+    mock_src.data_reader = mocks["data_reader"]
+    mock_src.file_writer = mocks["file_writer"]
+    mock_src.skill_metrics = mocks["skill_metrics"]
+    mock_src.postprocessing_tools = mocks["pt"]
+
+    # Inject mocks before exec so module-level imports resolve to our fakes
+    sys.modules["setup_library"] = mocks["sl"]
+    sys.modules["tag_library"] = MagicMock()
+    sys.modules["src"] = mock_src
+    sys.modules["src.skill_metrics"] = mocks["skill_metrics"]
+    sys.modules["src.file_writer"] = mocks["file_writer"]
+    sys.modules["src.data_reader"] = mocks["data_reader"]
+    sys.modules["src.postprocessing_tools"] = mocks["pt"]
+    sys.modules["src.horizon_config"] = _real_horizon_config
+
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_mocks():
+    """Return a minimal set of mocks needed to load recalculate_skill_metrics."""
+    mock_sl = MagicMock()
+    mock_sl.calculate_virtual_stations_data.side_effect = lambda x: x
+    mock_sl.calculate_neural_ensemble_forecast.side_effect = lambda x: x
+    mock_sl.calculate_neural_ensemble_forecast_decade.side_effect = lambda x: x
+
+    mock_skill_metrics = MagicMock()
+    mock_file_writer = MagicMock()
+    mock_data_reader = MagicMock()
+
+    mock_pt = MagicMock()
+    # timer() is used as a context manager — make it behave like one
+    mock_timer_ctx = MagicMock()
+    mock_timer_ctx.__enter__ = MagicMock(return_value=None)
+    mock_timer_ctx.__exit__ = MagicMock(return_value=False)
+    mock_pt.timer.return_value = mock_timer_ctx
+    mock_pt.TimingStats.return_value = MagicMock()
+
+    return {
+        "sl": mock_sl,
+        "skill_metrics": mock_skill_metrics,
+        "file_writer": mock_file_writer,
+        "data_reader": mock_data_reader,
+        "pt": mock_pt,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pentad_config():
+    """Minimal ShortTermHorizonConfig-like mock for pentad."""
+    cfg = MagicMock()
+    cfg.name = "pentad"
+    cfg.period_col = "pentad_in_year"
+    cfg.station_selection_env = "ieasyforecast_config_file_station_selection"
+    cfg.neural_ensemble_func = MagicMock(side_effect=lambda x: x)
+    return cfg
+
+
+@pytest.fixture
+def non_empty_data():
+    """Non-empty observed/modelled DataFrame with required columns."""
+    return pd.DataFrame(
+        {
+            "code": ["19999"],
+            "date": pd.to_datetime(["2024-01-05"]),
+            "forecasted_discharge": [100.0],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: _read_station_codes — env var override short-circuits file I/O
+# ---------------------------------------------------------------------------
+
+
+def test_read_station_codes_override(pentad_config):
+    """When SAPPHIRE_RECALC_STATION_CODE is set, skip file reading and return it."""
+    mocks = _make_mocks()
+
+    with patch.dict(os.environ, {"SAPPHIRE_RECALC_STATION_CODE": "19999"}):
+        with patch.dict(sys.modules, {}):
+            module = _load_recalc_module(mocks)
+
+            with patch("builtins.open") as mock_open:
+                result = module._read_station_codes(pentad_config)
+
+    assert result == ["19999"]
+    mock_open.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: _read_station_codes — reads station codes from config file
+# ---------------------------------------------------------------------------
+
+
+def test_read_station_codes_no_override(pentad_config):
+    """Without SAPPHIRE_RECALC_STATION_CODE, read codes from the config file."""
+    mocks = _make_mocks()
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump({"stationsID": ["19999", "19998"]}, f)
+        tmp_path = f.name
+
+    try:
+        tmp_dir = os.path.dirname(tmp_path)
+        tmp_file = os.path.basename(tmp_path)
+
+        env_override = {
+            "SAPPHIRE_RECALC_STATION_CODE": "",
+            "ieasyforecast_configuration_path": tmp_dir,
+            "ieasyforecast_config_file_station_selection": tmp_file,
+        }
+
+        with patch.dict(os.environ, env_override):
+            with patch.dict(sys.modules, {}):
+                module = _load_recalc_module(mocks)
+                result = module._read_station_codes(pentad_config)
+
+        assert result == ["19999", "19998"]
+    finally:
+        os.unlink(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: _run_short_term_recalc — early return when data is empty
+# ---------------------------------------------------------------------------
+
+
+def test_run_short_term_recalc_empty_data_returns_early(pentad_config):
+    """Empty observed+modelled DataFrames cause early return without skill calc."""
+    mocks = _make_mocks()
+    mocks["data_reader"].read_observed_and_modelled_data.return_value = (
+        pd.DataFrame(),
+        pd.DataFrame(),
+    )
+
+    with patch.dict(os.environ, {"SAPPHIRE_RECALC_STATION_CODE": "19999"}):
+        with patch.dict(sys.modules, {}):
+            module = _load_recalc_module(mocks)
+
+            timing_stats_ = MagicMock()
+            result = module._run_short_term_recalc(
+                pentad_config,
+                2024,
+                [],
+                timing_stats_,
+                codes=["19999"],
+            )
+
+    mocks["skill_metrics"].calculate_skill_metrics.assert_not_called()
+    assert result is timing_stats_
+
+
+# ---------------------------------------------------------------------------
+# Test 4: _run_short_term_recalc — skip virtual stations for scoped recalc
+# ---------------------------------------------------------------------------
+
+
+def test_run_short_term_recalc_skips_virtual_stations(pentad_config, non_empty_data):
+    """When SAPPHIRE_RECALC_STATION_CODE is set, virtual station calc is skipped."""
+    mocks = _make_mocks()
+    mocks["data_reader"].read_observed_and_modelled_data.return_value = (
+        non_empty_data,
+        non_empty_data,
+    )
+    mocks["skill_metrics"].calculate_skill_metrics.return_value = (
+        pd.DataFrame(),
+        non_empty_data,
+        MagicMock(),
+    )
+    mocks["file_writer"].save_forecast_data.return_value = None
+    mocks["file_writer"].save_skill_metrics.return_value = None
+
+    with patch.dict(os.environ, {"SAPPHIRE_RECALC_STATION_CODE": "19999"}):
+        with patch.dict(sys.modules, {}):
+            module = _load_recalc_module(mocks)
+
+            module._run_short_term_recalc(
+                pentad_config,
+                2024,
+                [],
+                MagicMock(),
+                codes=["19999"],
+            )
+
+    mocks["sl"].calculate_virtual_stations_data.assert_not_called()

--- a/bin/backup_sapphire_db.sh
+++ b/bin/backup_sapphire_db.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+
+# =============================================================================
+# SAPPHIRE Database Backup
+# =============================================================================
+#
+# Dumps the four active SAPPHIRE Postgres databases (preprocessing,
+# postprocessing, user, auth) using pg_dump's custom format (suitable for
+# pg_restore). Each dump is written to $BACKUP_DIR as a timestamped .dump
+# file, verified with pg_restore --list, and old dumps past the retention
+# window are pruned.
+#
+# No log file is written — stdout/stderr only. Cron is expected to capture
+# the output.
+#
+# Usage:
+#   bash bin/backup_sapphire_db.sh
+#   bash bin/backup_sapphire_db.sh -d /mnt/backups/sapphire
+#   bash bin/backup_sapphire_db.sh --retention-days 60
+#   bash bin/backup_sapphire_db.sh --dry-run
+#
+# Prerequisites:
+#   - Docker daemon running with SAPPHIRE DB containers up
+#   - sapphire/.env populated with POSTGRES_USER, POSTGRES_PASSWORD and the
+#     four DB names (PREPROCESSING_DB, POSTPROCESSING_DB, USER_DB, AUTH_DB)
+#   - Run from repository root (parent of sapphire/)
+#   - $BACKUP_DIR must exist and be writable by the invoking user
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Colors (matching bin/reset_sapphire_db.sh)
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+COMPOSE_DIR="sapphire"
+ENV_FILE="${COMPOSE_DIR}/.env"
+COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
+
+# Flags / defaults
+BACKUP_DIR="/var/backups/sapphire"
+RETENTION_DAYS=30
+DRY_RUN=false
+
+# Result tracking
+FAILED_DBS=()
+SUCCEEDED_DBS=()
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+log() {
+    local level="$1"
+    shift
+    local msg="$*"
+    local ts
+    ts="$(date '+%Y-%m-%d %H:%M:%S')"
+
+    case "$level" in
+        INFO)  echo -e "${BLUE}[${ts}] ${msg}${NC}" ;;
+        OK)    echo -e "${GREEN}[${ts}] ${msg}${NC}" ;;
+        WARN)  echo -e "${YELLOW}[${ts}] ${msg}${NC}" >&2 ;;
+        ERROR) echo -e "${RED}[${ts}] ${msg}${NC}" >&2 ;;
+        *)     echo "[${ts}] ${msg}" ;;
+    esac
+}
+
+banner() {
+    local msg="$1"
+    echo ""
+    echo -e "${BOLD}========================================${NC}"
+    echo -e "${BOLD} ${msg}${NC}"
+    echo -e "${BOLD}========================================${NC}"
+}
+
+file_size_human() {
+    local f="$1"
+    if [ ! -f "$f" ]; then
+        echo "0B"
+        return
+    fi
+    # BSD/macOS `stat -f %z`; GNU/Linux `stat -c %s`
+    local bytes
+    if bytes=$(stat -c %s "$f" 2>/dev/null); then
+        :
+    else
+        bytes=$(stat -f %z "$f" 2>/dev/null || echo 0)
+    fi
+    # Render in a portable way using awk
+    awk -v b="$bytes" 'BEGIN {
+        split("B KB MB GB TB", u, " ");
+        i = 1;
+        while (b >= 1024 && i < 5) { b = b / 1024; i++; }
+        if (i == 1) printf "%dB", b; else printf "%.1f%s", b, u[i];
+    }'
+}
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+print_usage() {
+    cat <<'USAGE'
+Usage: bash bin/backup_sapphire_db.sh [FLAGS]
+
+Dump the four SAPPHIRE Postgres databases to timestamped .dump files.
+
+Flags:
+  -d, --backup-dir PATH      Directory to write dumps to
+                             (default: /var/backups/sapphire)
+  -r, --retention-days N     Delete .dump files older than N days
+                             (default: 30; pass 0 to keep all)
+      --dry-run              Log actions without running pg_dump or deleting
+  -h, --help                 Show this help message
+
+Exit status:
+  0  All four dumps succeeded and verified
+  1  One or more dumps failed, env/config missing, or backup dir invalid
+
+Examples:
+  bash bin/backup_sapphire_db.sh
+  bash bin/backup_sapphire_db.sh -d /mnt/backups/sapphire -r 60
+  bash bin/backup_sapphire_db.sh --dry-run
+USAGE
+}
+
+# ---------------------------------------------------------------------------
+# Precondition checks
+# ---------------------------------------------------------------------------
+
+check_repo_root() {
+    if [ ! -f "${COMPOSE_FILE}" ]; then
+        log ERROR "Must run from the repository root (parent of sapphire/)."
+        log ERROR "  Expected: ${COMPOSE_FILE}"
+        exit 1
+    fi
+}
+
+load_env() {
+    if [ ! -f "${ENV_FILE}" ]; then
+        log ERROR "Env file not found: ${ENV_FILE}"
+        log ERROR "  Copy sapphire/.env.example to sapphire/.env and fill in values."
+        exit 1
+    fi
+
+    # Load required variables without echoing them. We parse only the keys we
+    # need rather than `source`-ing the file, to avoid executing arbitrary
+    # content and to keep POSTGRES_PASSWORD out of error paths.
+    local required=(POSTGRES_USER POSTGRES_PASSWORD PREPROCESSING_DB POSTPROCESSING_DB USER_DB AUTH_DB)
+    local var val
+    for var in "${required[@]}"; do
+        # Match `VAR=value`, strip optional surrounding quotes on value.
+        val=$(grep -E "^[[:space:]]*${var}=" "${ENV_FILE}" | tail -n 1 | sed -E "s/^[[:space:]]*${var}=//; s/^\"(.*)\"$/\1/; s/^'(.*)'$/\1/")
+        if [ -z "${val:-}" ]; then
+            log ERROR "Required variable ${var} is unset or empty in ${ENV_FILE}."
+            exit 1
+        fi
+        # Export without logging the value
+        export "${var}=${val}"
+    done
+}
+
+check_docker() {
+    if ! docker info >/dev/null 2>&1; then
+        log ERROR "Docker daemon is not running or not accessible to this user."
+        exit 1
+    fi
+}
+
+check_backup_dir() {
+    if [ ! -d "${BACKUP_DIR}" ]; then
+        log ERROR "Backup directory does not exist: ${BACKUP_DIR}"
+        log ERROR "  Create it first, e.g.: sudo mkdir -p '${BACKUP_DIR}' && sudo chown \"\$USER\" '${BACKUP_DIR}'"
+        exit 1
+    fi
+    if [ ! -w "${BACKUP_DIR}" ]; then
+        log ERROR "Backup directory is not writable: ${BACKUP_DIR}"
+        exit 1
+    fi
+}
+
+check_container_running() {
+    local container="$1"
+    if ! docker ps --format '{{.Names}}' | grep -qx "${container}"; then
+        log ERROR "Container '${container}' is not running. Start SAPPHIRE services first."
+        return 1
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Backup a single database
+# ---------------------------------------------------------------------------
+
+backup_db() {
+    local container="$1"
+    local db_name="$2"
+    local timestamp
+    timestamp="$(date '+%Y-%m-%d_%H%M%S')"
+    local out_file="${BACKUP_DIR}/${db_name}_${timestamp}.dump"
+
+    log INFO "Backup start: db=${db_name} container=${container} file=${out_file}"
+
+    if [ "${DRY_RUN}" = true ]; then
+        log INFO "  [dry-run] Would run: docker exec -e PGPASSWORD=*** ${container} pg_dump -U \"\$POSTGRES_USER\" -d ${db_name} --format=custom --compress=6"
+        log INFO "  [dry-run] Would verify with: pg_restore --list ${out_file}"
+        SUCCEEDED_DBS+=("${db_name}")
+        return 0
+    fi
+
+    if ! check_container_running "${container}"; then
+        FAILED_DBS+=("${db_name}")
+        return 1
+    fi
+
+    # Run pg_dump inside the container. PGPASSWORD is passed via -e so it is
+    # not visible in `ps` output on the host. Output is streamed to the dump
+    # file on the host via stdout redirection.
+    if docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" \
+        pg_dump -U "${POSTGRES_USER}" -d "${db_name}" --format=custom --compress=6 \
+        > "${out_file}" 2> >(while IFS= read -r line; do log WARN "  [${db_name}] ${line}"; done); then
+        :
+    else
+        log ERROR "pg_dump failed for ${db_name}. Renaming artifact to .FAILED."
+        mv -f "${out_file}" "${out_file}.FAILED" 2>/dev/null || true
+        FAILED_DBS+=("${db_name}")
+        return 1
+    fi
+
+    # Verify: non-empty file
+    if [ ! -s "${out_file}" ]; then
+        log ERROR "Dump file is empty for ${db_name}. Renaming to .FAILED."
+        mv -f "${out_file}" "${out_file}.FAILED" 2>/dev/null || true
+        FAILED_DBS+=("${db_name}")
+        return 1
+    fi
+
+    # Verify: pg_restore --list should succeed on a valid custom-format archive.
+    # We copy the file into the container (tmpfs /tmp) to avoid needing
+    # pg_restore on the host.
+    if ! docker exec -i "${container}" bash -lc "cat > /tmp/verify.dump && pg_restore --list /tmp/verify.dump >/dev/null && rm -f /tmp/verify.dump" < "${out_file}" 2>/dev/null; then
+        log ERROR "pg_restore --list verification failed for ${db_name}. Renaming to .FAILED."
+        mv -f "${out_file}" "${out_file}.FAILED" 2>/dev/null || true
+        FAILED_DBS+=("${db_name}")
+        return 1
+    fi
+
+    local size
+    size="$(file_size_human "${out_file}")"
+    log OK "Backup done: db=${db_name} file=${out_file} size=${size}"
+    SUCCEEDED_DBS+=("${db_name}")
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Retention
+# ---------------------------------------------------------------------------
+
+prune_old_backups() {
+    if [ "${RETENTION_DAYS}" -le 0 ]; then
+        log INFO "Retention disabled (--retention-days 0). Keeping all dumps."
+        return 0
+    fi
+
+    log INFO "Pruning .dump files older than ${RETENTION_DAYS} days in ${BACKUP_DIR} (keeps .FAILED files)."
+
+    if [ "${DRY_RUN}" = true ]; then
+        local would_delete=0
+        while IFS= read -r -d '' f; do
+            log INFO "  [dry-run] Would delete: ${f}"
+            would_delete=$((would_delete + 1))
+        done < <(find "${BACKUP_DIR}" -maxdepth 1 -type f -name '*.dump' -mtime "+${RETENTION_DAYS}" -print0 2>/dev/null)
+        log INFO "  [dry-run] Candidates: ${would_delete}"
+        return 0
+    fi
+
+    local deleted=0
+    while IFS= read -r -d '' f; do
+        if rm -f "${f}"; then
+            log INFO "  Deleted: ${f}"
+            deleted=$((deleted + 1))
+        else
+            log WARN "  Failed to delete: ${f}"
+        fi
+    done < <(find "${BACKUP_DIR}" -maxdepth 1 -type f -name '*.dump' -mtime "+${RETENTION_DAYS}" -print0 2>/dev/null)
+
+    log OK "Pruned ${deleted} old dump(s)."
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    # Parse arguments
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -d|--backup-dir)
+                if [ $# -lt 2 ]; then
+                    log ERROR "Flag $1 requires a value."
+                    exit 1
+                fi
+                BACKUP_DIR="$2"
+                shift 2
+                ;;
+            -r|--retention-days)
+                if [ $# -lt 2 ]; then
+                    log ERROR "Flag $1 requires a value."
+                    exit 1
+                fi
+                if ! [[ "$2" =~ ^[0-9]+$ ]]; then
+                    log ERROR "--retention-days must be a non-negative integer, got: $2"
+                    exit 1
+                fi
+                RETENTION_DAYS="$2"
+                shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            -h|--help)
+                print_usage
+                exit 0
+                ;;
+            *)
+                log ERROR "Unknown flag: $1"
+                print_usage
+                exit 1
+                ;;
+        esac
+    done
+
+    banner "SAPPHIRE Database Backup"
+
+    if [ "${DRY_RUN}" = true ]; then
+        log WARN "Dry-run mode: no pg_dump calls, no deletions."
+    fi
+
+    check_repo_root
+    load_env
+    check_backup_dir
+    if [ "${DRY_RUN}" = false ]; then
+        check_docker
+    fi
+
+    log INFO "Backup directory: ${BACKUP_DIR}"
+    log INFO "Retention days:   ${RETENTION_DAYS}"
+
+    # Four active DBs — container/db pairs
+    backup_db "sapphire-preprocessing-db"  "${PREPROCESSING_DB}"  || true
+    backup_db "sapphire-postprocessing-db" "${POSTPROCESSING_DB}" || true
+    backup_db "sapphire-user-db"           "${USER_DB}"           || true
+    backup_db "sapphire-auth-db"           "${AUTH_DB}"           || true
+
+    # Retention runs regardless of per-DB outcome; .FAILED files are never pruned.
+    prune_old_backups
+
+    banner "BACKUP SUMMARY"
+    log INFO "Succeeded: ${#SUCCEEDED_DBS[@]} (${SUCCEEDED_DBS[*]:-none})"
+    if [ "${#FAILED_DBS[@]}" -gt 0 ]; then
+        log ERROR "Failed:    ${#FAILED_DBS[@]} (${FAILED_DBS[*]})"
+        exit 1
+    fi
+    log OK "All four dumps succeeded and verified."
+    exit 0
+}
+
+main "$@"

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -28,18 +28,243 @@ To set up a new SAPPHIRE deployment, create a **data folder** outside the code r
 
 **Path convention**: All paths in the `.env` file are relative to the module working directory (`apps/<module>/`). For an external data folder at `../<country>_data_forecast_tools/`, use `../../../<country>_data_forecast_tools/` (three levels up from `apps/<module>/` to reach the parent of the repo root).
 
-TODO: Document the minimal set of required .env variables for a deployment that only uses linear regression with manual sites (no iEasyHydro HF, no data gateway, no ML models, no conceptual models). Many variables in the current .env examples are only needed for specific modules.
+### .env variable reference
 
-### Connecting to iEasyHydro HF
+The `.env` file drives every pipeline module. Variables fall into three categories: **Required** (the pipeline will not start without them), **Required-if** (needed only when a specific feature or module is enabled), and **Optional** (sensible default, or the feature is simply off when unset). The pipeline-side variables live in the external data folder (e.g. `<data_folder>/config/.env_develop_<country>`); the services-side variables are loaded by the FastAPI stack. In production both sets share a single `.env` file — see [SAPPHIRE services (API stack)](deployment.md#sapphire-services-api-stack) in the deployment guide.
 
-The `ieasyhydroforecast_connect_to_iEH` variable controls whether the pipeline attempts to connect to the iEasyHydro High Frequency database. Set to `True` to enable the iEH HF connection (requires `IEASYHYDROHF_HOST`, `IEASYHYDROHF_USERNAME`, `IEASYHYDROHF_PASSWORD`). Set to `False` for deployments without an iEH HF database — the pipeline will use config JSON files for site discovery and skip all SDK fetch calls.
+#### Minimal deployment profile
 
-```
-# Set to True to connect to iEasyHydro HF, False for config-file-only mode
+The minimal deployment runs linear regression against manual sites only — no iEasyHydro HF database, no SAPPHIRE Data Gateway, no ML models, no conceptual models, no long-term forecasts. Copy the block below into `<data_folder>/config/.env_develop_<country>`, replace the `<…>` placeholders, and the pipeline is runnable end-to-end. All other variables in the full reference table can be omitted.
+
+```bash
+# --- Identity and mode ---
+ieasyhydroforecast_organization=demo
 ieasyhydroforecast_connect_to_iEH=False
+ieasyhydroforecast_run_ML_models=false
+ieasyhydroforecast_run_CM_models=false
+
+# --- Station + output config files (kept under <data_folder>/config) ---
+ieasyforecast_configuration_path=../../../<data_folder>/config
+ieasyforecast_config_file_all_stations=config_all_stations_library.json
+ieasyforecast_config_file_station_selection=config_station_selection.json
+ieasyforecast_config_file_output=config_output.json
+ieasyforecast_restrict_stations_file=null
+
+# --- Intermediate data + last-run marker ---
+ieasyforecast_intermediate_data_path=../../../<data_folder>/intermediate_data
+ieasyforecast_last_successful_run_file=last_successful_run.txt
+
+# --- Bulletin templates and report output ---
+ieasyreports_templates_directory_path=../../../<data_folder>/templates
+ieasyforecast_template_pentad_bulletin_file=pentad_forecast_bulletin_template.xlsx
+ieasyforecast_template_pentad_sheet_file=short_term_trad_sheet_template.xlsx
+ieasyreports_report_output_path=../../../<data_folder>/reports
+ieasyforecast_bulletin_file_name=pentadal_forecast_bulletin.xlsx
+ieasyforecast_sheet_file_name=pentadal_forecast_sheet.xlsx
+
+# --- Dashboard map + daily discharge excel files ---
+ieasyforecast_gis_directory_path=../../../<data_folder>/GIS
+ieasyforecast_country_borders_file_name=<adm_boundaries>.shp
+ieasyforecast_daily_discharge_path=../../../<data_folder>/daily_runoff
+
+# --- Localization + logging ---
+ieasyforecast_locale_dir=../../../<data_folder>/config/locale
+ieasyforecast_locale=en_CH
+log_file=./forecast_logs.txt
+log_level=INFO
+
+# --- SAPPHIRE services (must point at the running API gateway) ---
+SAPPHIRE_API_ENABLED=true
+SAPPHIRE_API_URL=http://localhost:8000
+POSTGRES_USER=<db_user>
+POSTGRES_PASSWORD=<db_password>
+PREPROCESSING_DB=preprocessing_db
+POSTPROCESSING_DB=postprocessing_db
+USER_DB=user_db
+AUTH_DB=auth_db
+JWT_SECRET_KEY=<generate_strong_random_secret>
 ```
 
-TODO: Document `IEASYHYDROHF_HOST`, `IEASYHYDROHF_USERNAME`, `IEASYHYDROHF_PASSWORD` (the iEasyHydro HF SDK variables, distinct from the legacy `IEASYHYDRO_HOST` etc.). These are used by `preprocessing_runoff` and are separate from the legacy iEasyHydro SDK variables documented below.
+For deployments that enable more features, keep the minimal block as the base and layer on the variables listed in ["Add-ons"](#add-ons--what-to-flip-on-when-you-need-more) below.
+
+#### Full variable reference
+
+Pipeline-side variables (set in the external `<data_folder>/config/.env_develop_<country>`):
+
+| Variable | Category | Module(s) | Purpose | Default / Notes |
+|----------|----------|-----------|---------|-----------------|
+| `ieasyhydroforecast_organization` | Required | all | Deployment identifier (`demo`, `kghm`, `tjhm`, `uzhm`) | — |
+| `ieasyhydroforecast_connect_to_iEH` | Required | all | `True`/`False` — toggles iEH HF SDK fetch | — |
+| `ieasyhydroforecast_run_ML_models` | Required | dashboard, pipeline | `true`/`false` — gates ML forecast container | — |
+| `ieasyhydroforecast_run_CM_models` | Required | dashboard, pipeline | `true`/`false` — gates conceptual-model container | — |
+| `ieasyforecast_configuration_path` | Required | all | Path to station/output config JSON files | — |
+| `ieasyforecast_config_file_all_stations` | Required | all | Station library filename | `config_all_stations_library.json` |
+| `ieasyforecast_config_file_station_selection` | Required | all | Selected-stations filename | `config_station_selection.json` |
+| `ieasyforecast_config_file_output` | Required | all | Output config filename | `config_output.json` |
+| `ieasyforecast_intermediate_data_path` | Required | all | Where pipeline writes intermediate CSV/pkl | — |
+| `ieasyforecast_last_successful_run_file` | Required | linear_regression | Marker file for last successful run date | `last_successful_run.txt` |
+| `ieasyreports_templates_directory_path` | Required | postprocessing_forecasts | Bulletin/sheet template directory | — |
+| `ieasyforecast_template_pentad_bulletin_file` | Required | postprocessing_forecasts | Pentad bulletin template filename | — |
+| `ieasyforecast_template_pentad_sheet_file` | Required | postprocessing_forecasts | Pentad sheet template filename | — |
+| `ieasyreports_report_output_path` | Required | postprocessing_forecasts | Root for generated bulletins/sheets | — |
+| `ieasyforecast_bulletin_file_name` | Required | postprocessing_forecasts | Base name for pentad bulletins | — |
+| `ieasyforecast_sheet_file_name` | Required | postprocessing_forecasts | Base name for pentad sheets | — |
+| `ieasyforecast_gis_directory_path` | Required | dashboard | Directory holding admin boundary shapefiles | — |
+| `ieasyforecast_country_borders_file_name` | Required | dashboard | Admin boundaries shapefile (WGS84, EPSG:4326) | — |
+| `ieasyforecast_daily_discharge_path` | Required | preprocessing_runoff | Excel files with historical discharge | — |
+| `ieasyforecast_locale_dir` | Required | dashboard | Directory with `.mo`/`.po` locale files | — |
+| `ieasyforecast_locale` | Required | dashboard | Active locale (`ru_KG` or `en_CH`) | `en_CH` |
+| `log_file` | Required | all | Log file path (relative to module cwd) | `./forecast_logs.txt` |
+| `log_level` | Required | all | Python logging level | `INFO` |
+| `SAPPHIRE_API_ENABLED` | Required | all | `true`/`false` — use API vs CSV-only | `true` |
+| `SAPPHIRE_API_URL` | Required | all | API gateway base URL | `http://localhost:8000` |
+| `ieasyforecast_restrict_stations_file` | Required-if: dev restriction | all | Restrict to subset of stations; `null` to disable | — |
+| `IEASYHYDROHF_HOST` | Required-if: `connect_to_iEH=True` | preprocessing_runoff | iEasyHydro HF API endpoint (e.g. `http://host.docker.internal:5555/api/v1/`) | — |
+| `IEASYHYDROHF_USERNAME` | Required-if: `connect_to_iEH=True` | preprocessing_runoff | iEH HF API username | — |
+| `IEASYHYDROHF_PASSWORD` | Required-if: `connect_to_iEH=True` | preprocessing_runoff | iEH HF API password | — |
+| `ieasyhydroforecast_ssh_to_iEH` | Required-if: SSH tunnel to iEH | preprocessing_runoff | `True` if reaching iEH through an SSH tunnel | `False` |
+| `IEASYHYDRO_HOST` | Required-if: legacy iEH SDK | backend (legacy) | Legacy iEasyHydro (non-HF) endpoint | — |
+| `IEASYHYDRO_USERNAME` | Required-if: legacy iEH SDK | backend (legacy) | Legacy iEH username | — |
+| `IEASYHYDRO_PASSWORD` | Required-if: legacy iEH SDK | backend (legacy) | Legacy iEH password | — |
+| `ORGANIZATION_ID` | Required-if: legacy iEH SDK | backend (legacy) | Organization ID in legacy iEH | `1` |
+| `IEASYHYDRO_SPOTCHECK_SITES` | Required-if: spot-check enabled | preprocessing_runoff | Comma-separated site codes to spot-check | — |
+| `GOOGLE_SHEETS_ENABLED` | Required-if: manual-site sheet ingestion | preprocessing_runoff | `true`/`false` | `false` |
+| `GOOGLE_SHEETS_DISCHARGE_ID` | Required-if: `GOOGLE_SHEETS_ENABLED=true` | preprocessing_runoff | Spreadsheet ID | — |
+| `GOOGLE_SHEETS_CREDENTIALS_PATH` | Required-if: `GOOGLE_SHEETS_ENABLED=true` | preprocessing_runoff | Path to Google service account JSON key | — |
+| `GOOGLE_SHEETS_SITE_CODES` | Required-if: `GOOGLE_SHEETS_ENABLED=true` | preprocessing_runoff | Comma-separated manual site codes | — |
+| `ieasyhydroforecast_API_KEY_GATEAWAY` | Required-if: gateway used | preprocessing_gateway, ML, conceptual | API key for SAPPHIRE Data Gateway | — |
+| `SAPPHIRE_DG_HOST` | Required-if: gateway used | preprocessing_gateway, dashboard | Gateway base URL | — |
+| `SAPPHIRE_DG_API_KEY` | Required-if: gateway used | preprocessing_gateway | Gateway API key (alternative name) | — |
+| `ieasyhydroforecast_HRU_CONTROL_MEMBER` | Required-if: gateway used | preprocessing_gateway | HRU shapefile identifier for control member | — |
+| `ieasyhydroforecast_HRU_ENSEMBLE` | Required-if: gateway used | preprocessing_gateway | Comma-separated HRUs needing ensemble forecasts | — |
+| `ieasyhydroforecast_OUTPUT_PATH_DG` | Required-if: gateway used | preprocessing_gateway | Subdir under intermediate for gateway output | `data_gateway` |
+| `ieasyhydroforecast_OUTPUT_PATH_CM` | Required-if: gateway used | preprocessing_gateway | Subdir for control-member forcing | `control_member_forcing` |
+| `ieasyhydroforecast_OUTPUT_PATH_ENS` | Required-if: gateway used | preprocessing_gateway | Subdir for ensemble forcing | `ensemble_forcing` |
+| `ieasyhydroforecast_OUTPUT_PATH_REANALYSIS` | Required-if: gateway used | preprocessing_gateway | Subdir for ERA5 reanalysis output | — |
+| `ieasyhydroforecast_OUTPUT_PATH_SNOW` | Required-if: gateway used | preprocessing_gateway | Subdir for snow data output | — |
+| `ieasyhydroforecast_OUTPUT_PATH_DISCHARGE` | Required-if: ML used | ML | Subdir for ML prediction output | `predictions` |
+| `ieasyhydroforecast_models_and_scalers_path` | Required-if: ML or quantile mapping | preprocessing_gateway, ML | Path to trained scalers / QM params | — |
+| `ieasyhydroforecast_Q_MAP_PARAM_PATH` | Required-if: quantile mapping | preprocessing_gateway | Subdir under models_and_scalers for QM params | `params_quantile_mapping` |
+| `ieasyhydroforecast_PATH_TO_QMAPPED_ERA5` | Required-if: gateway used | preprocessing_gateway | Output subdir for QMapped ERA5 | `control_member_forcing` |
+| `ieasyhydroforecast_available_ML_models` | Required-if: `run_ML_models=true` | ML, dashboard | Comma-separated model tags | `TFT,TIDE,TSMIXER` |
+| `ieasyhydroforecast_config_hydroposts_available_for_ml_forecasts` | Required-if: `run_ML_models=true` | ML | JSON listing hydroposts eligible for ML | — |
+| `ieasyhydroforecast_ml_hru_models` | Required-if: `run_ML_models=true` | ML | Mapping from model → HRU | — |
+| `ieasyhydroforecast_SNOW_VARS` | Required-if: snow data used | preprocessing_gateway, long_term | Comma-separated snow vars (e.g. `SWE,HS,RoF`) | — |
+| `ieasyhydroforecast_HRU_SNOW_DATA` | Required-if: snow data used | preprocessing_gateway | HRU id for snow data | — |
+| `ieasyhydroforecast_HRU_SNOW_DATA_DASHBOARD` | Required-if: snow in dashboard | dashboard | HRU id exposed on snow visualization | — |
+| `ieasyhydroforecast_ECMWF_IFS_lead_time` | Required-if: ML used | ML | Forecast lead time in days for IFS | — |
+| `ieasyhydroforecast_NEW_STATIONS` | Required-if: onboarding new stations | preprocessing_gateway, ML | Comma-separated codes for backfill | — |
+| `ieasyhydroforecast_ml_long_term_configuration` | Required-if: long_term used | long_term | Path to long-term forecast config JSON | — |
+| `ieasyhydroforecast_ml_long_term_output_path` | Required-if: long_term used | long_term | Output subdir under intermediate data | — |
+| `ieasyhydroforecast_ml_long_term_path_to_static` | Required-if: long_term used | long_term | Static features CSV for long-term models | — |
+| `ieasyhydroforecast_ml_long_term_supported_modes` | Required-if: long_term used | long_term | Comma-separated modes (e.g. `month_1,seasonal`) | — |
+| `lt_forecast_mode` | Required-if: long_term used | long_term | Mode selected for a given run | — |
+| `SAPPHIRE_PIPELINE_SMTP_SERVER` | Required-if: email alerts | pipeline | SMTP host | `smtp.example.com` |
+| `SAPPHIRE_PIPELINE_SMTP_PORT` | Required-if: email alerts | pipeline | SMTP port | `587` |
+| `SAPPHIRE_PIPELINE_SMTP_USERNAME` | Required-if: email alerts | pipeline | SMTP login | — |
+| `SAPPHIRE_PIPELINE_SMTP_PASSWORD` | Required-if: email alerts | pipeline | SMTP password | — |
+| `SAPPHIRE_PIPELINE_SENDER_EMAIL` | Required-if: email alerts | pipeline | From-address for pipeline alerts | — |
+| `SAPPHIRE_PIPELINE_EMAIL_RECIPIENTS` | Required-if: email alerts | pipeline | Comma-separated recipient list | — |
+| `ieasyhydroforecast_config_file_data_gateway_name_twins` | Optional | preprocessing_gateway | JSON mapping gateway-name → iEH-name | — |
+| `ieasyforecast_hydrograph_day_file` | Optional | linear_regression, dashboard | Daily hydrograph filename | `hydrograph_day.csv` |
+| `ieasyforecast_hydrograph_pentad_file` | Optional | linear_regression, dashboard | Pentad hydrograph filename | `hydrograph_pentad.csv` |
+| `ieasyforecast_hydrograph_decad_file` | Optional | linear_regression, dashboard | Decad hydrograph filename | `hydrograph_decad.csv` |
+| `ieasyforecast_pentad_results_file` | Optional | linear_regression | Pentad forecast CSV filename | `forecasts_pentad.csv` |
+| `ieasyforecast_decad_results_file` | Optional | linear_regression | Decad forecast CSV filename | `forecasts_decad.csv` |
+| `ieasyforecast_daily_discharge_file` | Optional | preprocessing_runoff | Daily discharge CSV filename | `runoff_day.csv` |
+| `ieasyforecast_pentad_discharge_file` | Optional | linear_regression | Pentad runoff CSV filename | `runoff_pentad.csv` |
+| `ieasyforecast_decad_discharge_file` | Optional | linear_regression | Decad runoff CSV filename | `runoff_decad.csv` |
+| `ieasyforecast_analysis_pentad_file` | Optional | linear_regression | Pentad analysis CSV | `forecast_pentad_linreg.csv` |
+| `ieasyforecast_analysis_decad_file` | Optional | linear_regression | Decad analysis CSV | `forecast_decad_linreg.csv` |
+| `ieasyforecast_pentadal_skill_metrics_file` | Optional | postprocessing_forecasts | Pentad skill CSV backup filename | `skill_metrics_pentad.csv` |
+| `ieasyforecast_decadal_skill_metrics_file` | Optional | postprocessing_forecasts | Decad skill CSV backup filename | `skill_metrics_decad.csv` |
+| `ieasyforecast_monthly_skill_metrics_file` | Optional | postprocessing_forecasts | Monthly skill CSV backup filename | `skill_metrics_monthly.csv` |
+| `ieasyforecast_combined_forecast_pentad_file` | Optional | postprocessing_forecasts | Combined pentad forecast CSV | `combined_forecasts_pentad.csv` |
+| `ieasyforecast_combined_forecast_decad_file` | Optional | postprocessing_forecasts | Combined decad forecast CSV | `combined_forecasts_decad.csv` |
+| `ieasyforecast_monthly_combined_forecast_file` | Optional | postprocessing_forecasts | Monthly combined forecast CSV | `combined_forecasts_monthly.csv` |
+| `ieasyforecast_template_decad_bulletin_file` | Optional | postprocessing_forecasts | Decad bulletin template | — |
+| `ieasyforecast_template_decad_sheet_file` | Optional | postprocessing_forecasts | Decad sheet template | — |
+| `ieasyhydroforecast_backend_docker_image_tag` | Optional | dashboard (triggers) | Docker tag for backend images | `latest` |
+| `ieasyhydroforecast_frontend_docker_image_tag` | Optional | dashboard | Docker tag for frontend | `latest` |
+| `ieasyhydroforecast_data_root_dir` | Optional | dashboard (Docker triggers) | Host path of `<data_folder>` for Docker binds | — |
+| `ieasyhydroforecast_bin_path` | Optional | dashboard (Docker triggers) | Host path to `bin/` for Docker binds | — |
+| `ieasyhydroforecast_env_file_path` | Optional | run_locally.sh | Absolute path to `.env` (required by `run_locally.sh`) | — |
+| `ieasyhydroforecast_START_DATE` | Optional | linear_regression, long_term | Hindcast start date (YYYY-MM-DD) | — |
+| `ieasyhydroforecast_END_DATE` | Optional | linear_regression, long_term | Hindcast end date (YYYY-MM-DD) | — |
+| `ieasyhydroforecast_reanalysis_START_DATE` | Optional | preprocessing_gateway | ERA5 reanalysis window start | — |
+| `ieasyhydroforecast_reanalysis_END_DATE` | Optional | preprocessing_gateway | ERA5 reanalysis window end | — |
+| `ieasyhydroforecast_CODES_HINDECAST` | Optional | ML, long_term | Codes to hindcast | — |
+| `ieasyhydroforecast_SNOW_DISPLAY_START_MMDD` | Optional | dashboard | Snow viz start day (MM-DD) | — |
+| `SAPPHIRE_API_TOKEN` | Optional | all | Bearer token for API gateway | — |
+| `SAPPHIRE_API_FAILURE_MODE` | Optional | all | Failure policy when API unreachable (`warn`/`fail`) | `warn` |
+| `SAPPHIRE_SYNC_MODE` | Optional | preprocessing_gateway | `operational` or `historical` | `operational` |
+| `SAPPHIRE_CONSISTENCY_CHECK` | Optional | preprocessing_gateway | `true`/`false` — enable data consistency check | `false` |
+| `SAPPHIRE_CONSISTENCY_STRICT` | Optional | preprocessing_gateway | Fail on consistency mismatch | `false` |
+| `SAPPHIRE_SKILL_METRICS_START_YEAR` | Optional | postprocessing_forecasts | Override rolling window start year | current year − 20 |
+| `SAPPHIRE_SKILL_METRICS_YEAR` | Optional | postprocessing_forecasts | Target year for recalculation run | — |
+| `SAPPHIRE_RECALC_START_YEAR` | Optional | postprocessing_forecasts | Skill recalc window start | — |
+| `SAPPHIRE_RECALC_END_YEAR` | Optional | postprocessing_forecasts | Skill recalc window end | — |
+| `SAPPHIRE_SEASON_START_MONTH` | Optional | long_term | Hydrological season start month | — |
+| `SAPPHIRE_SEASON_END_MONTH` | Optional | long_term | Hydrological season end month | — |
+| `SAPPHIRE_HINDCAST_MODE` | Optional | ML, long_term | Enable hindcast code paths | — |
+| `SAPPHIRE_HINDCAST_TIMEOUT_SECONDS` | Optional | ML | ML hindcast container timeout | — |
+| `SAPPHIRE_MODEL_TO_USE` | Optional | long_term | Model override for a single run | — |
+| `FRESHNESS_THRESHOLD_DAYS` | Optional | validate_pipeline | Warn if intermediate data older than N days | `7` |
+| `POSTPROCESSING_GAPFILL_MAX_MONTHS` | Optional | postprocessing_forecasts | Max months to gap-fill | — |
+| `POSTPROCESSING_GAPFILL_WINDOW_DAYS` | Optional | postprocessing_forecasts | Gap-fill window (days) | — |
+| `POSTPROCESSING_GAPFILL_WINDOW_MONTHS` | Optional | postprocessing_forecasts | Gap-fill window (months) | — |
+| `POSTPROCESSING_GAPFILL_WINDOW_QUARTERS` | Optional | postprocessing_forecasts | Gap-fill window (quarters) | — |
+| `POSTPROCESSING_GAPFILL_WINDOW_SEASONS` | Optional | postprocessing_forecasts | Gap-fill window (seasons) | — |
+| `PREPROCESSING_MAINTENANCE_LOOKBACK_DAYS` | Optional | preprocessing_runoff | Maintenance pipeline lookback | — |
+
+Services-side variables (loaded by the FastAPI stack — in production they sit in the same `.env` as above; `sapphire/.env.example` is the reference). See [SAPPHIRE services (API stack)](deployment.md#sapphire-services-api-stack):
+
+| Variable | Category | Module(s) | Purpose | Default / Notes |
+|----------|----------|-----------|---------|-----------------|
+| `POSTGRES_USER` | Required | services | Postgres superuser for all service DBs | — |
+| `POSTGRES_PASSWORD` | Required | services | Postgres password | — |
+| `PREPROCESSING_DB` | Required | services | Preprocessing DB name | `preprocessing_db` |
+| `POSTPROCESSING_DB` | Required | services | Postprocessing DB name | `postprocessing_db` |
+| `USER_DB` | Required | services | User DB name | `user_db` |
+| `AUTH_DB` | Required | services | Auth DB name | `auth_db` |
+| `PREPROCESSING_DATABASE_URL` | Required | services | SQLAlchemy URL for preprocessing DB | Built from above |
+| `POSTPROCESSING_DATABASE_URL` | Required | services | SQLAlchemy URL for postprocessing DB | Built from above |
+| `USER_DATABASE_URL` | Required | services | SQLAlchemy URL for user DB | Built from above |
+| `AUTH_DATABASE_URL` | Required | services | SQLAlchemy URL for auth DB | Built from above |
+| `PREPROCESSING_API_URL` | Required | services | Internal URL the gateway uses for preprocessing | `http://preprocessing-api:8002` |
+| `POSTPROCESSING_API_URL` | Required | services | Internal URL for postprocessing | `http://postprocessing-api:8003` |
+| `USER_API_URL` | Required | services | Internal URL for user service | `http://user-api:8004` |
+| `AUTH_API_URL` | Required | services | Internal URL for auth service | `http://auth-api:8005` |
+| `JWT_SECRET_KEY` | Required | services | Signing key for JWT tokens (generate random) | — |
+| `JWT_ALGORITHM` | Optional | services | JWT algorithm | `HS256` |
+| `ACCESS_TOKEN_EXPIRE_MINUTES` | Optional | services | Access token lifetime | `30` |
+| `REFRESH_TOKEN_EXPIRE_DAYS` | Optional | services | Refresh token lifetime | `7` |
+| `REQUEST_TIMEOUT` | Optional | services | API gateway request timeout (s) | `30` |
+| `HEALTH_CHECK_TIMEOUT` | Optional | services | Health-check timeout (s) | `5` |
+| `API_KEY_ENABLED` | Optional | services | Enable API-key protection on gateway | `false` |
+| `API_KEY` | Required-if: `API_KEY_ENABLED=true` | services | Gateway API key | — |
+| `RATE_LIMIT_ENABLED` | Optional | services | Enable rate limiting | `false` |
+| `RATE_LIMIT` | Optional | services | Requests per minute when enabled | `100` |
+| `LOG_LEVEL` | Optional | services | Services log level | `INFO` |
+| `BATCH_SIZE` | Optional | services | Default batch size for migrations | `1000` |
+| `CSV_FOLDER` | Optional | services | CSV folder mounted into services | — |
+| `INTERMEDIATE_DATA_PATH` | Optional | services | Path to intermediate data (container side) | — |
+| `CONFIG_PATH` | Optional | services | Path to config (container side) | — |
+| `CONFIG_FOLDER` | Optional | services | Mount point inside containers | `/config` |
+
+Internal / Docker-only variables injected by the dashboard or Luigi at runtime (`SAPPHIRE_FORECAST_DATE`, `SAPPHIRE_PREDICTION_MODE`, `IN_DOCKER_CONTAINER`, `SAPPHIRE_OPDEV_ENV`) are documented separately under [Internal Docker environment variables](#internal-docker-environment-variables) and are not meant to be set in `.env`.
+
+#### Add-ons — what to flip on when you need more
+
+- **Connect to iEasyHydro HF.** Set `ieasyhydroforecast_connect_to_iEH=True`. Also set `IEASYHYDROHF_HOST`, `IEASYHYDROHF_USERNAME`, `IEASYHYDROHF_PASSWORD`. Add `ieasyhydroforecast_ssh_to_iEH=True` if reaching the HF API through an SSH tunnel.
+- **Legacy iEasyHydro SDK (non-HF).** Distinct from the HF variables above. Set `IEASYHYDRO_HOST`, `IEASYHYDRO_USERNAME`, `IEASYHYDRO_PASSWORD`, `ORGANIZATION_ID`. Used by the legacy `backend/` module only.
+- **SAPPHIRE Data Gateway.** Set `ieasyhydroforecast_API_KEY_GATEAWAY`, `SAPPHIRE_DG_HOST`, `ieasyhydroforecast_HRU_CONTROL_MEMBER`, `ieasyhydroforecast_models_and_scalers_path`. Required before enabling ML or conceptual models.
+- **ML models.** Set `ieasyhydroforecast_run_ML_models=true`. Also set the gateway block above, plus `ieasyhydroforecast_available_ML_models`, `ieasyhydroforecast_config_hydroposts_available_for_ml_forecasts`, `ieasyhydroforecast_ml_hru_models`, `ieasyhydroforecast_ECMWF_IFS_lead_time`.
+- **Long-term monthly forecasts.** Set `ieasyhydroforecast_ml_long_term_configuration`, `ieasyhydroforecast_ml_long_term_output_path`, `ieasyhydroforecast_ml_long_term_path_to_static`, `ieasyhydroforecast_ml_long_term_supported_modes`. Gateway block is also required if the models consume weather forcing.
+- **Conceptual rainfall-runoff.** Set `ieasyhydroforecast_run_CM_models=true`. Also set the gateway block plus the conceptual-model paths documented in [Configuration of the conceptual rainfall-runoff module](#configuration-of-the-conceptual-rainfall-runoff-module) below.
+- **Manual-site ingestion from Google Sheets.** Set `GOOGLE_SHEETS_ENABLED=true`. Also set `GOOGLE_SHEETS_DISCHARGE_ID`, `GOOGLE_SHEETS_CREDENTIALS_PATH`, `GOOGLE_SHEETS_SITE_CODES`. Sites must be marked `"data_source": "manual"` in `config_all_stations_library.json`.
+- **Email alerts on pipeline failure.** Set `SAPPHIRE_PIPELINE_SMTP_SERVER`, `SAPPHIRE_PIPELINE_SMTP_PORT`, `SAPPHIRE_PIPELINE_SMTP_USERNAME`, `SAPPHIRE_PIPELINE_SMTP_PASSWORD`, `SAPPHIRE_PIPELINE_SENDER_EMAIL`, `SAPPHIRE_PIPELINE_EMAIL_RECIPIENTS`.
+- **Spot-check validation of iEH HF data.** Set `IEASYHYDRO_SPOTCHECK_SITES` to a comma-separated list of site codes (e.g. `19999,19998`).
 
 ## Configuration of the forecast tools
 We recommend not changing the path ieasyforecast_configuration_path nor the names of the configuration files. You will need to edit the contents of the ieasyforecast_config_file_all_stations and make sure that the station codes given in ieasyforecast_config_file_station_selection are present also in ieasyforecast_config_file_all_stations. Please have a look at the example files in the config folder for guidance.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -26,7 +26,47 @@ To set up a new SAPPHIRE deployment, create a **data folder** outside the code r
 └── reports/                   # Generated forecast bulletins (created automatically)
 ```
 
-**Path convention**: All paths in the `.env` file are relative to the module working directory (`apps/<module>/`). For an external data folder at `../<country>_data_forecast_tools/`, use `../../../<country>_data_forecast_tools/` (three levels up from `apps/<module>/` to reach the parent of the repo root).
+**Path convention**: All paths in the `.env` file are relative to the module working directory (`apps/<module>/`). For an external data folder sitting alongside the repository, use `../../../<country>_data_forecast_tools/` (three levels up from `apps/<module>/` to reach the shared parent directory).
+
+#### Why three levels up
+
+The pipeline scripts run with their working directory set to `apps/<module>/` (e.g. `apps/linear_regression/`). The repository and the data folder are siblings in a shared parent directory:
+
+```
+parent/                                  ← ../../../ from apps/<module>/
+├── SAPPHIRE_Forecast_Tools/             ← the repository
+│   ├── apps/
+│   │   ├── linear_regression/           ← scripts run from here (cwd)
+│   │   ├── preprocessing_runoff/
+│   │   ├── machine_learning/
+│   │   └── ...
+│   ├── bin/
+│   └── sapphire/
+└── <country>_data_forecast_tools/       ← external data folder
+    ├── config/
+    │   └── <env_file>
+    ├── daily_runoff/
+    ├── intermediate_data/
+    └── ...
+```
+
+Walking back up from `apps/linear_regression/`:
+
+| `..` step | Lands in |
+|-----------|----------|
+| `..` | `apps/` |
+| `../..` | `SAPPHIRE_Forecast_Tools/` |
+| `../../..` | `parent/` (shared with the data folder) |
+
+Concrete example: an `.env` line like
+
+```bash
+ieasyforecast_configuration_path=../../../<data_folder>/config
+```
+
+resolves to `parent/<country>_data_forecast_tools/config/` when a script runs from `apps/linear_regression/`, `apps/preprocessing_runoff/`, or any other module — the relative path is the same for all modules because they share the `apps/<module>/` depth.
+
+If your deployment places the data folder somewhere else (e.g. a separate mount point, or at the same level as `SAPPHIRE_Forecast_Tools/`), adjust the `..` count accordingly. The rule is always "walk up until you hit the directory that contains your data folder, then descend in."
 
 ### .env variable reference
 

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -11,6 +11,7 @@ This document describes the steps for the installation of the SAPPHIRE Forecast 
     - [Install software on the server](#install-software-on-the-server)
     - [Verify server readiness](#verify-server-readiness)
 - [Step-by-step instructions](#step-by-step-instructions)
+  - [Deployment order](#deployment-order)
   - [Download this repository](#download-this-repository)
   - [General information for deployment](#general-information-for-deployment)
   - [Deployment of demo version on a local machine](#deployment-of-demo-version-on-a-local-machine)
@@ -18,6 +19,7 @@ This document describes the steps for the installation of the SAPPHIRE Forecast 
     - [Configuring your server](#configuring-your-server)
       - [Set up the Luigi Daemon (Production)](#set-up-the-luigi-daemon-production)
       - [Set up SSH tunnel to iEasyHydro HF (if required)](#set-up-ssh-tunnel-to-ieasyhydro-hf-if-required)
+      - [SAPPHIRE services (API stack)](#sapphire-services-api-stack)
     - [Copy your data to the repository](#copy-your-data-to-the-repository)
     - [Adapt the configuration files](#adapt-the-configuration-files)
     - [Deploy the forecast tools](#deploy-the-forecast-tools)
@@ -301,6 +303,32 @@ If any check fails, fix the issue before continuing. Common problems:
 | A port is already in use | Another service is listening | Identify it with `ss -tlnp | grep :<port>` and stop or reconfigure it |
 
 # Step-by-step instructions
+
+## Deployment order
+
+Deploy the components in the order below. Every later component depends on
+the ones above it, so skipping ahead will result in failures that are hard
+to diagnose.
+
+1. **SAPPHIRE services (databases + APIs)** — the FastAPI stack at
+   `sapphire/services/` and its PostgreSQL databases. Everything else reads
+   and writes through the `api-gateway`, so these must be up first.
+2. **Luigi daemon** — orchestrates the pipeline scripts. Must be running
+   before any pipeline task is triggered, either manually or from cron.
+3. **Pipeline scripts** (preprocessing, linear regression, ML, long-term,
+   postprocessing) — produce the forecasts. They call the services on each
+   run to read inputs and persist outputs.
+4. **Dashboards** — present forecasts to end users. They query the API
+   gateway and expect the postprocessing service to contain forecast data.
+
+If the order is broken — most commonly when the SAPPHIRE services are down
+while the pipeline runs — the pipeline either fails hard or silently falls
+back to CSV-only mode (depending on the module). A silent fallback is the
+more dangerous outcome: nothing visibly breaks, but no new data reaches the
+databases, and the dashboards keep showing stale forecasts until a human
+notices. Always confirm `curl http://localhost:8000/health/ready` returns
+OK before starting the Luigi daemon or triggering a pipeline run.
+
 ## Download this repository
 Download the [repository](https://github.com/hydrosolutions/SAPPHIRE_Forecast_Tools) to the host machine. This will give you the folder structure with which you can quickly deploy the forecast tools. You can, however, also build your own folder structure. If you choose to do so, you will have to adapt the paths in the .env file and the run commands accordingly.
 <details>
@@ -318,14 +346,12 @@ git clone https://github.com/hydrosolutions/SAPPHIRE_Forecast_Tools.git
 </details>
 
 ## General information for deployment
-We provide a script the should take care of most deployment steps for you and run the forecast tools for the first time.
-The script is located in the bin folder and run as follows from the SAPPHIRE_Forecast_Tools folder:
-```bash
-ieasyhydroforecast_url=<base url> nohup bash .bin/deploy_sapphire_forecast_tools.sh <env_file_path> > deployment.log 2>&1 &
-```
-where the env_file_path is the absolute path to your .env file. This command will log all output of the command to a file deployment.log in your folder SAPPHIRE_Forecast_Tools. You can view the progress of the deployment script by looking at the log file, for example with `less deployment.log`, and by checking the progress of the individual containers with `docker ps -a` and `docker logs <container_name>`.
+Deployment is performed as a sequence of manual steps rather than a single script. Follow the [Deployment order](#deployment-order) above for the high-level sequence, and refer to the following documents for the detailed walkthroughs:
 
-Please note that the deployment script assumes that the pentad forecast dashboard will be deployed at fc.pentad.<base url> and the decad dashboard will be deployed at fc.decad.<base url>. 
+- For a first-time deployment on a new server, see [`doc/plans/deployment_new_hydromet_aws.md`](plans/deployment_new_hydromet_aws.md).
+- For updates to an existing deployment, see [`doc/prod/update_deployment_checklist.md`](prod/update_deployment_checklist.md).
+
+The deployment assumes that the pentad forecast dashboard will be deployed at `fc.pentad.<base url>` and the decad dashboard at `fc.decad.<base url>`. You will have to configure your proxy manager and domain manager to forward port 5006 to `fc.pentad.<base url>` and port 5007 to `fc.decad.<base url>`.
 
 
 ## Deployment of demo version on a local machine
@@ -408,6 +434,119 @@ If the SAPPHIRE forecast tools need to access an iEasyHydro High Frequency (HF) 
 
 For the full step-by-step instructions with all commands, see the [Update Deployment Checklist — Section 1.2, Option B or C](prod/update_deployment_checklist.md#12-ieasyhydro-hf-connectivity-if-applicable).
 
+### SAPPHIRE services (API stack)
+
+The SAPPHIRE services are four FastAPI microservices (`preprocessing`,
+`postprocessing`, `user`, `auth`) fronted by an `api-gateway`, each backed
+by its own PostgreSQL database. They are orchestrated by
+`sapphire/docker-compose.yml` and hold the runoff, forecast, skill-metric,
+user, and authentication data that the pipeline and dashboards read and
+write through the gateway.
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `api-gateway` | 8000 | Routes requests to the backend services |
+| `preprocessing` | 8002 | Runoff, hydrograph, meteo, and snow data |
+| `postprocessing` | 8003 | Forecast results and skill metrics |
+| `user` | 8004 | User management |
+| `auth` | 8005 | Authentication and authorization |
+
+Each backend service has a dedicated PostgreSQL database exposed on a
+localhost-only port (5433–5436). Do not expose any of these ports to the
+internet.
+
+#### Starting the services
+
+Full configuration and operational notes are in
+[`sapphire/README.md`](../sapphire/README.md). In a deployment, the
+services read their configuration (database credentials, JWT secret,
+internal service URLs) from the same external `.env` file that the
+pipeline uses — not from `sapphire/.env`. The `sapphire/.env.example` file
+lists the required variables and is intended as a reference only.
+
+```bash
+# Variables to fill into your external <env_file> before starting the
+# services (see sapphire/.env.example for the full list):
+#   POSTGRES_USER=postgres
+#   POSTGRES_PASSWORD=<generate-strong-password>
+#   PREPROCESSING_DB=preprocessing_db
+#   POSTPROCESSING_DB=postprocessing_db
+#   USER_DB=user_db
+#   AUTH_DB=auth_db
+#   JWT_SECRET_KEY=<generate-strong-random-secret>
+#   PREPROCESSING_API_URL=http://preprocessing-api:8002
+#   POSTPROCESSING_API_URL=http://postprocessing-api:8003
+#   USER_API_URL=http://user-api:8004
+#   AUTH_API_URL=http://auth-api:8005
+
+# Start all services, passing the external env file explicitly
+cd /data/SAPPHIRE_Forecast_Tools/sapphire
+docker compose --env-file /absolute/path/to/<data_folder>/config/<env_file> up -d
+
+# Health check (expect 200 OK on both)
+curl http://localhost:8000/health
+curl http://localhost:8000/health/ready
+```
+
+Verify all containers are up with `docker ps --filter "name=sapphire"`
+before moving on.
+
+#### Populating historical data
+
+The preprocessing database must contain historical daily runoff going back
+multiple years before the pipeline can produce useful forecasts. There are
+two paths, depending on where your history lives.
+
+**Path A — migrate from existing CSV data.** Use this when you are
+migrating from a CSV-based SAPPHIRE deployment or restoring from backup.
+Run the data migrators from inside the service containers:
+
+```bash
+docker exec -it sapphire-preprocessing-api /bin/bash
+# Inside the container:
+python app/data_migrator.py --type runoff
+python app/data_migrator.py --type hydrograph
+python app/data_migrator.py --type meteo
+python app/data_migrator.py --type snow
+exit
+
+docker exec -it sapphire-postprocessing-api /bin/bash
+# Inside the container:
+python app/data_migrator.py --type skillmetric --batch-size 1
+python app/data_migrator.py --type lrforecast
+python app/data_migrator.py --type combinedforecast
+python app/data_migrator.py --type forecast
+```
+
+**Path B — initialize from Excel or iEasyHydro HF.** Use this for a
+greenfield deployment where historical data lives in Excel files under
+`daily_runoff/` and/or in an iEasyHydro HF database. The `initialize`
+target in `run_locally.sh` wraps the full first-time setup: it runs
+preprocessing in `maintenance` mode (re-reads Excel, detects gaps), pushes
+the full CSV history to the API via `initial_api_sync.py`, then runs the
+LR hindcast and skill-metric recalculation for both PENTAD and DECAD
+horizons. The hindcast start date is read from `ieasyhydroforecast_START_DATE`
+in your env file (a new required variable — the script exits with an
+error if it is missing).
+
+```bash
+# Set ieasyhydroforecast_START_DATE in your external env file first
+# (e.g., ieasyhydroforecast_START_DATE=2000-01-01 for a full hindcast).
+ieasyhydroforecast_env_file_path=/absolute/path/to/<data_folder>/config/<env_file> \
+  bash apps/run_locally.sh initialize
+```
+
+Note that `initialize` also populates the postprocessing database (LR
+forecasts and skill metrics), not just the preprocessing runoff history.
+For the full walkthrough of both paths and the mode semantics see
+[`doc/plans/deployment_new_hydromet_aws.md`](plans/deployment_new_hydromet_aws.md)
+Phase 4.3.
+
+For the first-time-deployment walkthrough see
+[`doc/plans/deployment_new_hydromet_aws.md`](plans/deployment_new_hydromet_aws.md).
+For updates to an existing deployment see
+[`doc/prod/update_deployment_checklist.md`](prod/update_deployment_checklist.md).
+
 ### Copy your data to the repository
 We recommend that you follow the folder structure of the repository. Please review the example data in the data folder to understand the folder structure and the data formats. You can copy your data to the data folder in the SAPPHIRE_Forecast_Tools folder or to any other location on your server.
 
@@ -427,23 +566,13 @@ Note that you might have to authenticate yourself with a password. You can also 
 To be described.
 
 ### Deploy the forecast tools
-We provide you with a shell script that pulls the latest images from Docker Hub and runs the containers. The script is located in the bin folder and run as follows from the SAPPHIRE_Forecast_Tools folder:
-```bash
-ieasyhydroforecast_url=<base url> bash ./bin/deploy_sapphire_forecast_tools.sh <absolute_path_to_data_directory>/config/.env_develop_kghm
-```
-The path to the data root folder is the parent directory of your data folder where you store your discharge, bulletin templates and other data.
-For deployment with sensitive data, we recommend a separate data folder which is located at the same hierarchical level as the SAPPHIRE_Forecast_Tools folder. In this case the path to the data root folder would be:
-```bash
-ieasyhydroforecast_url=<base url> bash .bin/run_sapphire_forecast_tools.sh /absolute/path/to/parent/directory/of/SAPPHIRE_Forecast_Tools
-```
+Follow the components in the sequence given by [Deployment order](#deployment-order): bring up the SAPPHIRE services, then the Luigi daemon, then the pipeline scripts, and finally the dashboards.
 
-Please note that the deployment script assumes that the pentad forecast dashboard will be deployed at fc.pentad.<base url> and the decad dashboard will be deployed at fc.decad.<base url>. You will have to configure your proxy manager and domain manager to forward port 5006 to fc.pentad.<base url> and port 5007 to fc.decad.<base url>. 
+For deployment with sensitive data, we recommend keeping a separate data folder at the same hierarchical level as the `SAPPHIRE_Forecast_Tools` folder. The data folder holds your discharge files, bulletin templates, and configuration files (including `<env_file>`). Paths passed to the pipeline scripts point into this data folder.
 
-For convenience sake you may want to run the forecast tools in the background and redirect the output to a log file. You can do this by running the following command:
-```bash
-nohup bash .bin/run_sapphire_forecast_tools.sh /absolute/path/to/SAPPHIRE_Forecast_Tools > logfile.log 2>&1 &
-```
-This will run the forecast tools in the background and redirect the output to a log file called logfile.log. The log file will be stored in the SAPPHIRE_Forecast_Tools folder.
+Detailed, step-by-step commands for first-time deployment (including `docker compose` invocations for the services and dashboards) are in [`doc/plans/deployment_new_hydromet_aws.md`](plans/deployment_new_hydromet_aws.md), Phases 4 and 8–9. For updates to an existing deployment, use [`doc/prod/update_deployment_checklist.md`](prod/update_deployment_checklist.md).
+
+The deployment assumes that the pentad forecast dashboard will be served at `fc.pentad.<base url>` and the decad dashboard at `fc.decad.<base url>`. You will have to configure your proxy manager and domain manager to forward port 5006 to `fc.pentad.<base url>` and port 5007 to `fc.decad.<base url>`.
 
 ### Accessing the outputs
 You should now be able to view the configuration dashboard in your browser under <your servers url> and the forecast dashboard under <your servers url>:5006/forecast_dashboard for pentadal or <your servers url>:5007/forecast_dashboard for decadal forecasts. You can trigger the writing of the forecast bulletins from the forecast dashboard.

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -617,7 +617,17 @@ The crontab below uses timestamped log files (e.g., `sapphire_gateway_20260116.l
 mkdir -p /home/ubuntu/logs
 ```
 
-Add the following to the crontab file. Adjust times for your timezone (example below uses UTC, with jobs running in the morning Bishkek time):
+Replace `<data_folder>` and `<env_file>` in the template below with the values for your deployment (for example, `my_data_forecast_tools` and `.env_develop`). The schedule is expressed in UTC; pick a row from the timezone reference table below and adapt the UTC hours in the crontab to the hours that best match your operational window (pentadal forecast usually runs in the morning local time, daily maintenance in the evening local time).
+
+| Country / City | UTC Offset | 03:00 UTC → local | 19:00 UTC → local |
+|----------------|-----------|-------------------|-------------------|
+| Kyrgyzstan / Bishkek | UTC+6 | 09:00 | 01:00 (+1 day) |
+| Tajikistan / Dushanbe | UTC+5 | 08:00 | 00:00 (+1 day) |
+| Uzbekistan / Tashkent | UTC+5 | 08:00 | 00:00 (+1 day) |
+| Nepal / Kathmandu | UTC+5:45 | 08:45 | 00:45 (+1 day) |
+| Switzerland / Zurich | UTC+1 (+2 DST) | 04:00 | 20:00 |
+
+Add the following to the crontab file:
 ```bash
 # m h  dom mon dow   command
 # ---------------------------------------------------------------------------
@@ -628,31 +638,31 @@ Add the following to the crontab file. Adjust times for your timezone (example b
 # Log cleanup: delete logs older than 7 days (runs daily at 02:00 UTC)
 0 2 * * * find /home/ubuntu/logs -name "sapphire_*.log" -mtime +7 -delete
 #
-# (1) Gateway Preprocessing at 03:00 UTC (09:00 Bishkek). Independent of daily data.
-0 3 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_preprocessing_gateway.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_gateway_$(date +\%Y\%m\%d).log 2>&1
+# (1) Gateway Preprocessing at 03:00 UTC. Independent of daily data.
+0 3 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_preprocessing_gateway.sh /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_gateway_$(date +\%Y\%m\%d).log 2>&1
 #
-# (2) Pentadal Forecast at 04:00 UTC (10:00 Bishkek). Luigi triggers runoff preprocessing.
-0 4 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_pentadal_forecasts.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_pentadal_$(date +\%Y\%m\%d).log 2>&1
+# (2) Pentadal Forecast at 04:00 UTC. Luigi triggers runoff preprocessing.
+0 4 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_pentadal_forecasts.sh /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_pentadal_$(date +\%Y\%m\%d).log 2>&1
 #
-# (3) Decadal Forecast at 05:00 UTC (11:00 Bishkek). Luigi uses completed runoff task.
-0 5 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_decadal_forecasts.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_decadal_$(date +\%Y\%m\%d).log 2>&1
+# (3) Decadal Forecast at 05:00 UTC. Luigi uses completed runoff task.
+0 5 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_decadal_forecasts.sh /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_decadal_$(date +\%Y\%m\%d).log 2>&1
 #
-# (4) Long-term Forecast at 06:00 UTC (12:00 Bishkek) on the 10th and 25th of each month.
+# (4) Long-term Forecast at 06:00 UTC on the 10th and 25th of each month.
 # The script self-gates via lt_schedule_query.py (±5 day tolerance on operational_issue_day).
-0 6 10,25 * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_long_term_forecasts.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_longterm_$(date +\%Y\%m\%d).log 2>&1
+0 6 10,25 * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_long_term_forecasts.sh /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_longterm_$(date +\%Y\%m\%d).log 2>&1
 #
-# (5) Daily maintenance via Luigi (replaces individual maintenance cron jobs)
+# (5) Daily maintenance via Luigi at 19:00 UTC (replaces individual maintenance cron jobs)
 # Luigi enforces dependency order: PrepRunoff + Gateway → LinReg → ML → PostProcessing → Frontend
 # ML concurrency is limited to 3 via Luigi resources.
-0 19 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_daily_maintenance.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_maintenance_$(date +\%Y\%m\%d).log 2>&1
+0 19 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_daily_maintenance.sh /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_maintenance_$(date +\%Y\%m\%d).log 2>&1
 #
 # (6) Periodic maintenance tasks (bimonthly/yearly)
-# Bimonthly long-term postprocessing (1st of odd months)
-0 22 1 1,3,5,7,9,11 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh long_term /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_periodic_longterm_$(date +\%Y\%m\%d).log 2>&1
-# Yearly skill recalculation (December 31)
-0 1 31 12 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_periodic_skillrecalc_$(date +\%Y\%m\%d).log 2>&1
-# Yearly snow norm recalculation (August 31)
-0 2 31 8 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_periodic_snownorms_$(date +\%Y\%m\%d).log 2>&1
+# Bimonthly long-term postprocessing at 22:00 UTC (1st of odd months)
+0 22 1 1,3,5,7,9,11 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh long_term /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_longterm_$(date +\%Y\%m\%d).log 2>&1
+# Yearly skill recalculation at 01:00 UTC on December 31
+0 1 31 12 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_skillrecalc_$(date +\%Y\%m\%d).log 2>&1
+# Yearly snow norm recalculation at 02:00 UTC on August 31
+0 2 31 8 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_snownorms_$(date +\%Y\%m\%d).log 2>&1
 ```
 To check if the cron jobs have been set up correctly, you can list them with `crontab -l`.
 

--- a/doc/operations/backup_restore.md
+++ b/doc/operations/backup_restore.md
@@ -1,0 +1,373 @@
+# SAPPHIRE Postgres Backup and Restore
+
+This guide is written for the hydromet sysadmin running SAPPHIRE on their
+own server. It covers how to take regular dumps of the four SAPPHIRE
+Postgres databases, store them safely, and restore from them when needed.
+
+---
+
+## 1. Why this matters
+
+SAPPHIRE stores all operational forecast data — runoff, meteo, skill
+metrics, forecast results, users — in Postgres. A single disk failure, a
+bad migration that corrupts a table, an accidental run of
+`bin/reset_sapphire_db.sh` (which destroys the DB volumes by design), or
+plain human error (`DROP TABLE`) will wipe that data permanently unless
+you have a recent backup. This document exists so every deployment has a
+turnkey way to take and restore backups without having to improvise.
+
+---
+
+## 2. What is and isn't backed up by this script
+
+**Backed up** by `bin/backup_sapphire_db.sh`:
+
+- Postgres database `preprocessing` (container `sapphire-preprocessing-db`)
+- Postgres database `postprocessing` (container `sapphire-postprocessing-db`)
+- Postgres database `user` (container `sapphire-user-db`)
+- Postgres database `auth` (container `sapphire-auth-db`)
+
+(The commented-out `task-db` in `sapphire/docker-compose.yml` is not
+covered — it is not in use.)
+
+**Not backed up** by this script — you must handle these separately:
+
+- The country-specific data directory (e.g. `<country>_data_forecast_tools/`)
+  containing CSV inputs, config, templates, intermediate data, reports.
+- Any `.env` files (`sapphire/.env`, app-level env files).
+- The `crontab` of the user running the pipeline.
+- Luigi daemon state (`/var/lib/luigi` or wherever `luigid` persists).
+- Docker images (rebuildable from the repo) and the `sapphire/` source tree
+  itself — use `git` for that.
+
+For the items above, a nightly `tar` to an off-site location is usually
+sufficient. For example:
+
+```bash
+tar czf /var/backups/sapphire/data_$(date +%F).tar.gz \
+    /path/to/<country>_data_forecast_tools \
+    /path/to/sapphire/.env
+```
+
+---
+
+## 3. Prerequisites
+
+- Docker is running and the SAPPHIRE DB containers
+  (`sapphire-preprocessing-db`, `sapphire-postprocessing-db`,
+  `sapphire-user-db`, `sapphire-auth-db`) are up.
+- `sapphire/.env` exists and contains `POSTGRES_USER`, `POSTGRES_PASSWORD`,
+  `PREPROCESSING_DB`, `POSTPROCESSING_DB`, `USER_DB`, `AUTH_DB`.
+- The backup directory (default `/var/backups/sapphire`) exists and is
+  writable by whichever user runs the script / cron job. Create it once:
+
+  ```bash
+  sudo mkdir -p /var/backups/sapphire
+  sudo chown "$USER" /var/backups/sapphire
+  ```
+
+- You run the script from the repository root (the parent of `sapphire/`).
+
+---
+
+## 4. Running a manual backup
+
+From the repo root:
+
+```bash
+bash bin/backup_sapphire_db.sh
+```
+
+Expected output (colours stripped):
+
+```
+========================================
+ SAPPHIRE Database Backup
+========================================
+[2026-04-17 02:00:01] Backup directory: /var/backups/sapphire
+[2026-04-17 02:00:01] Retention days:   30
+[2026-04-17 02:00:01] Backup start: db=<your-db-name> container=sapphire-preprocessing-db file=/var/backups/sapphire/<your-db-name>_2026-04-17_020001.dump
+[2026-04-17 02:00:42] Backup done: db=<your-db-name> file=/var/backups/sapphire/<your-db-name>_2026-04-17_020001.dump size=124.3MB
+... (three more DBs) ...
+[2026-04-17 02:03:15] Pruned 0 old dump(s).
+========================================
+ BACKUP SUMMARY
+========================================
+[2026-04-17 02:03:15] Succeeded: 4 (<preprocessing-db> <postprocessing-db> <user-db> <auth-db>)
+[2026-04-17 02:03:15] All four dumps succeeded and verified.
+```
+
+Inspect what was produced:
+
+```bash
+ls -lh /var/backups/sapphire/
+```
+
+You should see four files named `<db_name>_<YYYY-MM-DD_HHMMSS>.dump`,
+each non-empty. If any dump failed, you'll instead see a file with a
+`.FAILED` suffix — investigate before the next run.
+
+### 4.1 Useful flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `-d, --backup-dir PATH` | `/var/backups/sapphire` | Write dumps to a different location (e.g. a mounted external drive). |
+| `-r, --retention-days N` | `30` | Delete `.dump` files older than N days at the end of the run. `0` keeps everything. |
+| `--dry-run` | off | Log what would happen; run no `pg_dump` and delete nothing. |
+| `-h, --help` | — | Show usage. |
+
+### 4.2 Testing the script
+
+Before trusting it in cron, confirm it at least parses your environment:
+
+```bash
+bash bin/backup_sapphire_db.sh --dry-run
+```
+
+A dry run prints the `docker exec` and `find` commands it *would* run,
+without actually dumping anything. After that, run it for real once and
+inspect the first produced file:
+
+```bash
+bash bin/backup_sapphire_db.sh
+ls -lh /var/backups/sapphire/
+```
+
+To sanity-check one of the dumps manually:
+
+```bash
+docker exec -i sapphire-preprocessing-db \
+    pg_restore --list /dev/stdin \
+    < /var/backups/sapphire/<your-db-name>_2026-04-17_020001.dump \
+    | head -20
+```
+
+You should see a list of tables, sequences and indexes. If the output is
+empty or `pg_restore` errors, the file is not a valid archive.
+
+---
+
+## 5. Scheduling daily backups with cron
+
+Run as the user that owns the backup directory (NOT as root, unless the
+directory is root-owned). Edit the crontab with `crontab -e` and add:
+
+```cron
+# SAPPHIRE nightly DB backup at 02:00 local time
+0 2 * * * cd /home/ubuntu/SAPPHIRE_forecast_tools && /bin/bash bin/backup_sapphire_db.sh >> /home/ubuntu/logs/sapphire_backup.log 2>&1
+```
+
+Create the log directory once:
+
+```bash
+mkdir -p /home/ubuntu/logs
+```
+
+After a week, glance at the log and `/var/backups/sapphire/` to confirm
+dumps are arriving and rotating.
+
+---
+
+## 6. Retention recommendation
+
+- **On-server default**: 30 days of daily dumps. The script's default
+  `--retention-days 30` handles this automatically.
+- **Off-site copy**: at least weekly, to something that is *not* the same
+  server. Pick one of the options below based on what your hydromet has
+  available.
+
+Off-site options (pick one — the choice is yours):
+
+**Option A — `rsync` to another server over SSH** (common when the
+hydromet has a secondary machine):
+
+```bash
+# Weekly (Sundays 03:00)
+0 3 * * 0 rsync -az --delete /var/backups/sapphire/ backupuser@backup-host:/srv/sapphire_backups/
+```
+
+**Option B — `aws s3 sync` to an S3 bucket** (for deployments with cloud
+access):
+
+```bash
+# Weekly (Sundays 03:00)
+0 3 * * 0 aws s3 sync /var/backups/sapphire/ s3://<your-bucket>/sapphire/ --delete
+```
+
+Configure `~/.aws/credentials` for the user running cron, and restrict
+the IAM policy to `PutObject`/`DeleteObject` on that bucket prefix.
+
+**Option C — physical external drive** (air-gapped deployments). Mount
+the drive monthly, `rsync -a /var/backups/sapphire/ /mnt/usb/`,
+unmount, store the drive off-site. Document the rotation schedule in
+your local runbook.
+
+Whichever option you choose, verify at least once that a file copied
+off-site is readable and restorable on a different machine. Untested
+backups are not backups.
+
+---
+
+## 7. Restoring from a backup
+
+Restore is a destructive operation on the target database. Read the whole
+section before running any command, and keep a copy of the current dump
+in a safe place first.
+
+The four databases are independent — you can restore one without
+touching the others. Replace `<your-db-name>` with the actual database
+name from `sapphire/.env`, and `<timestamp>` with the dump file you
+chose.
+
+### 7.1 Stop the service that talks to the target DB
+
+| Target DB | Service to stop | Command |
+|-----------|-----------------|---------|
+| preprocessing | `preprocessing-api` | `docker compose -f sapphire/docker-compose.yml stop preprocessing-api` |
+| postprocessing | `postprocessing-api` | `docker compose -f sapphire/docker-compose.yml stop postprocessing-api` |
+| user | `user-api` and `auth-api` | `docker compose -f sapphire/docker-compose.yml stop user-api auth-api` |
+| auth | `auth-api` | `docker compose -f sapphire/docker-compose.yml stop auth-api` |
+
+The DB container itself stays up — `pg_restore` needs to connect to it.
+
+### 7.2 Drop and recreate the target DB
+
+`pg_restore` expects an empty target. The cleanest way is to drop the DB
+and recreate it:
+
+```bash
+# Read the Postgres credentials and DB names from the .env so you don't
+# hand-type the password. Replace with the var name of the DB you are
+# restoring: PREPROCESSING_DB, POSTPROCESSING_DB, USER_DB, or AUTH_DB.
+set -a; source sapphire/.env; set +a
+
+# Example: restoring the preprocessing DB
+CONTAINER=sapphire-preprocessing-db
+TARGET_DB="${PREPROCESSING_DB}"
+
+docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${CONTAINER}" \
+    psql -U "${POSTGRES_USER}" -d postgres \
+    -c "DROP DATABASE IF EXISTS \"${TARGET_DB}\";"
+
+docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${CONTAINER}" \
+    psql -U "${POSTGRES_USER}" -d postgres \
+    -c "CREATE DATABASE \"${TARGET_DB}\" OWNER \"${POSTGRES_USER}\";"
+```
+
+If the `DROP DATABASE` fails with "database is being accessed by other
+users", make sure you stopped the service in step 7.1, then retry.
+
+### 7.3 Restore from the `.dump` file
+
+```bash
+DUMP_FILE=/var/backups/sapphire/<your-db-name>_<timestamp>.dump
+
+docker exec -i -e PGPASSWORD="${POSTGRES_PASSWORD}" "${CONTAINER}" \
+    pg_restore -U "${POSTGRES_USER}" -d "${TARGET_DB}" \
+    --no-owner --no-privileges \
+    < "${DUMP_FILE}"
+```
+
+`--no-owner --no-privileges` makes restore tolerant of differences
+between the dump's original role/privileges and the target cluster —
+harmless here since all four DBs are owned by the same Postgres user.
+
+Expect a handful of warnings about extensions (`plpgsql`) or comments;
+they are safe to ignore. A real failure shows as a non-zero exit status
+with an error line.
+
+### 7.4 Restart services and verify health
+
+```bash
+docker compose -f sapphire/docker-compose.yml up -d
+curl -sf http://localhost:8000/health && echo OK
+curl -sf http://localhost:8000/health/ready && echo READY
+```
+
+Then spot-check an API endpoint that reads from the restored DB, e.g.:
+
+```bash
+# Preprocessing: list a handful of runoff records
+curl -s "http://localhost:8000/api/preprocessing/runoff/?limit=1" | head
+
+# Postprocessing: list a skill metric
+curl -s "http://localhost:8000/api/postprocessing/skill-metric/?limit=1" | head
+```
+
+If the dashboard is running, load the forecast page and confirm data
+appears for a known station (e.g. `19999`).
+
+---
+
+## 8. Quarterly restore drill
+
+Backups that have never been restored cannot be trusted. Every quarter
+(pick a date, put it in your calendar), do the following. Total time:
+about 15 minutes.
+
+1. Copy the latest successful dump to a scratch location.
+2. Create a scratch DB in the same container and restore into it, e.g.:
+
+   ```bash
+   # Preprocessing example — use a throwaway DB name
+   SCRATCH=preprocessing_restore_test
+   docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" sapphire-preprocessing-db \
+       psql -U "${POSTGRES_USER}" -d postgres -c "CREATE DATABASE ${SCRATCH};"
+   docker exec -i -e PGPASSWORD="${POSTGRES_PASSWORD}" sapphire-preprocessing-db \
+       pg_restore -U "${POSTGRES_USER}" -d "${SCRATCH}" --no-owner --no-privileges \
+       < /var/backups/sapphire/<your-db-name>_<timestamp>.dump
+   ```
+
+3. Compare a row count between scratch and production for one or two
+   tables you care about:
+
+   ```bash
+   docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" sapphire-preprocessing-db \
+       psql -U "${POSTGRES_USER}" -d "${SCRATCH}" -c "SELECT count(*) FROM runoff;"
+   docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" sapphire-preprocessing-db \
+       psql -U "${POSTGRES_USER}" -d "${PREPROCESSING_DB}" -c "SELECT count(*) FROM runoff;"
+   ```
+
+4. Drop the scratch DB:
+
+   ```bash
+   docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" sapphire-preprocessing-db \
+       psql -U "${POSTGRES_USER}" -d postgres -c "DROP DATABASE ${SCRATCH};"
+   ```
+
+If row counts differ wildly or the restore errors, investigate before
+the next scheduled drill — your backup strategy has a hole.
+
+---
+
+## 9. Known limitations
+
+- **Point-in-time consistency across the four DBs is not guaranteed.**
+  The script dumps each database sequentially without stopping the
+  services. Writes that happen during the ~minute-long dump window may
+  leave a small amount of drift between, say, a forecast row in
+  `postprocessing` and the runoff row in `preprocessing` it was
+  computed from. For routine operational use this is acceptable —
+  SAPPHIRE writes are infrequent and idempotent, and a rerun of the
+  affected pipeline step fills any gap.
+
+- **If you need stronger guarantees**, stop the API services for the
+  ~1 minute the dump takes:
+
+  ```bash
+  docker compose -f sapphire/docker-compose.yml stop \
+      preprocessing-api postprocessing-api user-api auth-api
+  bash bin/backup_sapphire_db.sh
+  docker compose -f sapphire/docker-compose.yml start \
+      preprocessing-api postprocessing-api user-api auth-api
+  ```
+
+  *Future work:* a `--stop-services` flag on the backup script that
+  orchestrates the above automatically. Not implemented today — file an
+  issue if you want it.
+
+- **Dumps are not encrypted at rest.** If the server or the off-site
+  destination is in an environment where Postgres data needs to be
+  encrypted, either encrypt the backup directory (LUKS on Linux) or
+  pipe the dump through `gpg` before writing it. That is out of scope
+  for the current script.

--- a/doc/plans/deployment_new_hydromet_aws.md
+++ b/doc/plans/deployment_new_hydromet_aws.md
@@ -745,7 +745,7 @@ Practical steps (not yet documented):
 | DOC-GAP-8 | Path convention explanation buried | Low | `doc/configuration.md` |
 | DOC-GAP-9 | ~~**Deployment order not documented**~~ | **High** | ✅ Fixed (`doc/deployment.md`) |
 | DOC-GAP-10 | No reverse proxy / HTTPS instructions | Medium | `doc/deployment.md` |
-| DOC-GAP-11 | Crontab template is deployment-specific | Low | `doc/deployment.md` |
+| ~~DOC-GAP-11~~ | ~~Crontab template is deployment-specific~~ | ~~Low~~ | ✅ Fixed (crontab placeholders + TZ reference table in deployment.md) |
 | DOC-GAP-12 | Testing section outdated | Low | `doc/deployment.md` |
 | ~~DOC-GAP-13~~ | ~~**Deprecated `deploy_sapphire_forecast_tools.sh` still recommended in `doc/deployment.md`**~~ | ~~**Medium**~~ | ✅ Fixed (deprecated-script references removed from deployment.md) |
 
@@ -794,6 +794,7 @@ Changes already applied to the docs as part of deployment preparation.
 | DOC-GAP-3 + DOC-GAP-9 | Added "Deployment order" and "SAPPHIRE services (API stack)" sections to doc/deployment.md | <branch> |
 | DOC-GAP-5 | Added `initialize` target (see review_gi_draft_infra_new_deployment_initialization.md) + Phase 4.3 updated in this plan | <branch> |
 | DOC-GAP-13 | Removed deprecated deploy_sapphire_forecast_tools.sh / run_sapphire_forecast_tools.sh references from doc/deployment.md | <branch> |
+| DOC-GAP-11 | Generalised crontab in doc/deployment.md (placeholders + timezone reference table) | <branch> |
 
 ---
 

--- a/doc/plans/deployment_new_hydromet_aws.md
+++ b/doc/plans/deployment_new_hydromet_aws.md
@@ -744,7 +744,7 @@ Practical steps (not yet documented):
 | ~~DOC-GAP-5~~ | ~~**No "fresh deployment" path for services — DB init required**~~ | ~~**High**~~ | ✅ Fixed (initialize target implemented; Phase 4.3 updated) |
 | ~~DOC-GAP-6~~ | ~~**No minimal .env variable reference**~~ | ~~**High**~~ | ✅ Fixed (`.env variable reference` section added to `doc/configuration.md`) |
 | ~~DOC-GAP-7~~ | ~~iEasyHydro HF SDK vars undocumented~~ | ~~Medium~~ | ✅ Fixed (covered in `doc/configuration.md` reference table + Add-ons) |
-| DOC-GAP-8 | Path convention explanation buried | Low | `doc/configuration.md` |
+| ~~DOC-GAP-8~~ | ~~Path convention explanation buried~~ | ~~Low~~ | ✅ Fixed (tree diagram + worked example added to `doc/configuration.md`) |
 | DOC-GAP-9 | ~~**Deployment order not documented**~~ | **High** | ✅ Fixed (`doc/deployment.md`) |
 | DOC-GAP-10 | No reverse proxy / HTTPS instructions | Medium | `doc/deployment.md` |
 | ~~DOC-GAP-11~~ | ~~Crontab template is deployment-specific~~ | ~~Low~~ | ✅ Fixed (crontab placeholders + TZ reference table in deployment.md) |
@@ -800,6 +800,7 @@ Changes already applied to the docs as part of deployment preparation.
 | DOC-GAP-11 | Generalised crontab in doc/deployment.md (placeholders + timezone reference table) | <branch> |
 | DOC-GAP-6 | Added categorised `.env variable reference` with minimal deployment profile to doc/configuration.md | <branch> |
 | DOC-GAP-7 | iEasyHydro HF SDK variables now documented in doc/configuration.md reference table and Add-ons section | <branch> |
+| DOC-GAP-8 | Added directory-tree diagram and worked example for the `../../../<data_folder>/` path convention in doc/configuration.md | <branch> |
 
 ---
 

--- a/doc/plans/deployment_new_hydromet_aws.md
+++ b/doc/plans/deployment_new_hydromet_aws.md
@@ -608,8 +608,10 @@ Practical steps (not yet documented):
   # The script self-gates via lt_schedule_query.py (±5 day tolerance on operational_issue_day).
   0 6 10,25 * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_long_term_forecasts.sh /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_longterm_$(date +\%Y\%m\%d).log 2>&1
 
-  # (5) Daily maintenance (evening UTC)
-  0 14 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_daily_maintenance.sh /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_maintenance_$(date +\%Y\%m\%d).log 2>&1
+  # (5) Daily maintenance via Luigi at 19:00 UTC (replaces individual maintenance cron jobs)
+  # Luigi enforces dependency order: PrepRunoff + Gateway → LinReg → ML → PostProcessing → Frontend
+  # ML concurrency is limited to 3 via Luigi resources.
+  0 19 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_daily_maintenance.sh /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_maintenance_$(date +\%Y\%m\%d).log 2>&1
 
   # (6) Periodic maintenance
   # Bimonthly long-term postprocessing (1st of odd months)
@@ -740,8 +742,8 @@ Practical steps (not yet documented):
 | DOC-GAP-3 | ~~**SAPPHIRE services missing from deployment.md entirely**~~ | **Critical** | ✅ Fixed (`doc/deployment.md` new section) |
 | ~~DOC-GAP-4~~ | ~~No guidance on sapphire/.env values~~ | ~~Medium~~ | ✅ Fixed (sapphire/.env.example commented + sapphire/README.md Environment setup expanded) |
 | ~~DOC-GAP-5~~ | ~~**No "fresh deployment" path for services — DB init required**~~ | ~~**High**~~ | ✅ Fixed (initialize target implemented; Phase 4.3 updated) |
-| DOC-GAP-6 | **No minimal .env variable reference** | **High** | `doc/configuration.md` |
-| DOC-GAP-7 | iEasyHydro HF SDK vars undocumented | Medium | `doc/configuration.md` |
+| ~~DOC-GAP-6~~ | ~~**No minimal .env variable reference**~~ | ~~**High**~~ | ✅ Fixed (`.env variable reference` section added to `doc/configuration.md`) |
+| ~~DOC-GAP-7~~ | ~~iEasyHydro HF SDK vars undocumented~~ | ~~Medium~~ | ✅ Fixed (covered in `doc/configuration.md` reference table + Add-ons) |
 | DOC-GAP-8 | Path convention explanation buried | Low | `doc/configuration.md` |
 | DOC-GAP-9 | ~~**Deployment order not documented**~~ | **High** | ✅ Fixed (`doc/deployment.md`) |
 | DOC-GAP-10 | No reverse proxy / HTTPS instructions | Medium | `doc/deployment.md` |
@@ -796,6 +798,8 @@ Changes already applied to the docs as part of deployment preparation.
 | DOC-GAP-5 | Added `initialize` target (see review_gi_draft_infra_new_deployment_initialization.md) + Phase 4.3 updated in this plan | <branch> |
 | DOC-GAP-13 | Removed deprecated deploy_sapphire_forecast_tools.sh / run_sapphire_forecast_tools.sh references from doc/deployment.md | <branch> |
 | DOC-GAP-11 | Generalised crontab in doc/deployment.md (placeholders + timezone reference table) | <branch> |
+| DOC-GAP-6 | Added categorised `.env variable reference` with minimal deployment profile to doc/configuration.md | <branch> |
+| DOC-GAP-7 | iEasyHydro HF SDK variables now documented in doc/configuration.md reference table and Add-ons section | <branch> |
 
 ---
 

--- a/doc/plans/deployment_new_hydromet_aws.md
+++ b/doc/plans/deployment_new_hydromet_aws.md
@@ -246,28 +246,59 @@ python app/data_migrator.py --type forecast
 python app/data_migrator.py --type longforecast
 ```
 
-**Path B — Initial sync mode (pipeline reads from Excel/iEH HF, writes all
-to API):**
+**Path B — `initialize` target (fresh deployment: Excel/iEH HF → API →
+hindcast → skill metrics):**
 
 Use this for a fresh deployment where historical data lives in Excel files
-in `daily_runoff/` and/or in the iEasyHydro HF database. This runs the
-normal preprocessing pipeline but writes ALL records to the API instead of
-only today's.
+in `daily_runoff/` and/or in the iEasyHydro HF database. The `initialize`
+target in `apps/run_locally.sh` wraps the full first-time sequence in a
+single command (added per the reviewed issue
+`doc/plans/issues/review_gi_draft_infra_new_deployment_initialization.md`):
+
+1. **Preprocessing (maintenance fetch)** — re-reads Excel files and
+   detects gaps. `operational` mode would only fetch today, so
+   `maintenance` is required for a cold start.
+2. **`initial_api_sync.py`** — pushes the full CSV history to the
+   preprocessing API. This sets `SAPPHIRE_SYNC_MODE=initial` internally
+   so every record is written, not just today's.
+3. **LR hindcast (PENTAD + DECAD)** — runs `linear_regression.py
+   --hindcast --start-date $ieasyhydroforecast_START_DATE` for each
+   horizon. Populates the postprocessing database with historical
+   forecasts used by the skill-metric calculation.
+4. **Skill metrics (PENTAD + DECAD)** — runs
+   `recalculate_skill_metrics.py` for each horizon.
 
 ```bash
-SAPPHIRE_SYNC_MODE=initial \
-  ieasyhydroforecast_env_file_path=/data/<data_folder>/config/<env_file> \
-  bash apps/run_locally.sh preprocessing_runoff
+# ieasyhydroforecast_START_DATE is a new REQUIRED env variable for the
+# initialize path (per R7 in the reviewed issue). Set it in your external
+# env file first, e.g. ieasyhydroforecast_START_DATE=2000-01-01 for a
+# full hindcast. If it is missing, `run_locally.sh initialize` exits
+# with an error.
+ieasyhydroforecast_env_file_path=/data/<data_folder>/config/<env_file> \
+  bash apps/run_locally.sh initialize
 ```
 
-After initial sync, switch back to operational mode (the default) for daily
-runs. The `initial` mode is supported by `preprocessing_runoff`,
-`preprocessing_gateway`, and `linear_regression` — each module's
-`_write_*_to_api()` functions check `SAPPHIRE_SYNC_MODE` to decide how much
-data to write:
+After initialization completes, daily runs use the normal targets
+(`short-term`, `long-term`, `daily`, `maintenance`, etc.) which default
+to `operational` mode.
+
+For reference, `SAPPHIRE_SYNC_MODE` is the internal mechanism that the
+`_write_*_to_api()` functions in `preprocessing_runoff`,
+`preprocessing_gateway`, and `linear_regression` check to decide how much
+data to push on each run:
 - `operational` (default): today only
 - `maintenance`: last 30 days
 - `initial`: all data
+
+`run_locally.sh initialize` sets `SAPPHIRE_SYNC_MODE=initial` internally
+for the `initial_api_sync.py` step; you should not need to set it
+manually at the command line. Note in particular that setting
+`SAPPHIRE_SYNC_MODE=initial` on a plain `preprocessing_runoff` run does
+**not** work as a substitute — `get_runoff_data_for_sites_HF` only
+recognises `operational` and `maintenance` as fetch modes (see
+`apps/preprocessing_runoff/src/src.py:3520-3524`), so the fetch is
+demoted to `operational` (today only) even though the API write would
+try to send "all data" that was never fetched.
 
 > `[DOC-GAP-5]` **No "fresh deployment" path for SAPPHIRE services.**
 > The migration docs assume you have existing CSV data. For a brand-new
@@ -706,16 +737,17 @@ Practical steps (not yet documented):
 |----|-----|----------|--------------|
 | ~~DOC-GAP-1~~ | ~~SAPPHIRE services ports not in deployment.md~~ | ~~Low~~ | ✅ Fixed |
 | DOC-GAP-2 | No locale/translation setup instructions | Medium | `doc/configuration.md` |
-| DOC-GAP-3 | **SAPPHIRE services missing from deployment.md entirely** | **Critical** | `doc/deployment.md` new section |
+| DOC-GAP-3 | ~~**SAPPHIRE services missing from deployment.md entirely**~~ | **Critical** | ✅ Fixed (`doc/deployment.md` new section) |
 | DOC-GAP-4 | No guidance on sapphire/.env values | Medium | `sapphire/.env.example` + `sapphire/README.md` |
-| DOC-GAP-5 | **No "fresh deployment" path for services — DB init required** | **High** | Phase 4.3 updated; issue `mid_prio_gi_draft_infra_initial_sync_docs.md` |
+| ~~DOC-GAP-5~~ | ~~**No "fresh deployment" path for services — DB init required**~~ | ~~**High**~~ | ✅ Fixed (initialize target implemented; Phase 4.3 updated) |
 | DOC-GAP-6 | **No minimal .env variable reference** | **High** | `doc/configuration.md` |
 | DOC-GAP-7 | iEasyHydro HF SDK vars undocumented | Medium | `doc/configuration.md` |
 | DOC-GAP-8 | Path convention explanation buried | Low | `doc/configuration.md` |
-| DOC-GAP-9 | **Deployment order not documented** | **High** | `doc/deployment.md` |
+| DOC-GAP-9 | ~~**Deployment order not documented**~~ | **High** | ✅ Fixed (`doc/deployment.md`) |
 | DOC-GAP-10 | No reverse proxy / HTTPS instructions | Medium | `doc/deployment.md` |
 | DOC-GAP-11 | Crontab template is deployment-specific | Low | `doc/deployment.md` |
 | DOC-GAP-12 | Testing section outdated | Low | `doc/deployment.md` |
+| ~~DOC-GAP-13~~ | ~~**Deprecated `deploy_sapphire_forecast_tools.sh` still recommended in `doc/deployment.md`**~~ | ~~**Medium**~~ | ✅ Fixed (deprecated-script references removed from deployment.md) |
 
 ### Priority for pre-deployment fixes
 
@@ -759,6 +791,9 @@ Changes already applied to the docs as part of deployment preparation.
 | ID | What was done | Commit / branch |
 |----|---------------|-----------------|
 | DOC-GAP-1 | Added structured port table with SAPPHIRE services ports and security guidance to `doc/deployment.md` > "Configuring your server" | `develop_long_term_fix_api_postprocessing_forecasts` |
+| DOC-GAP-3 + DOC-GAP-9 | Added "Deployment order" and "SAPPHIRE services (API stack)" sections to doc/deployment.md | <branch> |
+| DOC-GAP-5 | Added `initialize` target (see review_gi_draft_infra_new_deployment_initialization.md) + Phase 4.3 updated in this plan | <branch> |
+| DOC-GAP-13 | Removed deprecated deploy_sapphire_forecast_tools.sh / run_sapphire_forecast_tools.sh references from doc/deployment.md | <branch> |
 
 ---
 

--- a/doc/plans/deployment_new_hydromet_aws.md
+++ b/doc/plans/deployment_new_hydromet_aws.md
@@ -738,7 +738,7 @@ Practical steps (not yet documented):
 | ~~DOC-GAP-1~~ | ~~SAPPHIRE services ports not in deployment.md~~ | ~~Low~~ | ✅ Fixed |
 | DOC-GAP-2 | No locale/translation setup instructions | Medium | `doc/configuration.md` |
 | DOC-GAP-3 | ~~**SAPPHIRE services missing from deployment.md entirely**~~ | **Critical** | ✅ Fixed (`doc/deployment.md` new section) |
-| DOC-GAP-4 | No guidance on sapphire/.env values | Medium | `sapphire/.env.example` + `sapphire/README.md` |
+| ~~DOC-GAP-4~~ | ~~No guidance on sapphire/.env values~~ | ~~Medium~~ | ✅ Fixed (sapphire/.env.example commented + sapphire/README.md Environment setup expanded) |
 | ~~DOC-GAP-5~~ | ~~**No "fresh deployment" path for services — DB init required**~~ | ~~**High**~~ | ✅ Fixed (initialize target implemented; Phase 4.3 updated) |
 | DOC-GAP-6 | **No minimal .env variable reference** | **High** | `doc/configuration.md` |
 | DOC-GAP-7 | iEasyHydro HF SDK vars undocumented | Medium | `doc/configuration.md` |
@@ -792,6 +792,7 @@ Changes already applied to the docs as part of deployment preparation.
 |----|---------------|-----------------|
 | DOC-GAP-1 | Added structured port table with SAPPHIRE services ports and security guidance to `doc/deployment.md` > "Configuring your server" | `develop_long_term_fix_api_postprocessing_forecasts` |
 | DOC-GAP-3 + DOC-GAP-9 | Added "Deployment order" and "SAPPHIRE services (API stack)" sections to doc/deployment.md | <branch> |
+| DOC-GAP-4 | Added inline comments and placeholder values to sapphire/.env.example; expanded sapphire/README.md Environment setup section with per-group guidance | <branch> |
 | DOC-GAP-5 | Added `initialize` target (see review_gi_draft_infra_new_deployment_initialization.md) + Phase 4.3 updated in this plan | <branch> |
 | DOC-GAP-13 | Removed deprecated deploy_sapphire_forecast_tools.sh / run_sapphire_forecast_tools.sh references from doc/deployment.md | <branch> |
 | DOC-GAP-11 | Generalised crontab in doc/deployment.md (placeholders + timezone reference table) | <branch> |

--- a/sapphire/.env.example
+++ b/sapphire/.env.example
@@ -1,27 +1,35 @@
 # ============== POSTGRES CREDENTIALS ==============
-POSTGRES_USER=
-POSTGRES_PASSWORD=
+# Credentials for all four service databases (preprocessing, postprocessing, user, auth).
+POSTGRES_USER=postgres
+# Strong password. Generate with: openssl rand -base64 24
+POSTGRES_PASSWORD=<generate-strong-password>
 
 # ============== DATABASE NAMES ==============
-PREPROCESSING_DB=
-POSTPROCESSING_DB=
-USER_DB=
-AUTH_DB=
+# Conventional names — match the psql examples in sapphire/README.md.
+PREPROCESSING_DB=preprocessing_db
+POSTPROCESSING_DB=postprocessing_db
+USER_DB=user_db
+AUTH_DB=auth_db
 
 # ============== DATABASE URLS (used by services) ==============
+# Composed from the values above; normally no edit required.
 PREPROCESSING_DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@preprocessing-db:5432/${PREPROCESSING_DB}
 POSTPROCESSING_DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postprocessing-db:5432/${POSTPROCESSING_DB}
 USER_DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@user-db:5432/${USER_DB}
 AUTH_DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@auth-db:5432/${AUTH_DB}
 
 # ============== SERVICE URLS ==============
-PREPROCESSING_API_URL=
-POSTPROCESSING_API_URL=
-USER_API_URL=
-AUTH_API_URL=
+# Inter-service URLs on the sapphire-network Docker bridge — NOT localhost.
+# Bare-metal deployments (services running outside Docker) would use http://localhost:<port>.
+PREPROCESSING_API_URL=http://preprocessing-api:8002
+POSTPROCESSING_API_URL=http://postprocessing-api:8003
+USER_API_URL=http://user-api:8004
+AUTH_API_URL=http://auth-api:8005
 
 # ============== AUTH / JWT ==============
-JWT_SECRET_KEY=change-this-to-a-strong-random-secret
+# Generate once per deployment: openssl rand -hex 32
+# Rotating this value invalidates all outstanding access and refresh tokens.
+JWT_SECRET_KEY=<generate-strong-random-secret>
 JWT_ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 REFRESH_TOKEN_EXPIRE_DAYS=7
@@ -29,14 +37,18 @@ REFRESH_TOKEN_EXPIRE_DAYS=7
 # ============== API GATEWAY ==============
 REQUEST_TIMEOUT=30
 HEALTH_CHECK_TIMEOUT=5
+# Enabling API_KEY_ENABLED requires setting API_KEY to a strong random string.
 API_KEY_ENABLED=false
 API_KEY=your-secret-api-key
+# RATE_LIMIT is in requests per minute per client IP.
 RATE_LIMIT_ENABLED=false
 RATE_LIMIT=100
 
 # ============== SHARED SERVICE CONFIG ==============
 LOG_LEVEL=INFO
 BATCH_SIZE=1000
+# Host-side mount target for CSV data used by the data-migration scripts.
+# Format: /absolute/path/to/<data_folder>/daily_runoff. Leave blank if not running migrators.
 CSV_FOLDER=
 
 # ============== INITIALIZATION (run_locally.sh initialize) ==============
@@ -45,6 +57,10 @@ CSV_FOLDER=
 # ieasyhydroforecast_START_DATE=2000-01-06
 
 # ============== DATA PATHS ==============
+# HOST-side paths bind-mounted into the preprocessing-api and postprocessing-api
+# containers at /intermediate_data and /config respectively.
+# Format: /absolute/path (e.g. /data/<data_folder>/intermediate_data).
 INTERMEDIATE_DATA_PATH=
 CONFIG_PATH=
+# CONTAINER-side path for the config mount. Normally should not be changed.
 CONFIG_FOLDER=/config

--- a/sapphire/README.md
+++ b/sapphire/README.md
@@ -47,6 +47,30 @@ Two options:
 
 The `sapphire/.env` file is gitignored — each developer maintains their own copy.
 
+#### What to set
+
+The `.env.example` file is organised into nine groups. Below is an operator-oriented walkthrough; the inline comments in `.env.example` give short reminders, this section gives the "why".
+
+**Postgres credentials** — `POSTGRES_USER`, `POSTGRES_PASSWORD`. The compose stack uses a single pair of credentials for all four service databases. Keep `POSTGRES_USER=postgres` (the conventional default the psql examples below assume) and generate a strong password with `openssl rand -base64 24`. Do not commit the resulting value.
+
+**Database names** — `PREPROCESSING_DB`, `POSTPROCESSING_DB`, `USER_DB`, `AUTH_DB`. Conventional names (`preprocessing_db`, `postprocessing_db`, `user_db`, `auth_db`) match the `docker exec ... psql -d <db>` examples later in this README. Change them only if you have a specific reason.
+
+**Database URLs** — `PREPROCESSING_DATABASE_URL` and friends. These are pre-wired via variable interpolation against the values above, so operators normally do not edit them. Important caveat: Postgres only applies `POSTGRES_PASSWORD` the **first** time a database volume is initialised. If you edit `.env` to change credentials after services have booted, you must drop the DB volumes (`docker compose down -v`) before the new password takes effect.
+
+**Service URLs** — `PREPROCESSING_API_URL` etc. These are the inter-service URLs on the `sapphire-network` Docker bridge (`http://preprocessing-api:8002` and friends), not `localhost`. Most operators keep the Docker defaults. Only change them if you are running one of the services on bare metal outside the compose stack, in which case use `http://localhost:<port>`.
+
+**Auth / JWT** — `JWT_SECRET_KEY`, `JWT_ALGORITHM`, `ACCESS_TOKEN_EXPIRE_MINUTES`, `REFRESH_TOKEN_EXPIRE_DAYS`. Generate the secret once per deployment with `openssl rand -hex 32` and store it safely — rotating it invalidates every outstanding access and refresh token, forcing all users and service clients to re-authenticate. The algorithm (`HS256`) and token lifetimes (30-minute access, 7-day refresh) have sensible defaults and rarely need tuning.
+
+**API gateway** — `REQUEST_TIMEOUT`, `HEALTH_CHECK_TIMEOUT`, `API_KEY_ENABLED`, `API_KEY`, `RATE_LIMIT_ENABLED`, `RATE_LIMIT`. The two optional features (API-key gating and rate limiting) are off by default and reasonable to enable in production-facing deployments. Rate limit is expressed as requests per minute per client IP. Enabling `API_KEY_ENABLED` requires setting `API_KEY` to a strong random string and distributing it to every client of the gateway.
+
+**Shared service config** — `LOG_LEVEL`, `BATCH_SIZE`, `CSV_FOLDER`. `LOG_LEVEL` defaults to `INFO`; bump to `DEBUG` when troubleshooting. `BATCH_SIZE` controls default chunk size for the API migration scripts. `CSV_FOLDER` is the host-side mount target for the CSV data used by the `data_migrator.py` scripts — leave it blank for deployments that do not run the migrators.
+
+**Initialization** — `ieasyhydroforecast_START_DATE` is used **only** by the one-time `run_locally.sh initialize` path for first-time deployment. For standard operational runs it is unused. See [`doc/plans/deployment_new_hydromet_aws.md`](../doc/plans/deployment_new_hydromet_aws.md) Phase 4.3 for the initialization workflow.
+
+**Data paths** — `INTERMEDIATE_DATA_PATH`, `CONFIG_PATH`, `CONFIG_FOLDER`. The first two are **host-side** absolute paths that get bind-mounted into the `preprocessing-api` and `postprocessing-api` containers at `/intermediate_data` and `/config` respectively. `CONFIG_FOLDER=/config` is the **container-side** path of that mount and should normally be left unchanged.
+
+For a categorised variable reference (which variables are required, conditional, or optional) across the pipeline AND services, see [`doc/configuration.md`](../doc/configuration.md) under `.env variable reference`. For a minimal deployment profile, see the same section.
+
 ### Start all services
 
 ```bash


### PR DESCRIPTION
## Summary

- **Fix ML API read timeout in `add_new_station.py`**: Switch from unfiltered full-table API reads to per-code reads (matching `fill_ml_gaps.py` pattern). Add `timeout` parameter to `_read_ml_forecasts_from_api()` for defense-in-depth. No date filter applied so stale stations are still found and not re-hindcasted daily.

- **Add scoped skill metric recalculation to dashboard "Save Changes"**: After linreg + postprocessing containers, a third container runs `recalculate_skill_metrics.py` for the edited station only via `SAPPHIRE_RECALC_STATION_CODE` env var. Skips virtual station computation for scoped runs. Guards against empty DataFrames. Non-fatal on failure.

- **Fix corrupt pickle crash**: `save_stations_to_file` now uses atomic temp file + rename. Dashboard startup falls back to synchronous HF fetch (30s timeout) when pickle is missing/corrupt. Catches `EOFError` on corrupt pickles.

## Test plan

- [x] `SAPPHIRE_TEST_ENV=True bash run_tests.sh machine_learning` — 119 passed
- [x] `SAPPHIRE_TEST_ENV=True bash run_tests.sh postprocessing_forecasts` — 1318 passed
- [x] `SAPPHIRE_TEST_ENV=True bash run_tests.sh forecast_dashboard` — 242 passed
- [ ] Server test: verify `add_new_station.py` no longer times out on decadal/pentadal pipeline
- [ ] Server test: verify skill metrics update after "Save Changes" in dashboard
- [ ] Server test: delete `all_stations.pkl`, restart dashboard, verify recovery via HF fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)