### PR TITLE
Ingest monthly discharge norms from iEH HF SDK into hydrographs table

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         name: Run integration tests
         # Integration tests are skipped by default. Set TEST_LOCAL=true to run local tests.
         # Usage: TEST_LOCAL=true git commit -m "message"
-        entry: bash -c 'cd apps/forecast_dashboard && uv run pytest tests/test_integration.py -v'
+        entry: bash -c 'if [ "${TEST_LOCAL}" = "true" ]; then cd apps/forecast_dashboard && uv run pytest tests/test_integration.py -v; fi'
         language: system
         types: [python]
         pass_filenames: false

--- a/apps/iEasyHydroForecast/forecast_library.py
+++ b/apps/iEasyHydroForecast/forecast_library.py
@@ -2965,7 +2965,7 @@ def read_hydrograph_data(
     Parameters:
     -----------
     horizon_type : str
-        Either 'pentad' or 'decade'.
+        Either 'pentad', 'decade', or 'month'.
     site_codes : list[str] | None
         List of station codes to filter (used only for API source).
     start_date : str | None
@@ -2989,8 +2989,10 @@ def read_hydrograph_data(
     ValueError
         If horizon_type is invalid.
     """
-    if horizon_type not in ("pentad", "decade"):
-        raise ValueError(f"horizon_type must be 'pentad' or 'decade', got: {horizon_type}")
+    if horizon_type not in ("pentad", "decade", "month"):
+        raise ValueError(
+            f"horizon_type must be 'pentad', 'decade', or 'month', got: {horizon_type}"
+        )
 
     # Check if API is enabled (default: true)
     api_enabled = os.getenv("SAPPHIRE_API_ENABLED", "true").lower() == "true"
@@ -3394,7 +3396,14 @@ def _write_hydrograph_to_api(data: pd.DataFrame, horizon_type: str) -> bool:
                 - decad_in_year: decad in year (1-36)
                 - day_of_year: day of year (1-366)
                 - (same statistics as pentad)
-        horizon_type: Either "pentad" or "decade"
+            For month:
+                - code: station code
+                - date: first-of-month date (YYYY-MM-01)
+                - month: month in month (1-12)
+                - month_in_year: month in year (1-12)
+                - day_of_year: representative mid-month day of year
+                - norm: long-term monthly normal
+        horizon_type: Either "pentad", "decade", or "month"
 
     Returns:
         True if successful, False otherwise
@@ -3426,8 +3435,13 @@ def _write_hydrograph_to_api(data: pd.DataFrame, horizon_type: str) -> bool:
     elif horizon_type == "decade":
         horizon_value_col = "decad"
         horizon_in_year_col = "decad_in_year"
+    elif horizon_type == "month":
+        horizon_value_col = "month"
+        horizon_in_year_col = "month_in_year"
     else:
-        raise ValueError(f"Invalid horizon_type: {horizon_type}. Must be 'pentad' or 'decade'")
+        raise ValueError(
+            f"Invalid horizon_type: {horizon_type}. Must be 'pentad', 'decade', or 'month'"
+        )
 
     # Determine current and previous year columns
     # Look for year columns in the data (they are named by year, e.g., "2025", "2026")
@@ -5342,6 +5356,111 @@ def write_decad_hydrograph_data(data: pd.DataFrame, iehhf_sdk=None):
             # Log warning but don't raise - hydrograph overwrites entire file
 
     return api_ok
+
+
+def write_month_hydrograph_data(
+    code_list: list[str],
+    iehhf_sdk,
+    current_year: int | None = None,
+) -> bool:
+    """
+    Fetch monthly discharge norms from the iEH HF SDK and write them to the
+    SAPPHIRE hydrographs table with horizon_type='month'.
+
+    This function is the monthly-norm sibling of write_pentad_hydrograph_data /
+    write_decad_hydrograph_data. Unlike those functions it does not accept a
+    runoff DataFrame — it reads norms directly from the SDK and writes 12
+    norm-only rows per site (one per calendar month of current_year).
+
+    Args:
+        code_list: List of site codes to fetch monthly norms for. Manual
+            (Google-Sheets-backed) sites should be filtered out by the caller
+            before passing this list.
+        iehhf_sdk: Initialised iEasyHydroHF SDK object. Must support
+            ``get_norm_for_site(code, "discharge", norm_period="m")`` returning
+            a list of 12 floats.
+        current_year: The year to stamp on the ``date`` column
+            (``YYYY-01-01 .. YYYY-12-01``). Defaults to
+            ``datetime.date.today().year`` when None.
+
+    Returns:
+        True if at least one site was written successfully to the API.
+        False if zero sites produced valid norm data (no API call is made).
+
+    Raises:
+        RuntimeError: If ``_write_hydrograph_to_api`` returns False (API
+            disabled / unavailable / readiness-check failed). The monthly path
+            has no CSV fallback, so a False return would mean zero rows
+            persisted while the caller exits 0 — failing loudly prevents that
+            silent data loss.
+        Any exception raised by ``_write_hydrograph_to_api`` propagates
+            unchanged (fatal write failure).
+    """
+    if current_year is None:
+        current_year = dt.date.today().year
+
+    # Mid-month representative day-of-year values (non-leap reference).
+    # These are climatology markers, not calendar records — consumers should
+    # treat them as month-centroid labels.
+    mid_month_doy = [15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349]
+
+    if not code_list:
+        logger.error("write_month_hydrograph_data called with empty code_list — nothing to write")
+        return False
+
+    site_dfs = []
+    for code in code_list:
+        try:
+            norms = iehhf_sdk.get_norm_for_site(code, "discharge", norm_period="m")
+        except Exception as exc:
+            logger.warning(
+                f"write_month_hydrograph_data: SDK call failed for site {code}, skipping. "
+                f"Error: {exc}"
+            )
+            continue
+
+        if len(norms) != 12:
+            logger.warning(
+                f"write_month_hydrograph_data: expected 12 norm values for site {code}, "
+                f"got {len(norms)} — skipping this site."
+            )
+            continue
+
+        months = list(range(1, 13))
+        site_df = pd.DataFrame(
+            {
+                "code": str(code),
+                "date": [dt.date(current_year, m, 1) for m in months],
+                "month": months,
+                "month_in_year": months,
+                "day_of_year": mid_month_doy,
+                "norm": [float(v) for v in norms],
+            }
+        )
+        site_dfs.append(site_df)
+
+    if not site_dfs:
+        logger.error(
+            "write_month_hydrograph_data: no sites produced valid monthly norms — "
+            "skipping API write."
+        )
+        return False
+
+    combined_df = pd.concat(site_dfs, ignore_index=True)
+    logger.info(
+        f"write_month_hydrograph_data: writing {len(combined_df)} monthly norm rows "
+        f"for {combined_df['code'].nunique()} site(s) (year={current_year})"
+    )
+
+    api_result = _write_hydrograph_to_api(combined_df, "month")
+    if api_result is False:
+        raise RuntimeError(
+            "Monthly norm API write returned False — no rows persisted; "
+            "failing loudly rather than silently exiting 0. "
+            "Check SAPPHIRE_API_ENABLED, SAPPHIRE_API_AVAILABLE, and API readiness."
+        )
+
+    return True
 
 
 def write_decad_hydrograph_data_first_version(data: pd.DataFrame, iehhf_sdk=None):

--- a/apps/iEasyHydroForecast/tests/test_forecast_library.py
+++ b/apps/iEasyHydroForecast/tests/test_forecast_library.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
 import pandas as pd
+import pytest
 from pandas.testing import assert_frame_equal
 
 from iEasyHydroForecast import forecast_library as fl
@@ -3782,6 +3783,332 @@ class TestLrVisibilityParams(unittest.TestCase):
             f"forecast_horizon_int=18 → target=19 (1st pentad of April): must call "
             f"_read_lr_visibility with horizon_value=1, got {horizon_value_passed}."
         )
+
+
+# =============================================================================
+# Tests for Phase 1: monthly hydrograph norm ingestion
+# =============================================================================
+
+
+class TestWriteHydrographToApiMonthlyHorizon:
+    """Tests for _write_hydrograph_to_api with horizon_type='month'."""
+
+    @pytest.fixture
+    def sample_monthly_hydrograph_data(self):
+        """Create sample monthly hydrograph data (12 rows for one site)."""
+        mid_month_doy = [15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349]
+        return pd.DataFrame(
+            {
+                "code": ["19999"] * 12,
+                "date": pd.to_datetime([f"2025-{m:02d}-01" for m in range(1, 13)]),
+                "month": list(range(1, 13)),
+                "month_in_year": list(range(1, 13)),
+                "day_of_year": mid_month_doy,
+                "norm": [float(v) for v in range(100, 112)],
+            }
+        )
+
+    @patch("iEasyHydroForecast.forecast_library.SapphirePreprocessingClient")
+    def test_accepts_month_horizon_type(self, mock_client_class, sample_monthly_hydrograph_data):
+        """_write_hydrograph_to_api with horizon_type='month' must succeed and
+        call write_hydrograph with the correct column mapping."""
+        if not fl.SAPPHIRE_API_AVAILABLE:
+            pytest.skip("sapphire-api-client not installed")
+
+        os.environ["SAPPHIRE_API_ENABLED"] = "true"
+        try:
+            mock_client = Mock()
+            mock_client.readiness_check.return_value = True
+            mock_client.write_hydrograph.return_value = 12
+            mock_client_class.return_value = mock_client
+
+            result = fl._write_hydrograph_to_api(sample_monthly_hydrograph_data, "month")
+
+            assert result is True
+            mock_client.write_hydrograph.assert_called_once()
+
+            call_args = mock_client.write_hydrograph.call_args[0][0]
+            assert len(call_args) == 12
+
+            # Check horizon_type and column mapping on first record
+            first = call_args[0]
+            assert first["horizon_type"] == "month"
+            assert first["horizon_value"] == 1  # month=1
+            assert first["horizon_in_year"] == 1  # month_in_year=1
+            assert first["day_of_year"] == 15
+            assert first["norm"] == 100.0
+            assert first["code"] == "19999"
+            assert first["date"] == "2025-01-01"
+        finally:
+            os.environ.pop("SAPPHIRE_API_ENABLED", None)
+
+    @patch("iEasyHydroForecast.forecast_library.SapphirePreprocessingClient")
+    def test_unknown_horizon_type_still_raises(
+        self, mock_client_class, sample_monthly_hydrograph_data
+    ):
+        """Regression: unknown horizon_type must still raise ValueError."""
+        if not fl.SAPPHIRE_API_AVAILABLE:
+            pytest.skip("sapphire-api-client not installed")
+
+        os.environ["SAPPHIRE_API_ENABLED"] = "true"
+        try:
+            mock_client = Mock()
+            mock_client.readiness_check.return_value = True
+            mock_client_class.return_value = mock_client
+
+            with pytest.raises(ValueError, match="Invalid horizon_type"):
+                fl._write_hydrograph_to_api(sample_monthly_hydrograph_data, "invalid")
+        finally:
+            os.environ.pop("SAPPHIRE_API_ENABLED", None)
+
+
+class TestReadHydrographDataMonthHorizon:
+    """Tests for read_hydrograph_data horizon validator with 'month'."""
+
+    @patch("iEasyHydroForecast.forecast_library._read_hydrograph_data_from_api")
+    def test_accepts_month_horizon_type(self, mock_read_from_api):
+        """read_hydrograph_data must not raise ValueError for horizon_type='month'."""
+        if not fl.SAPPHIRE_API_AVAILABLE:
+            pytest.skip("sapphire-api-client not installed")
+
+        os.environ["SAPPHIRE_API_ENABLED"] = "true"
+        try:
+            mock_read_from_api.return_value = pd.DataFrame()
+            # Must not raise
+            fl.read_hydrograph_data("month")
+            mock_read_from_api.assert_called_once()
+        finally:
+            os.environ.pop("SAPPHIRE_API_ENABLED", None)
+
+    def test_unknown_horizon_type_still_raises(self):
+        """Regression: unknown horizon_type must still raise ValueError."""
+        with pytest.raises(ValueError, match="horizon_type must be"):
+            fl.read_hydrograph_data("fortnight")
+
+
+class TestWriteMonthHydrographData:
+    """Tests for the new write_month_hydrograph_data function."""
+
+    MID_MONTH_DOY = [15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349]
+
+    def _make_sdk(self, codes, norm_values=None, raise_for=None):
+        """Build a mock SDK whose get_norm_for_site returns 12 values per code.
+
+        Args:
+            codes: list of site codes that should return data
+            norm_values: optional dict {code: list-of-12} for custom values.
+                Default gives range(100, 112) for each code.
+            raise_for: optional list of codes that should raise on SDK call.
+        """
+        if norm_values is None:
+            norm_values = {c: list(range(100, 112)) for c in codes}
+        if raise_for is None:
+            raise_for = []
+
+        mock_sdk = MagicMock()
+
+        def side_effect(code, param, norm_period):
+            if code in raise_for:
+                raise RuntimeError(f"SDK error for {code}")
+            return norm_values.get(code, [])
+
+        mock_sdk.get_norm_for_site.side_effect = side_effect
+        return mock_sdk
+
+    # ------------------------------------------------------------------
+    # Test 5: happy path — 3 codes, all succeed
+    # ------------------------------------------------------------------
+    @patch("iEasyHydroForecast.forecast_library._write_hydrograph_to_api")
+    def test_happy_path_three_codes(self, mock_write_api):
+        """SDK returning 12 values for 3 codes → 36 rows written, returns True."""
+        mock_write_api.return_value = True
+        codes = ["19999", "29999", "39999"]
+        sdk = self._make_sdk(codes)
+
+        result = fl.write_month_hydrograph_data(codes, sdk, current_year=2025)
+
+        assert result is True
+        mock_write_api.assert_called_once()
+        call_args = mock_write_api.call_args
+        df_written = call_args[0][0]
+        horizon_type_arg = call_args[0][1]
+
+        assert horizon_type_arg == "month"
+        assert len(df_written) == 36  # 12 × 3
+        assert set(df_written.columns) >= {
+            "code",
+            "date",
+            "month",
+            "month_in_year",
+            "day_of_year",
+            "norm",
+        }
+        # Verify month values
+        assert list(df_written[df_written["code"] == "19999"]["month"]) == list(range(1, 13))
+        # Verify day_of_year values
+        assert list(df_written[df_written["code"] == "19999"]["day_of_year"]) == self.MID_MONTH_DOY
+        # Verify norm values
+        assert list(df_written[df_written["code"] == "19999"]["norm"]) == list(range(100, 112))
+
+    # ------------------------------------------------------------------
+    # Test 6: explicit current_year uses that year for dates
+    # ------------------------------------------------------------------
+    @patch("iEasyHydroForecast.forecast_library._write_hydrograph_to_api")
+    def test_explicit_current_year(self, mock_write_api):
+        """When current_year=2020 is passed, dates must use 2020."""
+        mock_write_api.return_value = True
+        codes = ["19999"]
+        sdk = self._make_sdk(codes)
+
+        fl.write_month_hydrograph_data(codes, sdk, current_year=2020)
+
+        df_written = mock_write_api.call_args[0][0]
+        dates = list(df_written["date"])
+        assert dates[0] == dt.date(2020, 1, 1)
+        assert dates[11] == dt.date(2020, 12, 1)
+
+    # ------------------------------------------------------------------
+    # Test 7: SDK raises for one code, other codes succeed
+    # ------------------------------------------------------------------
+    @patch("iEasyHydroForecast.forecast_library._write_hydrograph_to_api")
+    def test_sdk_raises_for_one_code(self, mock_write_api):
+        """SDK raising for one code → that code skipped, others succeed, returns True."""
+        mock_write_api.return_value = True
+        codes = ["19999", "29999", "39999"]
+        sdk = self._make_sdk(codes, raise_for=["29999"])
+
+        result = fl.write_month_hydrograph_data(codes, sdk, current_year=2025)
+
+        assert result is True
+        df_written = mock_write_api.call_args[0][0]
+        assert len(df_written) == 24  # only 2 codes × 12
+        assert "29999" not in df_written["code"].values
+
+    # ------------------------------------------------------------------
+    # Test 8: SDK returns wrong-length list → site skipped
+    # ------------------------------------------------------------------
+    @patch("iEasyHydroForecast.forecast_library._write_hydrograph_to_api")
+    def test_sdk_returns_wrong_length(self, mock_write_api):
+        """SDK returning 11 values → that site skipped with warning, others succeed."""
+        mock_write_api.return_value = True
+        codes = ["19999", "29999"]
+        sdk = self._make_sdk(
+            codes,
+            norm_values={"19999": list(range(11)), "29999": list(range(100, 112))},
+        )
+
+        result = fl.write_month_hydrograph_data(codes, sdk, current_year=2025)
+
+        assert result is True
+        df_written = mock_write_api.call_args[0][0]
+        assert len(df_written) == 12  # only 29999 succeeded
+        assert "19999" not in df_written["code"].values
+
+    # ------------------------------------------------------------------
+    # Test 9: ALL sites fail → returns False, no API call
+    # ------------------------------------------------------------------
+    @patch("iEasyHydroForecast.forecast_library._write_hydrograph_to_api")
+    def test_all_sites_fail(self, mock_write_api):
+        """SDK failing for all codes → returns False, API never called."""
+        codes = ["19999", "29999"]
+        sdk = self._make_sdk(codes, raise_for=codes)
+
+        result = fl.write_month_hydrograph_data(codes, sdk, current_year=2025)
+
+        assert result is False
+        mock_write_api.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Test 10: empty code_list → returns False, no API call
+    # ------------------------------------------------------------------
+    @patch("iEasyHydroForecast.forecast_library._write_hydrograph_to_api")
+    def test_empty_code_list(self, mock_write_api):
+        """Empty code_list → returns False immediately, API never called."""
+        sdk = MagicMock()
+
+        result = fl.write_month_hydrograph_data([], sdk, current_year=2025)
+
+        assert result is False
+        mock_write_api.assert_not_called()
+        sdk.get_norm_for_site.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Test 11a: API disabled → _write_hydrograph_to_api returns False
+    #           → write_month_hydrograph_data must raise RuntimeError
+    # ------------------------------------------------------------------
+    @patch("iEasyHydroForecast.forecast_library._write_hydrograph_to_api")
+    def test_raises_when_api_disabled(self, mock_write_api, monkeypatch):
+        """When SAPPHIRE_API_ENABLED=false causes _write_hydrograph_to_api to
+        return False, write_month_hydrograph_data must raise RuntimeError."""
+        mock_write_api.return_value = False
+        monkeypatch.setenv("SAPPHIRE_API_ENABLED", "false")
+        codes = ["19999"]
+        sdk = self._make_sdk(codes)
+
+        with pytest.raises(RuntimeError):
+            fl.write_month_hydrograph_data(codes, sdk, current_year=2025)
+
+    # ------------------------------------------------------------------
+    # Test 11b: SAPPHIRE_API_AVAILABLE=False → _write_hydrograph_to_api
+    #           returns False → must raise RuntimeError
+    # ------------------------------------------------------------------
+    @patch("iEasyHydroForecast.forecast_library._write_hydrograph_to_api")
+    def test_raises_when_api_unavailable(self, mock_write_api, monkeypatch):
+        """When SAPPHIRE_API_AVAILABLE is False (client not installed),
+        _write_hydrograph_to_api returns False → must raise RuntimeError."""
+        mock_write_api.return_value = False
+        monkeypatch.setattr(fl, "SAPPHIRE_API_AVAILABLE", False)
+        codes = ["19999"]
+        sdk = self._make_sdk(codes)
+
+        with pytest.raises(RuntimeError):
+            fl.write_month_hydrograph_data(codes, sdk, current_year=2025)
+
+    # ------------------------------------------------------------------
+    # Test 11c: readiness-check failure → _write_hydrograph_to_api returns
+    #           False → must raise RuntimeError
+    # ------------------------------------------------------------------
+    @patch("iEasyHydroForecast.forecast_library._write_hydrograph_to_api")
+    def test_raises_when_readiness_check_fails(self, mock_write_api, monkeypatch):
+        """Simulating readiness-check failure by stubbing _write_hydrograph_to_api
+        to return False → write_month_hydrograph_data must raise RuntimeError."""
+        mock_write_api.return_value = False
+        codes = ["19999"]
+        sdk = self._make_sdk(codes)
+
+        with pytest.raises(RuntimeError):
+            fl.write_month_hydrograph_data(codes, sdk, current_year=2025)
+
+    # ------------------------------------------------------------------
+    # Test 12: API write raises → exception propagates unchanged
+    # ------------------------------------------------------------------
+    @patch("iEasyHydroForecast.forecast_library._write_hydrograph_to_api")
+    def test_api_exception_propagates(self, mock_write_api):
+        """If _write_hydrograph_to_api raises, the exception must propagate out."""
+        mock_write_api.side_effect = ConnectionError("API unreachable")
+        codes = ["19999"]
+        sdk = self._make_sdk(codes)
+
+        with pytest.raises(ConnectionError, match="API unreachable"):
+            fl.write_month_hydrograph_data(codes, sdk, current_year=2025)
+
+    # ------------------------------------------------------------------
+    # Test: default current_year uses today's year
+    # ------------------------------------------------------------------
+    @patch("iEasyHydroForecast.forecast_library._write_hydrograph_to_api")
+    def test_default_current_year_uses_today(self, mock_write_api):
+        """When current_year is not passed, dates should use datetime.date.today().year."""
+        mock_write_api.return_value = True
+        codes = ["19999"]
+        sdk = self._make_sdk(codes)
+
+        fl.write_month_hydrograph_data(codes, sdk)
+
+        df_written = mock_write_api.call_args[0][0]
+        expected_year = dt.date.today().year
+        dates = list(df_written["date"])
+        assert dates[0] == dt.date(expected_year, 1, 1)
+        assert dates[11] == dt.date(expected_year, 12, 1)
 
 
 if __name__ == "__main__":

--- a/apps/pipeline/README
+++ b/apps/pipeline/README
@@ -97,9 +97,10 @@ Bimonthly/yearly tasks, triggered by separate cron entries:
 
 ```
 RunPeriodicMaintenanceWorkflow(task_type=...)
-  ├─ long_term   → LongTermPostProcessingMaintenance   (bimonthly)
-  ├─ skill_recalc → YearlySkillRecalculation            (Jan 1)
-  └─ snow_norms  → YearlySnowNormRecalculation          (Aug 25)
+  ├─ long_term      → LongTermPostProcessingMaintenance   (bimonthly)
+  ├─ skill_recalc   → YearlySkillRecalculation            (Jan 1)
+  ├─ snow_norms     → YearlySnowNormRecalculation          (Aug 25)
+  └─ monthly_norms  → YearlyMonthlyNormsRecalculation      (Jan 1)
 ```
 
 ## Docker Compose

--- a/apps/pipeline/pipeline_docker.py
+++ b/apps/pipeline/pipeline_docker.py
@@ -2021,11 +2021,47 @@ class YearlySnowNormRecalculation(DockerTaskBase):
         )
 
 
+class YearlyMonthlyNormsRecalculation(DockerTaskBase):
+    """Yearly monthly norm fetch from iEH HF SDK, called from the yearly periodic-maintenance cron."""
+
+    image_name = "sapphire-preprunoff"
+    container_name = "maintenance-monthly-norms"
+    command = ["uv", "run", "sync_monthly_norms.py"]
+
+    docker_logs_file_path = (
+        f"{get_bind_path(env.get('ieasyforecast_intermediate_data_path'))}"
+        f"/docker_logs/log_maintenance_monthly_norms_"
+        f"{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
+    )
+
+    def output(self):
+        marker = get_maintenance_marker_filepath("monthly_norms")
+        return luigi.LocalTarget(marker)
+
+    def run(self):
+        volumes = _standard_maintenance_volumes()
+        environment = _common_maintenance_env()
+
+        status, details = self.execute_with_retries(
+            lambda attempt: self.run_docker_container(
+                image_name=self.image_name,
+                container_name=self.container_name,
+                volumes=volumes,
+                environment=environment,
+                attempt_number=attempt,
+                mem_limit="4g",
+                memswap_limit="6g",
+                command=self.command,
+                network="host",
+            )
+        )
+
+
 class RunPeriodicMaintenanceWorkflow(luigi.Task):
     """Parameterized workflow for periodic maintenance tasks.
 
     Args:
-        task_type: One of 'long_term', 'skill_recalc', 'snow_norms'
+        task_type: One of 'long_term', 'skill_recalc', 'snow_norms', 'monthly_norms'
     """
 
     task_type = luigi.Parameter()
@@ -2035,6 +2071,7 @@ class RunPeriodicMaintenanceWorkflow(luigi.Task):
             "long_term": LongTermPostProcessingMaintenance(),
             "skill_recalc": YearlySkillRecalculation(),
             "snow_norms": YearlySnowNormRecalculation(),
+            "monthly_norms": YearlyMonthlyNormsRecalculation(),
         }
         if self.task_type not in task_map:
             raise ValueError(

--- a/apps/pipeline/tests/test_maintenance_tasks.py
+++ b/apps/pipeline/tests/test_maintenance_tasks.py
@@ -289,6 +289,16 @@ class TestPeriodicMaintenanceTasks:
         path = task.output().path
         assert "maintenance_snow_norms_" in path
 
+    def test_monthly_norms_task_attributes(self, mock_env):
+        """YearlyMonthlyNormsRecalculation has correct marker, image, container, command."""
+        from pipeline_docker import YearlyMonthlyNormsRecalculation
+
+        task = YearlyMonthlyNormsRecalculation()
+        assert "monthly_norms" in task.output().path
+        assert task.image_name == "sapphire-preprunoff"
+        assert task.container_name == "maintenance-monthly-norms"
+        assert task.command == ["uv", "run", "sync_monthly_norms.py"]
+
 
 class TestRunPeriodicMaintenanceWorkflow:
     """Test RunPeriodicMaintenanceWorkflow parameterized orchestrator."""
@@ -325,6 +335,17 @@ class TestRunPeriodicMaintenanceWorkflow:
         task = RunPeriodicMaintenanceWorkflow(task_type="snow_norms")
         dep = task.requires()
         assert isinstance(dep, YearlySnowNormRecalculation)
+
+    def test_monthly_norms_routing(self, mock_env):
+        """task_type='monthly_norms' routes to YearlyMonthlyNormsRecalculation."""
+        from pipeline_docker import (
+            RunPeriodicMaintenanceWorkflow,
+            YearlyMonthlyNormsRecalculation,
+        )
+
+        task = RunPeriodicMaintenanceWorkflow(task_type="monthly_norms")
+        dep = task.requires()
+        assert isinstance(dep, YearlyMonthlyNormsRecalculation)
 
     def test_invalid_task_type(self, mock_env):
         """Invalid task_type raises ValueError."""

--- a/apps/preprocessing_runoff/sync_monthly_norms.py
+++ b/apps/preprocessing_runoff/sync_monthly_norms.py
@@ -1,0 +1,248 @@
+"""Yearly monthly discharge norm ingestion from iEH HF SDK.
+
+Fetches monthly discharge norms for every forecast-enabled site from the
+iEasyHydro High Frequency (HF) SDK and writes them to the SAPPHIRE
+hydrographs table with ``horizon_type='month'`` (12 rows per site, one per
+calendar month of the current year).
+
+Manual (Google-Sheets-backed) sites are filtered out before the SDK call;
+they do not contribute to the monthly norm table and would silently return
+no data if passed in.
+
+Designed to run once a year (e.g., ``0 3 1 1 *`` — 1 January 03:00 UTC).
+
+Usage::
+
+    # Dry-run: print resolved site list and exit without writing
+    uv run sync_monthly_norms.py --dry-run
+
+    # Normal run (year resolved from today)
+    uv run sync_monthly_norms.py
+
+    # Explicitly specify the target year
+    uv run sync_monthly_norms.py --current-year 2025
+
+Exit codes:
+    0  Partial or full success — at least one SDK site's norm was written.
+       Also used by --dry-run and --help (no write attempted).
+    1  RuntimeError from the library (API disabled / unavailable / readiness
+       check failed). The monthly path has no CSV fallback; the caller
+       (Luigi, cron, ``set -e`` shell) sees a nonzero exit and retries.
+    2  Full failure — the library returned False because zero SDK sites
+       produced valid monthly norms (SDK returned wrong-length or empty
+       data for every site).
+    3  Unexpected exception not covered by the above (generic catch-all).
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Path setup — ensure iEasyHydroForecast is importable from this directory.
+# ---------------------------------------------------------------------------
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_IEHF_DIR = os.path.join(_SCRIPT_DIR, "..", "iEasyHydroForecast")
+if _IEHF_DIR not in sys.path:
+    sys.path.insert(0, _IEHF_DIR)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+# ---------------------------------------------------------------------------
+# Imports from shared libraries (after path setup)
+# ---------------------------------------------------------------------------
+import setup_library as sl
+from forecast_library import write_month_hydrograph_data
+from ieasyhydro_sdk.sdk import IEasyHydroHFSDK
+from setup_library import (
+    _get_manual_site_codes,
+    get_all_forecast_sites_from_HF_SDK,
+)
+
+# ---------------------------------------------------------------------------
+# Logging — simple stream handler; the Luigi runner captures stdout/stderr.
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    stream=sys.stdout,
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sync_monthly_norms.py",
+        description=(
+            "Fetch monthly discharge norms for all forecast-enabled SDK sites "
+            "from the iEH HF API and write them to the SAPPHIRE hydrographs "
+            "table (horizon_type='month').\n\n"
+            "Exit codes: 0=success/dry-run, 1=API RuntimeError, "
+            "2=zero SDK sites succeeded, 3=unexpected exception."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--current-year",
+        type=int,
+        default=None,
+        metavar="YEAR",
+        help=(
+            "Year to stamp on the date column (e.g. 2025 → dates "
+            "2025-01-01 .. 2025-12-01). Defaults to the current calendar year."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help=(
+            "Resolve the site list and print it, then exit 0 without "
+            "calling the library or the SDK norm endpoint. "
+            "Useful to validate configuration."
+        ),
+    )
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Entry point for the yearly monthly norm ingestion task.
+
+    Initialises the iEH HF SDK, loads all forecast-enabled site codes,
+    filters out manual (Google-Sheets-backed) sites, and delegates to
+    ``forecast_library.write_month_hydrograph_data``.
+
+    Args:
+        None — reads from ``sys.argv`` and the deployment ``.env`` file.
+
+    Returns:
+        None — exits via ``sys.exit`` with an appropriate code.
+
+    Exit codes:
+        0  Success (or --dry-run / --help).
+        1  ``RuntimeError`` from ``write_month_hydrograph_data`` (API
+           disabled / unavailable / readiness check failed).
+        2  Zero SDK sites produced valid monthly norms.
+        3  Unexpected exception.
+    """
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        # ------------------------------------------------------------------
+        # 1. Load deployment environment (.env file)
+        # ------------------------------------------------------------------
+        sl.load_environment()
+
+        # ------------------------------------------------------------------
+        # 2. Initialise the iEH HF SDK
+        # ------------------------------------------------------------------
+        sdk = IEasyHydroHFSDK()
+        logger.info("iEasyHydro HF SDK initialised.")
+
+        # ------------------------------------------------------------------
+        # 3. Load all forecast-enabled sites (includes manual sites appended
+        #    by setup_library at lines 1567-1571)
+        # ------------------------------------------------------------------
+        _fc_sites, site_codes, _site_ids = get_all_forecast_sites_from_HF_SDK(sdk)
+        if site_codes is None:
+            site_codes = []
+        logger.info("Total forecast-enabled sites (before filtering): %d", len(site_codes))
+
+        # ------------------------------------------------------------------
+        # 4. Filter out manual sites — they are not available via the iEH HF
+        #    SDK norm endpoint and would produce empty/wrong-length responses.
+        # ------------------------------------------------------------------
+        manual_codes = _get_manual_site_codes()
+        manual_set = set(manual_codes)
+
+        sdk_only_codes = []
+        for code in site_codes:
+            if code in manual_set:
+                logger.info(
+                    "Skipping manual site %s — not available via iEH HF SDK, "
+                    "daily/monthly data comes from alternate source",
+                    code,
+                )
+            else:
+                sdk_only_codes.append(code)
+
+        logger.info(
+            "SDK-only sites after filtering %d manual site(s): %d site(s) → %s",
+            len(manual_codes),
+            len(sdk_only_codes),
+            sdk_only_codes,
+        )
+
+        # ------------------------------------------------------------------
+        # 5. Resolve current_year (for logging; the library handles None too)
+        # ------------------------------------------------------------------
+        from datetime import date as _date
+
+        resolved_year = args.current_year if args.current_year is not None else _date.today().year
+        logger.info("Target year for monthly norm rows: %d", resolved_year)
+
+        # ------------------------------------------------------------------
+        # 6. --dry-run: print and exit without writing
+        # ------------------------------------------------------------------
+        if args.dry_run:
+            print(f"DRY-RUN — sdk_only_codes: {sdk_only_codes}")
+            print(f"DRY-RUN — current_year: {resolved_year}")
+            logger.info("Dry-run complete — no data written.")
+            sys.exit(0)
+
+        # ------------------------------------------------------------------
+        # 7. Guard: no SDK sites → exit 2
+        # ------------------------------------------------------------------
+        if not sdk_only_codes:
+            logger.error(
+                "No SDK sites remain after filtering — nothing to write. "
+                "Check that at least one forecast-enabled site is not manual."
+            )
+            sys.exit(2)
+
+        # ------------------------------------------------------------------
+        # 8. Call the library function
+        # ------------------------------------------------------------------
+        logger.info(
+            "Calling write_month_hydrograph_data for %d SDK site(s).",
+            len(sdk_only_codes),
+        )
+        result = write_month_hydrograph_data(sdk_only_codes, sdk, current_year=args.current_year)
+
+        if not result:
+            logger.error(
+                "write_month_hydrograph_data returned False — "
+                "zero SDK sites produced valid monthly norms."
+            )
+            sys.exit(2)
+
+        logger.info("Monthly norm ingestion completed successfully.")
+        sys.exit(0)
+
+    except RuntimeError as exc:
+        logger.error("API error during monthly norm ingestion: %s", exc)
+        sys.exit(1)
+
+    except SystemExit:
+        # Re-raise SystemExit (from sys.exit calls above or argparse --help)
+        raise
+
+    except Exception as exc:
+        logger.exception("Unexpected error during monthly norm ingestion: %s", exc)
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/preprocessing_runoff/test/test_sync_monthly_norms.py
+++ b/apps/preprocessing_runoff/test/test_sync_monthly_norms.py
@@ -1,0 +1,333 @@
+"""Smoke tests for sync_monthly_norms.py CLI entry point.
+
+Tests cover happy-path filtering, zero-SDK-sites edge case, RuntimeError
+propagation from the library, --dry-run mode, --current-year passthrough,
+and --help.
+
+All external boundaries (SDK init, library calls) are mocked.
+"""
+
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure the preprocessing_runoff directory is on sys.path so that the
+# entry-point module can be imported directly.
+PREPROC_RUNOFF_DIR = os.path.join(os.path.dirname(__file__), "..")
+if PREPROC_RUNOFF_DIR not in sys.path:
+    sys.path.insert(0, PREPROC_RUNOFF_DIR)
+
+# Also ensure iEasyHydroForecast is on path (needed by setup_library import
+# inside sync_monthly_norms).
+IEHF_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "iEasyHydroForecast")
+if IEHF_DIR not in sys.path:
+    sys.path.insert(0, IEHF_DIR)
+
+# Import the module under test once at collection time.
+# All tests patch attributes on the already-imported module object.
+import sync_monthly_norms as _mod  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Patch target constants (all relative to the sync_monthly_norms namespace)
+# ---------------------------------------------------------------------------
+_MOD = "sync_monthly_norms"
+_PATCH_LOAD_ENV = f"{_MOD}.sl.load_environment"
+_PATCH_SDK = f"{_MOD}.IEasyHydroHFSDK"
+_PATCH_GET_SITES = f"{_MOD}.get_all_forecast_sites_from_HF_SDK"
+_PATCH_MANUAL = f"{_MOD}._get_manual_site_codes"
+_PATCH_WRITE = f"{_MOD}.write_month_hydrograph_data"
+
+
+# ---------------------------------------------------------------------------
+# Helper: run main() with argv, return exit code
+# ---------------------------------------------------------------------------
+
+
+def _run_main(argv: list[str], extra_patches: list | None = None) -> int:
+    """
+    Run sync_monthly_norms.main() with sys.argv = argv.
+
+    Returns the integer exit code (0 for normal return, 0/nonzero for
+    SystemExit).  Never re-raises SystemExit.
+
+    *extra_patches* is a list of already-entered patch context managers
+    that the caller has set up; this helper adds the common infrastructure
+    patches on top.
+    """
+    with patch("sys.argv", [f"{_MOD}.py"] + argv):
+        try:
+            _mod.main()
+            return 0
+        except SystemExit as exc:
+            return int(exc.code) if exc.code is not None else 0
+
+
+# ---------------------------------------------------------------------------
+# Shared mock SDK factory
+# ---------------------------------------------------------------------------
+
+
+def _make_sdk() -> MagicMock:
+    return MagicMock(name="IEasyHydroHFSDK_instance")
+
+
+# ---------------------------------------------------------------------------
+# Test 1: happy path — one manual site filtered out, library called correctly
+# ---------------------------------------------------------------------------
+
+
+class TestMainHappyPath:
+    """main() filters manual sites and calls the library with sdk-only codes."""
+
+    def test_write_called_with_sdk_only_codes(self):
+        """write_month_hydrograph_data receives only the SDK sites."""
+        mock_sdk_inst = _make_sdk()
+
+        with (
+            patch(_PATCH_LOAD_ENV),
+            patch(_PATCH_SDK, return_value=mock_sdk_inst),
+            patch(
+                _PATCH_GET_SITES,
+                return_value=(MagicMock(), ["10001", "16022", "16230"], [1, 2, 3]),
+            ),
+            patch(_PATCH_MANUAL, return_value=["10001"]),
+            patch(_PATCH_WRITE, return_value=True) as mock_write,
+        ):
+            exit_code = _run_main([])
+
+        assert exit_code == 0, f"Expected exit code 0, got {exit_code}"
+        mock_write.assert_called_once()
+
+        call_args = mock_write.call_args
+        code_list_arg = call_args.args[0] if call_args.args else call_args.kwargs["code_list"]
+        assert "10001" not in code_list_arg, "Manual site must be filtered out"
+        assert "16022" in code_list_arg
+        assert "16230" in code_list_arg
+
+    def test_manual_site_info_logged(self, caplog):
+        """An info-level log must be emitted for each skipped manual site."""
+        mock_sdk_inst = _make_sdk()
+
+        with (
+            patch(_PATCH_LOAD_ENV),
+            patch(_PATCH_SDK, return_value=mock_sdk_inst),
+            patch(
+                _PATCH_GET_SITES,
+                return_value=(MagicMock(), ["10001", "16022"], [1, 2]),
+            ),
+            patch(_PATCH_MANUAL, return_value=["10001"]),
+            patch(_PATCH_WRITE, return_value=True),
+            caplog.at_level(logging.INFO),
+        ):
+            _run_main([])
+
+        relevant = [r for r in caplog.records if "10001" in r.message]
+        assert relevant, "Expected a log message mentioning the skipped manual site '10001'"
+        # Must be info or below (not warning/error)
+        for r in relevant:
+            assert r.levelno <= logging.INFO, (
+                f"Log for manual site should be INFO, got {r.levelname}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: zero SDK sites after filtering → exit 2
+# ---------------------------------------------------------------------------
+
+
+class TestZeroSdkSites:
+    """When all forecast sites are manual, exit code must be 2."""
+
+    def test_exit_code_2_when_all_manual(self):
+        mock_sdk_inst = _make_sdk()
+
+        with (
+            patch(_PATCH_LOAD_ENV),
+            patch(_PATCH_SDK, return_value=mock_sdk_inst),
+            patch(
+                _PATCH_GET_SITES,
+                return_value=(MagicMock(), ["10001", "10002"], [1, 2]),
+            ),
+            patch(_PATCH_MANUAL, return_value=["10001", "10002"]),
+            patch(_PATCH_WRITE, return_value=False),
+        ):
+            exit_code = _run_main([])
+
+        assert exit_code == 2, f"Expected exit code 2, got {exit_code}"
+
+    def test_library_not_called_when_no_sdk_sites(self):
+        """write_month_hydrograph_data must not be called when list is empty."""
+        mock_sdk_inst = _make_sdk()
+
+        with (
+            patch(_PATCH_LOAD_ENV),
+            patch(_PATCH_SDK, return_value=mock_sdk_inst),
+            patch(
+                _PATCH_GET_SITES,
+                return_value=(MagicMock(), ["10001"], [1]),
+            ),
+            patch(_PATCH_MANUAL, return_value=["10001"]),
+            patch(_PATCH_WRITE) as mock_write,
+        ):
+            _run_main([])
+
+        mock_write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: library raises RuntimeError → exit 1
+# ---------------------------------------------------------------------------
+
+
+class TestLibraryRuntimeError:
+    """RuntimeError from write_month_hydrograph_data must produce exit code 1."""
+
+    def test_exit_code_1_on_runtime_error(self):
+        mock_sdk_inst = _make_sdk()
+
+        with (
+            patch(_PATCH_LOAD_ENV),
+            patch(_PATCH_SDK, return_value=mock_sdk_inst),
+            patch(
+                _PATCH_GET_SITES,
+                return_value=(MagicMock(), ["16022"], [1]),
+            ),
+            patch(_PATCH_MANUAL, return_value=[]),
+            patch(_PATCH_WRITE, side_effect=RuntimeError("API unavailable")),
+        ):
+            exit_code = _run_main([])
+
+        assert exit_code == 1, f"Expected exit code 1, got {exit_code}"
+
+    def test_runtime_error_is_logged_not_swallowed(self, caplog):
+        """The RuntimeError message must appear in logs, not be silently consumed."""
+        mock_sdk_inst = _make_sdk()
+
+        with (
+            patch(_PATCH_LOAD_ENV),
+            patch(_PATCH_SDK, return_value=mock_sdk_inst),
+            patch(
+                _PATCH_GET_SITES,
+                return_value=(MagicMock(), ["16022"], [1]),
+            ),
+            patch(_PATCH_MANUAL, return_value=[]),
+            patch(_PATCH_WRITE, side_effect=RuntimeError("API unavailable")),
+            caplog.at_level(logging.ERROR),
+        ):
+            _run_main([])
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records, "Expected an ERROR-level log when RuntimeError is raised"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: --dry-run flag
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    """--dry-run must print the site list and exit 0 without calling the library."""
+
+    def test_dry_run_does_not_call_library(self):
+        mock_sdk_inst = _make_sdk()
+
+        with (
+            patch(_PATCH_LOAD_ENV),
+            patch(_PATCH_SDK, return_value=mock_sdk_inst),
+            patch(
+                _PATCH_GET_SITES,
+                return_value=(MagicMock(), ["10001", "16022", "16230"], [1, 2, 3]),
+            ),
+            patch(_PATCH_MANUAL, return_value=["10001"]),
+            patch(_PATCH_WRITE) as mock_write,
+        ):
+            exit_code = _run_main(["--dry-run"])
+
+        assert exit_code == 0, f"Expected exit code 0 from dry-run, got {exit_code}"
+        mock_write.assert_not_called()
+
+    def test_dry_run_prints_sdk_site_list(self, capsys):
+        """stdout must contain the filtered sdk_only_codes and current_year."""
+        mock_sdk_inst = _make_sdk()
+
+        with (
+            patch(_PATCH_LOAD_ENV),
+            patch(_PATCH_SDK, return_value=mock_sdk_inst),
+            patch(
+                _PATCH_GET_SITES,
+                return_value=(MagicMock(), ["10001", "16022", "16230"], [1, 2, 3]),
+            ),
+            patch(_PATCH_MANUAL, return_value=["10001"]),
+            patch(_PATCH_WRITE),
+        ):
+            _run_main(["--dry-run"])
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "16022" in combined, "Expected sdk site 16022 in dry-run output"
+        assert "16230" in combined, "Expected sdk site 16230 in dry-run output"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: --current-year passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentYear:
+    """--current-year=2020 must be forwarded to write_month_hydrograph_data."""
+
+    def test_current_year_passed_to_library(self):
+        mock_sdk_inst = _make_sdk()
+
+        with (
+            patch(_PATCH_LOAD_ENV),
+            patch(_PATCH_SDK, return_value=mock_sdk_inst),
+            patch(
+                _PATCH_GET_SITES,
+                return_value=(MagicMock(), ["16022"], [1]),
+            ),
+            patch(_PATCH_MANUAL, return_value=[]),
+            patch(_PATCH_WRITE, return_value=True) as mock_write,
+        ):
+            _run_main(["--current-year", "2020"])
+
+        mock_write.assert_called_once()
+        call_kwargs = mock_write.call_args.kwargs
+        call_args = mock_write.call_args.args
+
+        # current_year may be positional (index 2) or keyword
+        current_year = call_kwargs.get("current_year") or (
+            call_args[2] if len(call_args) > 2 else None
+        )
+        assert current_year == 2020, f"Expected current_year=2020, got {current_year!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: --help exits 0 and prints usage
+# ---------------------------------------------------------------------------
+
+
+class TestHelp:
+    """--help must exit 0 and print a usage message."""
+
+    def test_help_exits_zero(self):
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", [f"{_MOD}.py", "--help"]):
+                _mod.main()
+        assert exc_info.value.code == 0
+
+    def test_help_prints_usage(self, capsys):
+        try:
+            with patch("sys.argv", [f"{_MOD}.py", "--help"]):
+                _mod.main()
+        except SystemExit:
+            pass
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "usage" in combined.lower(), (
+            f"Expected 'usage' in --help output, got: {combined[:300]!r}"
+        )

--- a/bin/README.md
+++ b/bin/README.md
@@ -120,7 +120,7 @@ docker compose -f bin/docker-compose-luigi.yml run --rm pentadal
 # Run daily maintenance
 docker compose -f bin/docker-compose-luigi.yml run --rm daily-maintenance
 
-# Run periodic maintenance (long_term, skill_recalc, or snow_norms)
+# Run periodic maintenance (long_term, skill_recalc, snow_norms, or monthly_norms)
 MAINTENANCE_TASK_TYPE=skill_recalc \
   docker compose -f bin/docker-compose-luigi.yml run --rm periodic-maintenance
 ```
@@ -228,6 +228,7 @@ See `doc/deployment.md` for the full recommended crontab. Summary:
 | 22:00 1st odd months | `run_periodic_maintenance.sh long_term` | Long-term postprocessing |
 | 01:00 Dec 31 | `run_periodic_maintenance.sh skill_recalc` | Yearly skill recalculation |
 | 02:00 Aug 31 | `run_periodic_maintenance.sh snow_norms` | Yearly snow norm recalculation |
+| 03:00 Jan 1  | `run_periodic_maintenance.sh monthly_norms` | Yearly monthly discharge norm recalculation from iEH HF SDK |
 
 Log files use timestamped names (`sapphire_*_YYYYMMDD.log`) with automatic
 cleanup of logs older than 7 days.

--- a/bin/docker-compose-luigi.yml
+++ b/bin/docker-compose-luigi.yml
@@ -111,7 +111,7 @@ services:
     container_name: sapphire-pipeline-daily-maintenance
 
   # Periodic maintenance workflow (bimonthly/yearly tasks)
-  # Pass MAINTENANCE_TASK_TYPE env var to select: long_term, skill_recalc, snow_norms
+  # Pass MAINTENANCE_TASK_TYPE env var to select: long_term, skill_recalc, snow_norms, monthly_norms
   # Usage: MAINTENANCE_TASK_TYPE=long_term docker compose -f bin/docker-compose-luigi.yml run --rm periodic-maintenance
   periodic-maintenance:
     extends: pipeline-base

--- a/bin/run_periodic_maintenance.sh
+++ b/bin/run_periodic_maintenance.sh
@@ -5,9 +5,10 @@
 # Usage: bash bin/run_periodic_maintenance.sh <task_type> <env_file_path>
 #
 # Task types:
-#   long_term    - Bimonthly long-term postprocessing (1st of odd months)
-#   skill_recalc - Yearly full skill metrics recalculation (December 31)
-#   snow_norms   - Yearly snow norm recalculation (August 31)
+#   long_term      - Bimonthly long-term postprocessing (1st of odd months)
+#   skill_recalc   - Yearly full skill metrics recalculation (December 31)
+#   snow_norms     - Yearly snow norm recalculation (August 31)
+#   monthly_norms  - Yearly monthly norm recalculation from iEH HF SDK (January 1)
 #
 # Example:
 #   bash bin/run_periodic_maintenance.sh long_term /path/to/config/.env
@@ -23,7 +24,7 @@ TASK_TYPE="${1}"
 if [ -z "$TASK_TYPE" ]; then
     echo "| Error: task_type argument required."
     echo "| Usage: bash bin/run_periodic_maintenance.sh <task_type> <env_file_path>"
-    echo "| Valid task_types: long_term, skill_recalc, snow_norms"
+    echo "| Valid task_types: long_term, skill_recalc, snow_norms, monthly_norms"
     exit 1
 fi
 echo "| Running Periodic Maintenance: ${TASK_TYPE}"

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -738,6 +738,8 @@ Add the following to the crontab file:
 0 1 31 12 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_skillrecalc_$(date +\%Y\%m\%d).log 2>&1
 # Yearly snow norm recalculation at 02:00 UTC on August 31
 0 2 31 8 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_snownorms_$(date +\%Y\%m\%d).log 2>&1
+# Yearly monthly discharge norm recalculation from iEH HF SDK at 03:00 UTC on January 1
+0 3 1 1 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh monthly_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_monthlynorms_$(date +\%Y\%m\%d).log 2>&1
 ```
 To check if the cron jobs have been set up correctly, you can list them with `crontab -l`.
 

--- a/doc/plans/deployment_new_hydromet_aws.md
+++ b/doc/plans/deployment_new_hydromet_aws.md
@@ -648,6 +648,8 @@ Skip this section if the deployment is LAN-only — users can reach the dashboar
   0 1 31 12 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_skillrecalc_$(date +\%Y\%m\%d).log 2>&1
   # Yearly snow norm recalculation (August 31)
   0 2 31 8 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_snownorms_$(date +\%Y\%m\%d).log 2>&1
+  # Yearly monthly discharge norm recalculation from iEH HF SDK (January 1)
+  0 3 1 1 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh monthly_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_monthlynorms_$(date +\%Y\%m\%d).log 2>&1
   ```
 
   > `[DOC-GAP-11]` ✅ **Resolved** — crontab in `doc/deployment.md` now uses `<data_folder>`/`<env_file>` placeholders and includes a timezone reference table.

--- a/doc/plans/issues/review_gi_draft_infra_monthly_norms_from_sdk.md
+++ b/doc/plans/issues/review_gi_draft_infra_monthly_norms_from_sdk.md
@@ -1,0 +1,415 @@
+# Ingest monthly discharge norms from iEH HF SDK into the hydrographs table
+
+## Status — implemented 2026-04-23
+
+Implemented on branch `develop_infra_monthly_norms_from_sdk` (based on
+`maxat_sapphire_2` @ `b74871b`). Awaiting review + merge.
+
+Commits (P1 → P4):
+
+| Phase | Commit | Summary |
+|-------|--------|---------|
+| P1 TDD | `f69bfb8` | Tests for monthly hydrograph norm ingestion |
+| P1 | `b18d119` | `write_month_hydrograph_data` + `horizon_type="month"` in `forecast_library.py` (read + write paths) |
+| P2 TDD | `80b02ff` | Tests for `sync_monthly_norms` entry point |
+| P2 | `fb4ed2e` | `apps/preprocessing_runoff/sync_monthly_norms.py` CLI entry point |
+| P3 TDD | `24ac7f4` | Tests for `YearlyMonthlyNormsRecalculation` + task routing |
+| P3 | `8826829` | Register `monthly_norms` in `RunPeriodicMaintenanceWorkflow`; update shell + compose comments |
+| P4 | `fee4107` | Yearly cron line in `doc/deployment.md` and `doc/plans/deployment_new_hydromet_aws.md` |
+
+Cron line shipped (Jan 1, 03:00 UTC):
+
+```cron
+0 3 1 1 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh monthly_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_monthlynorms_$(date +\%Y\%m\%d).log 2>&1
+```
+
+Server rollout instructions: see "Server rollout" section below.
+
+## Server rollout
+
+Pre-requisite: the branch must be merged (or the server checkout switched to
+`develop_infra_monthly_norms_from_sdk`) and the `sapphire-preprunoff` Docker
+image rebuilt/pulled so it contains `sync_monthly_norms.py`.
+
+1. **Merge or switch branch** on the server:
+   ```bash
+   cd /data/SAPPHIRE_Forecast_Tools
+   git fetch origin
+   git checkout maxat_sapphire_2 && git pull   # once the PR is merged
+   # — or, for a pre-merge trial run —
+   # git checkout develop_infra_monthly_norms_from_sdk && git pull
+   ```
+
+2. **Rebuild / pull the preprunoff image** so it contains `sync_monthly_norms.py`:
+   ```bash
+   # Pull the published tag (recommended once the branch is merged + CI pushed):
+   docker pull mabesa/sapphire-preprunoff:latest
+   # — or rebuild locally from the checkout:
+   bash bin/utils/build_docker_images.sh latest
+   ```
+
+3. **Optional first-time manual run** to populate monthly norms immediately
+   instead of waiting until next Jan 1:
+   ```bash
+   bash bin/run_periodic_maintenance.sh monthly_norms /data/<data_folder>/config/<env_file>
+   ```
+   Verify rows appear in `hydrographs` with `horizon_type='month'` and
+   `date` set to first-of-month of the current year.
+
+4. **Add the cron line** (`crontab -e`) — append under the existing periodic
+   maintenance section:
+   ```cron
+   # Yearly monthly discharge norm recalculation from iEH HF SDK at 03:00 UTC on January 1
+   0 3 1 1 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh monthly_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_monthlynorms_$(date +\%Y\%m\%d).log 2>&1
+   ```
+   Replace `<data_folder>` and `<env_file>` with the deployment's values.
+
+5. **Verify** with `crontab -l` and (on next Jan 1 or after the manual step)
+   check `/home/ubuntu/logs/sapphire_periodic_monthlynorms_*.log`.
+
+---
+
+## Problem
+
+SAPPHIRE currently ingests pentadal (`'p'`, 72 values/site) and decadal (`'d'`,
+36 values/site) discharge norms from the iEasyHydro HF SDK and writes them to
+the `hydrographs` table. The SDK also exposes monthly norms (`'m'`, 12
+values/site) via the same `get_norm_for_site(site_code, "discharge",
+norm_period="m")` API, but no code path in this repo fetches or persists them.
+
+Operational consequences:
+- The `hydrographs` table has no rows with `horizon_type='month'` for any
+  deployment, so dashboards and downstream modules cannot show monthly
+  climatology baselines.
+- Hydromets that may later enable monthly (long-term) forecasts would need the
+  norms as a prerequisite; today the norm table is unpopulated for that horizon.
+
+## Decision
+
+Add a **yearly** periodic-maintenance task that fetches monthly norms from the
+iEH HF SDK for every forecast-enabled site and writes them to the `hydrographs`
+table with `horizon_type='month'`. Ship it as an opt-in cron line so any
+hydromet can enable it.
+
+**Decisions (locked in):**
+- **Scope of write:** only the `norm` column is populated from the SDK. Other
+  columns (`count`, `mean`, `std`, `min`, `max`, `q05`..`q95`, `previous`,
+  `current`) stay NULL on monthly rows. Full-stat computation from local runoff
+  history is a separate follow-up if/when a consumer needs it.
+- **Trigger:** new `monthly_norms` task in `bin/run_periodic_maintenance.sh`,
+  run yearly via cron (norms are long-term averages — daily re-fetch is
+  wasteful). Runs via the existing `periodic-maintenance` Luigi service,
+  consistent with `skill_recalc` and `snow_norms`.
+- **Row shape per site:** 12 rows, one per calendar month. `horizon_value` and
+  `horizon_in_year` = 1..12. `day_of_year` = representative mid-month day
+  (`[15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349]`, non-leap
+  reference — this is a climatology marker, not a calendar record). Consumers
+  should treat `day_of_year` as a month-centroid label; in leap years calendar
+  `day_of_year` for months March-December would be off by one vs these
+  non-leap values. That's acceptable for climatology.
+- **`date` column convention:** mirror the existing pentad/decad norm
+  writer. `forecast_library.py:4541` sets
+  `current_year = data["date"].dt.year.max()` (most recent year in the
+  runoff history), and `forecast_library.py:4694-4696` assigns
+  `date = get_issue_date_from_pentad(p, current_year)` to each pentad row.
+  For monthly: `date` = first-of-month of `current_year`
+  (`2025-01-01, 2025-02-01, …, 2025-12-01` for a run where the most recent
+  runoff year is 2025). Each yearly re-run therefore writes 12 *new* rows per
+  site under a fresh date — the `hydrographs` table accumulates year-by-year
+  snapshots. The server-side upsert (`sapphire/services/preprocessing/app/crud.py:89`,
+  keyed on `(horizon_type, code, date)`) handles within-year re-runs
+  idempotently (the daily LR pipeline already relies on this for
+  pentad/decad). Note: the SDK norm is a fixed climatology with no year
+  dimension (confirmed by reading `ieasyhydro_sdk/sdk_endpoint_definitions.py`
+  — the endpoint accepts no year filter), so the values under different dates
+  will typically be identical; the year-indexed dates reflect *when the
+  snapshot was taken*, not a change in the underlying norm. **Empirically
+  confirmed** on the uzhm preprocessing DB 2026-04-23: `hydrographs`
+  contains only 2026 dates (deployment started in 2026), matching the
+  "new rows per year" behaviour — mature deployments (e.g. kghm running
+  since 2023) would show multiple years in the date range.
+- **Column names for month (new):** `horizon_value` DataFrame column is
+  `month` (1..12); the "horizon in year" column is `month_in_year` (also
+  1..12). Matches the `pentad`/`pentad_in_year` and `decad`/`decad_in_year`
+  naming used by existing writers.
+- **Site enumeration:** reuse `get_all_forecast_sites_from_HF_SDK()` in
+  `setup_library.py` for the full forecast-enabled list, **then filter out
+  manual sites** at the entry-point script using `_get_manual_site_codes()`
+  (`setup_library.py:712`). Reason: manual sites (e.g. Google-Sheets-backed
+  Zarafshan 10001) are appended unconditionally at `setup_library.py:1567-1571`;
+  the SDK cannot return norms for them. Passing them in would generate a
+  warning per site on every yearly run — proportional to the number of
+  manual sites in the deployment. Filtering at the entry point keeps the
+  library function general and emits exactly one `info` log per skipped
+  manual site rather than N `warning` logs.
+- **Failure policy:** per-site log-and-continue **for SDK sites**. An SDK
+  site where the SDK returns empty, errors, or returns a length ≠ 12 is
+  skipped with a warning; the remaining sites still get written. Manual
+  sites are not passed in at all (see Site enumeration), so they don't
+  count against the success/failure tally.
+- **Failure must be loud at the API layer.** `_write_hydrograph_to_api`
+  returns `False` (not raises) when the API is disabled
+  (`SAPPHIRE_API_ENABLED=false`), unavailable (`SAPPHIRE_API_AVAILABLE=False`),
+  or the readiness check fails (`forecast_library.py:3402-3418`). The
+  pentad/decad callers (`forecast_library.py:4739-4744`) discard that
+  return value and only set `api_ok=False` on an *exception* — they get
+  away with it because they also write a CSV fallback (line 4762). The
+  monthly path has **no CSV fallback**, so a naïve mirror would exit 0
+  with zero rows persisted and the Luigi marker written, masking the
+  outage for a full year. The new `write_month_hydrograph_data` must
+  **check the return value of `_write_hydrograph_to_api` and raise** if
+  it is `False`. The Luigi task therefore fails, the marker is not
+  written, and the operator sees the failure in Luigi's status UI /
+  cron log on the next retry. Do not change the pentad/decad caller
+  behaviour — they have their CSV safety net and we are not in scope to
+  fix that here.
+- **No schema change:** `HorizonType.MONTH` already exists in
+  `sapphire/services/preprocessing/app/models.py:11`.
+
+## Approach
+
+Mirror the pentad/decad library functions
+(`apps/iEasyHydroForecast/forecast_library.py:4502` and `:4793`) with a
+monthly-only variant, scoped to just the norm overlay (no by-month runoff
+aggregation). Wire it through the same `periodic-maintenance` orchestration
+that `skill_recalc` and `snow_norms` already use.
+
+**Why not extend `write_pentad_hydrograph_data`:** those functions expect a
+runoff DataFrame as primary input and compute stats from it. Monthly-only
+would require ugly conditionals. Cleaner to add a sibling function that takes
+`code_list + sdk` and writes norm-only rows.
+
+**Why yearly, not bimonthly:** SDK monthly norms are multi-year climatologies
+computed on the iEH HF side. They change when the iEH HF backend recomputes
+its long-term averages, which is infrequent. Yearly is enough; operators can
+dispatch the task manually between runs if they want a fresher snapshot.
+
+## Scope
+
+**In scope:**
+- Extend `_write_hydrograph_to_api` in
+  `apps/iEasyHydroForecast/forecast_library.py` so that
+  `horizon_type="month"` is accepted alongside the existing `"pentad"` /
+  `"decade"` branches.
+- Extend `read_hydrograph_data` in the same file (the read-path validator
+  at `forecast_library.py:2992-2993` currently raises
+  `ValueError(f"horizon_type must be 'pentad' or 'decade', got: {horizon_type}")`)
+  to accept `"month"`. Symmetric to the write-path extension — without it,
+  no consumer can query the rows we are about to insert, and the plan's
+  rollout promise ("dashboards can later query `horizon_type='month'`") is
+  structurally blocked. Dashboard rewire is still out of scope; the read
+  *capability* just needs to land with the write.
+- New library function
+  `write_month_hydrograph_data(code_list, iehhf_sdk, current_year=None)` in
+  the same file. When `current_year` is None the implementation resolves it
+  to `date.today().year` (no runoff DataFrame is passed in, so we can't
+  mirror the exact pentad/decad expression
+  `data["date"].dt.year.max()`; calling the entry point from the yearly
+  cron makes `date.today().year` a faithful substitute).
+- New entry-point script (CLI-invokable inside the periodic-maintenance
+  container) that initialises the SDK, loads site codes, and calls the library
+  function. Location: **`apps/preprocessing_runoff/sync_monthly_norms.py`**
+  (monthly norms are discharge-related, so they fit `preprocessing_runoff`
+  alongside existing discharge-ingest logic; compare `snow_norms` → lives in
+  `preprocessing_gateway`, `skill_recalc` → lives in
+  `postprocessing_forecasts`).
+- Add a `YearlyMonthlyNormsRecalculation` Luigi task in
+  `apps/pipeline/pipeline_docker.py` and register it in
+  `RunPeriodicMaintenanceWorkflow.task_map` (per the Files-touched table).
+  Update help-text / comments in `bin/run_periodic_maintenance.sh`,
+  `bin/docker-compose-luigi.yml`, `bin/README.md` — no dispatch-logic
+  changes in the shell layer (validation happens in Luigi).
+- Pytest tests (TDD — write first):
+  - Unit: `write_month_hydrograph_data` with a mocked SDK returning 12 values
+    → 12 rows/site written with correct `horizon_type`, `horizon_value`,
+    `day_of_year`, `norm`.
+  - Unit: SDK returning empty / raising / wrong-length → site skipped, logged,
+    other sites still processed.
+  - Unit: empty `code_list` → no-op, returns True.
+  - Smoke: entry-point script `main()` invokable with mocked SDK + fake site
+    list; exits 0.
+- Cron template line + docs: `bin/README.md` cron table,
+  `doc/deployment.md`, `doc/plans/deployment_new_hydromet_aws.md` Phase 10
+  crontab template.
+
+**Out of scope:**
+- Populating `count`, `mean`, `std`, `min`, `max`, `q05`..`q95` for monthly
+  rows (separate follow-up if dashboard ever needs monthly-resolution
+  quantiles).
+- A fallback path that computes monthly norms from local history (runoffs
+  table or Google Sheets) when the SDK returns no result for a manual
+  (Sheets-backed) site. The expectation — to be verified during the Phase 3
+  integration test, not assumed — is that the SDK will not return norms for
+  sites whose history lives only in Google Sheets. If that's confirmed, a
+  local-history fallback is a separate follow-up issue.
+- Migrating existing deployments: this is additive. Rolling out means
+  enabling the new cron line.
+- Any consumer changes (dashboard, long_term_forecasting) — they can start
+  reading the new rows once populated, but their code is not touched here.
+- `sapphire/services/` — no service changes.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `apps/iEasyHydroForecast/forecast_library.py` | **Three changes:** (a) extend `_write_hydrograph_to_api` (currently at line 3374) to accept `horizon_type="month"` — add a third branch in the if/elif/else at line ~3425 that sets `horizon_value_col="month"`, `horizon_in_year_col="month_in_year"` and extend the docstring. Keep the `ValueError` default branch so unknown horizon types still raise. (b) Extend `read_hydrograph_data` horizon validator at line 2992-2993 the same way — accept `"month"` alongside `"pentad"` / `"decade"`. (c) Add `write_month_hydrograph_data(code_list, iehhf_sdk, current_year=None)` alongside `write_pentad_hydrograph_data` (line 4502) / `write_decad_hydrograph_data` (line 4793). When `current_year is None`, default to `date.today().year`. Per-site try/except mirroring line 4598; length-check against 12; build 12-row DataFrame per site with `code, date (first-of-month of current_year: YYYY-01-01 .. YYYY-12-01), month (1..12), month_in_year (1..12), day_of_year (mid-month list, non-leap), norm`; concatenate and call `_write_hydrograph_to_api(df, "month")`. **Must check the return value of `_write_hydrograph_to_api` and raise if `False`** (see Decisions > "Failure must be loud"). Mirrors the pentad/decad path which uses `current_year = data["date"].dt.year.max()` to stamp `date = get_issue_date_from_pentad(p, current_year)` per-row (line 4541, 4694-4696). |
+| `apps/iEasyHydroForecast/tests/test_forecast_library.py` | Add test class `TestWriteMonthHydrographData` covering: 12-row write, SDK empty, SDK raises, wrong length, empty `code_list`, mixed success/failure across sites. Also add at least one test for `_write_hydrograph_to_api` accepting `"month"` and rejecting a bogus horizon type (keeps the "invalid horizon_type" error path covered). |
+| `apps/preprocessing_runoff/sync_monthly_norms.py` *(new)* | CLI entry point: read env, init `IEasyHydroHFSDK`, load forecast-enabled site codes via `get_all_forecast_sites_from_HF_SDK()`, **filter out manual sites using `_get_manual_site_codes()`** (emit one `info` log per skipped manual site), call `write_month_hydrograph_data(sdk_only_codes, sdk)`, exit 0 on partial/full success, non-zero if zero SDK sites succeeded or if the library raises due to API unavailability. Mirrors `apps/preprocessing_gateway/recalculate_snow_norms.py` in argparse setup, SDK init, and logging. |
+| `apps/preprocessing_runoff/test/test_sync_monthly_norms.py` *(new)* | Smoke test: `main()` with mocked SDK + stub code list → exits 0, library function called with the right args. Directory is `test/` (singular) per preprocessing_runoff convention; iEasyHydroForecast uses `tests/` (plural) — both are intentional. |
+| `apps/pipeline/pipeline_docker.py` | **Two changes:** (a) Add new class `YearlyMonthlyNormsRecalculation(DockerTaskBase)` mirroring `YearlySnowNormRecalculation` at line 1992, but with `image_name="sapphire-preprunoff"` (gspread already installed in that image per commit `13898f7`), `container_name="maintenance-monthly-norms"`, `command=["uv", "run", "sync_monthly_norms.py"]`, `marker = get_maintenance_marker_filepath("monthly_norms")` in `output()`. Mem limits: 4g/6g same as snow_norms unless benchmarking says otherwise. (b) Add `"monthly_norms": YearlyMonthlyNormsRecalculation()` to the `task_map` dict in `RunPeriodicMaintenanceWorkflow.requires` at line ~2037. |
+| `apps/pipeline/tests/test_maintenance_tasks.py` | Add test mirroring the existing `YearlySnowNormRecalculation` test (pipeline_docker.py:285 pattern): asserts marker path, image_name, command. |
+| `bin/run_periodic_maintenance.sh` | Update the valid-task-types list at lines 10 (doc comment) and 26 (error message) to include `monthly_norms`. No dispatch-logic change needed (the shell script is a pass-through; validation happens in `RunPeriodicMaintenanceWorkflow`). |
+| `bin/docker-compose-luigi.yml` | Update the comment at lines 114-115 listing valid `MAINTENANCE_TASK_TYPE` values. `docker-compose` config itself already supports any value via `${MAINTENANCE_TASK_TYPE:-long_term}` at line 127 — no structural change. |
+| `bin/README.md` | Update the `monthly_norms` task mention in the periodic-maintenance section around line 123; add a row to the cron-schedule table around line 221. |
+| `apps/pipeline/README` | Update the ASCII routing tree at lines 99-102 to add `monthly_norms → YearlyMonthlyNormsRecalculation` alongside `long_term`, `skill_recalc`, `snow_norms`. Keeps the developer-facing routing map in sync with `bin/README.md` and `pipeline_docker.py`. |
+| `doc/deployment.md` | Add yearly cron line in the `Set up cron job` section, with comment explaining the task. |
+| `doc/plans/deployment_new_hydromet_aws.md` | Add the same line to the Phase 10 crontab template around line 637-650. |
+
+## Phases
+
+### Phase 1 — Library function + tests
+- **Goal:** `_write_hydrograph_to_api` and `read_hydrograph_data` both accept
+  `"month"`; `write_month_hydrograph_data` exists, fails loudly on API
+  unavailability; all three tested, tests green across iEasyHydroForecast
+  AND linear_regression.
+- **Files:**
+  - `apps/iEasyHydroForecast/forecast_library.py` — extend
+    `_write_hydrograph_to_api` (line ~3425 if/elif chain) to handle `"month"`;
+    extend `read_hydrograph_data` horizon validator at line 2992-2993 to
+    accept `"month"`; add the new `write_month_hydrograph_data` function
+    with explicit `False`-return check that raises.
+  - `apps/iEasyHydroForecast/tests/test_forecast_library.py` — tests per the
+    Scope section, plus a regression test that `_write_hydrograph_to_api`
+    and `read_hydrograph_data` still raise on unknown horizon types.
+    **Must include a test that `write_month_hydrograph_data` raises when
+    `_write_hydrograph_to_api` returns `False`** (parameterize with the
+    three conditions: `SAPPHIRE_API_ENABLED=false`,
+    `SAPPHIRE_API_AVAILABLE=False`, and readiness-check failure).
+- **Explicitly not allowed:** edits to `sapphire/services/`, other modules, or
+  any Dockerfile. No changes to existing pentad/decad behaviour — in
+  particular, do not modify the `api_ok`-flag pattern at
+  `forecast_library.py:4739-4744` in the pentad/decad callers.
+- **Agents:** 1 (Sonnet 4.6, worktree isolation).
+- **Acceptance:** the following two commands each return zero failures
+  and zero unexpected skips (run sequentially — `run_tests.sh` accepts
+  exactly one module argument, multi-arg invocation silently drops the
+  rest per `run_tests.sh:154-192`):
+  - `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh iEasyHydroForecast`
+  - `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh linear_regression`
+    (covers `test_forecast_library_api.py::TestWriteHydrographToApi`, which
+    exercises the shared `_write_hydrograph_to_api` helper — a regression
+    here would otherwise slip past the iEasyHydroForecast run).
+  The pre-existing pentad/decad test cases must continue to pass unchanged.
+
+### Phase 2 — Entry-point script + smoke test
+- **Goal:** CLI script that Phase 3's Luigi task can invoke.
+- **Files:** `apps/preprocessing_runoff/sync_monthly_norms.py`,
+  `apps/preprocessing_runoff/test/test_sync_monthly_norms.py`.
+- **Depends on:** P1.
+- **Agents:** 1.
+- **Acceptance:** smoke test passes; `python sync_monthly_norms.py --help`
+  runs without import errors. Structure should mirror `preprocessing_gateway`'s
+  snow-norm entry point (same arg parsing, same SDK init, same logging setup).
+
+### Phase 3 — Periodic-maintenance + Luigi wiring
+- **Goal:** `bash bin/run_periodic_maintenance.sh monthly_norms <env_file>`
+  runs the new task end-to-end (against a test deployment).
+- **Files:**
+  - `apps/pipeline/pipeline_docker.py` — new class
+    `YearlyMonthlyNormsRecalculation(DockerTaskBase)` modelled line-for-line
+    on `YearlySnowNormRecalculation` (line 1992) with the three swaps listed
+    in the Files-touched table (image, container name, command, marker). And
+    add the `"monthly_norms": …` entry to `RunPeriodicMaintenanceWorkflow`'s
+    `task_map` at line ~2037 — without this, the Luigi workflow raises
+    `ValueError` for unknown task_type.
+  - `apps/pipeline/tests/test_maintenance_tasks.py` — new test mirroring the
+    `YearlySnowNormRecalculation` test at line ~285.
+  - `bin/run_periodic_maintenance.sh` — lines 10 and 26 (doc-comment + error
+    message): add `monthly_norms` to the valid-task-types list.
+  - `bin/docker-compose-luigi.yml` — comment at lines 114-115 only; no
+    structural change.
+  - `bin/README.md` — lines ~123 (prose) and ~221 (cron-schedule table).
+  - `apps/pipeline/README` — ASCII routing tree at lines 99-102; add
+    `monthly_norms → YearlyMonthlyNormsRecalculation` row.
+- **Explicitly not allowed:** changes to the snow_norms or skill_recalc task
+  definitions, or to `_standard_maintenance_volumes` / `_common_maintenance_env`
+  helpers (shared utilities — accidentally touching them would bleed into
+  other tasks).
+- **Depends on:** P2.
+- **Agents:** 1.
+- **Acceptance:**
+  - `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh pipeline` — zero
+    failures, zero unexpected skips.
+  - Against a test `.env` with a live iEH HF connection, running
+    `bash bin/run_periodic_maintenance.sh monthly_norms <env>` results in rows
+    in `hydrographs` with `horizon_type='month'`, `date` = first-of-month
+    of the run's current year (e.g., `2026-01-01 .. 2026-12-01` when run in
+    2026), and non-null `norm` for every forecast-enabled site whose norm
+    the SDK can return. The marker file at
+    `get_maintenance_marker_filepath("monthly_norms")` exists afterwards.
+  - Re-running the same task immediately should be a no-op (Luigi sees the
+    marker and skips) unless the marker file is removed first.
+
+### Phase 4 — Cron + docs
+- **Goal:** Operators can enable the task via crontab with a documented line.
+- **Files:** `bin/README.md`, `doc/deployment.md`,
+  `doc/plans/deployment_new_hydromet_aws.md`.
+- **Depends on:** P3.
+- **Agents:** 1.
+- **Acceptance:** Docs include the new cron line (e.g. `0 3 1 1 *` — Jan 1 at
+  03:00 UTC) with a one-liner explaining what it does and that it is yearly.
+
+### Dependency graph
+
+```json
+{
+  "phases": {
+    "P1": { "depends_on": [], "parallel_agents": 1 },
+    "P2": { "depends_on": ["P1"], "parallel_agents": 1 },
+    "P3": { "depends_on": ["P2"], "parallel_agents": 1 },
+    "P4": { "depends_on": ["P3"], "parallel_agents": 1 }
+  }
+}
+```
+
+## Testing plan
+
+- Unit tests per phase (see `Scope > In scope` and phase acceptance criteria).
+- Manual integration test after Phase 3: run
+  `bash bin/run_periodic_maintenance.sh monthly_norms <uzhm-env-file>` on the
+  uzhm staging host and verify that `hydrographs` contains up to ~48 rows
+  (4 iEH-HF-sourced uzhm sites × 12 months) with `horizon_type='month'`,
+  `date` = first-of-month in the run's current year (e.g.,
+  `2026-01-01..2026-12-01`), and non-null `norm`.
+- **Empirical check of manual-site behaviour.** The Google-Sheets-backed
+  Zarafshan station (10001) is *expected* to be absent from the SDK result,
+  but that's an inference, not a tested fact. During the Phase 3 manual
+  integration test, explicitly confirm the run log shows a log-and-continue
+  warning for 10001 (or equivalent) rather than an unhandled exception. If
+  the SDK *does* return norms for 10001 (e.g., because iEH HF has an
+  internal norm record for it), note the values and update the
+  out-of-scope section accordingly.
+
+## Rollout
+
+- Strictly additive: writes new rows, doesn't modify existing ones.
+- No data migration.
+- No consumer changes today; dashboards can later query `horizon_type='month'`
+  if they want to surface climatology.
+- Deployment change: operators opt in by adding one cron line. Not enabled
+  automatically.
+- **Table-size growth:** mirrors pentad/decad. After N years of yearly runs,
+  the `hydrographs` table holds ~`12 × N × (number of forecast-enabled sites)`
+  monthly rows, plus the existing `72 × N` pentad and `36 × N` decad rows
+  per site. For a 10-station hydromet over 10 years: ~1 200 monthly rows
+  total — negligible vs the ~10 800 pentad + ~3 600 decad rows already
+  written under the same convention. No pruning needed.
+
+## Orchestration note (per CLAUDE.md)
+
+Each phase is delegated to a Sonnet 4.6 general-purpose agent with
+`isolation: "worktree"` and an explicit file-allowlist in the prompt. Orchestrator
+reviews the diff after every phase and runs the full `SAPPHIRE_TEST_ENV=True
+bash run_tests.sh` before moving on. This work is **unrelated to the
+`fix_pipeline_uzhm_timeout_support` branch** and should land on its own
+feature branch (suggested name: `develop_infra_monthly_norms_from_sdk`).


### PR DESCRIPTION
## Summary
- Add `write_month_hydrograph_data` in `forecast_library.py`; extend `_write_hydrograph_to_api` and `read_hydrograph_data` to accept `horizon_type="month"` (P1).
- New CLI entry point `apps/preprocessing_runoff/sync_monthly_norms.py` that fetches monthly discharge norms from the iEH HF SDK for every forecast-enabled site (manual sites filtered out) and writes 12 rows/site with `horizon_type='month'` and first-of-month dates in the current year (P2).
- New `YearlyMonthlyNormsRecalculation` Luigi task + `monthly_norms` routing key in `RunPeriodicMaintenanceWorkflow`; shell/compose comment updates so `bash bin/run_periodic_maintenance.sh monthly_norms <env>` works end-to-end (P3).
- Yearly cron line (Jan 1, 03:00 UTC) documented in `doc/deployment.md` and `doc/plans/deployment_new_hydromet_aws.md` (P4).
- TDD throughout. Plan moved to `review_gi_draft_infra_monthly_norms_from_sdk.md` with per-phase commit table and server rollout instructions.

**Fail-loud contract:** `write_month_hydrograph_data` checks the return value of `_write_hydrograph_to_api` and raises if `False` — the monthly path has no CSV fallback, so a silent empty-year write cannot happen.

**Additive only:** no schema changes, no consumer changes, no modifications to existing pentad/decad behaviour. Operators opt in by adding the cron line.

## Test plan
- [x] `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh iEasyHydroForecast` — 281 passed, 0 skipped
- [x] `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh linear_regression` — 327 passed, 0 skipped (exercises shared `_write_hydrograph_to_api`)
- [x] `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_runoff` — 269 passed, 0 skipped (includes 10 new `test_sync_monthly_norms.py` tests)
- [x] `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh pipeline` — 173 passed, 0 skipped
- [ ] Manual integration on uzhm/kghm staging: `bash bin/run_periodic_maintenance.sh monthly_norms <env>` → verify rows in `hydrographs` with `horizon_type='month'`, `date` = first-of-month of current year, non-null `norm`; confirm log-and-continue warning for manual (Google-Sheets-backed) sites
- [ ] Re-run immediately → Luigi no-op (marker exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)