### PR TITLE
Fix Luigi serialization crash in long-term pipeline notification

### DIFF
--- a/apps/pipeline/pipeline_docker.py
+++ b/apps/pipeline/pipeline_docker.py
@@ -1310,8 +1310,11 @@ class SendPipelineCompletionNotification(luigi.Task):
     # Custom message parameter
     custom_message = luigi.Parameter(default="")
 
-    # Tasks this notification depends on
-    depends_on = luigi.Parameter(default=[])
+    # Declared so Luigi's metaclass accepts the kwarg; actual task list
+    # is handled by __init__ / self._depends_on. Must be a string default
+    # — a non-string default (e.g. []) gets serialized as "()" and crashes
+    # the remote scheduler.
+    depends_on = luigi.Parameter(default="")
 
     # Use the intermediate_data_path for log files instead of /app/
     intermediate_data_path = get_bind_path(env.get("ieasyforecast_intermediate_data_path"))


### PR DESCRIPTION
## Summary

- `SendPipelineCompletionNotification.depends_on` was declared as `luigi.Parameter(default=[])`. Luigi's string Parameter serialized the list default as the string `"()"`, which `requires()` then iterated as individual characters — crashing with `requires() must return Task objects but () is a <class 'str'>`.
- Fix: change `default=[]` to `default=""` (proper string default). The `__init__` keyword arg handles the real task list; the Parameter declaration exists only so Luigi's metaclass accepts the kwarg from callers.
- Only affects the long-term pipeline workflow (`RunLongTermWorkflow`) which yields the notification without passing `depends_on`. Pentad/decad/maintenance workflows pass `depends_on` explicitly and were unaffected.

## Test plan

- [x] `SAPPHIRE_TEST_ENV=True bash run_tests.sh pipeline` — 171 passed
- [ ] Server test: `bash bin/run_long_term_forecasts.sh` completes without Luigi crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)