### PR TITLE
Dispatch single-river xlsx alongside wide-matrix under uzhm

### DIFF
--- a/apps/preprocessing_runoff/src/src.py
+++ b/apps/preprocessing_runoff/src/src.py
@@ -13,7 +13,7 @@ import re
 import sys
 import time
 from contextlib import contextmanager
-from datetime import date, timedelta
+from datetime import timedelta
 from pathlib import Path
 
 import numpy as np
@@ -818,7 +818,7 @@ def read_runoff_data_from_uzhm_wide_xlsx(
                     try:
                         records.append(
                             {
-                                date_col: date(year, month_idx, day),
+                                date_col: pd.Timestamp(year, month_idx, day),
                                 discharge_col: float(discharge_val),
                                 code_col: int(code),
                                 name_col: name,
@@ -842,19 +842,28 @@ def read_all_runoff_data_from_uzhm_excel(
     code_list=None,
 ):
     """
-    Reads daily runoff data from all uzhm wide-matrix Excel files in the
-    daily discharge directory using parallel processing.
+    Reads daily runoff data from all uzhm Excel files in the daily discharge
+    directory using parallel processing.
 
-    Each file must have a pure-digits stem (e.g. ``16022.xlsx``). Temporary
-    files (stems starting with ``~``) are excluded.
+    Two filename conventions are supported:
+
+    * **Wide-matrix** — pure-digit stem, e.g. ``16022.xlsx``.  Each sheet is
+      named with a year; rows represent days 1-31 and columns represent months.
+    * **Single-river** — exactly-5-digit code prefix followed by
+      ``_{name}_SYSTEM``, e.g. ``19999_Demo_River_UZB_SYSTEM.xlsx``.  Each
+      sheet is named with a year; column A is the date string and column B is
+      the discharge value.
+
+    Temporary files (names starting with ``~``) are excluded. Files whose stems
+    match neither pattern are silently skipped.
 
     Args:
         date_col: Name of the date column in the output DataFrame.
         discharge_col: Name of the discharge column in the output DataFrame.
         name_col: Name of the station name column in the output DataFrame.
         code_col: Name of the station code column in the output DataFrame.
-        code_list: List of station code strings to include. If None a
-            warning is logged and all files are processed.
+        code_list: List of station code strings to include. If None an
+            error is logged and all files are processed.
 
     Returns:
         Combined DataFrame from all matching files, or None if no data
@@ -871,35 +880,91 @@ def read_all_runoff_data_from_uzhm_excel(
     if not os.path.exists(daily_discharge_dir):
         raise FileNotFoundError(f"Directory '{daily_discharge_dir}' not found.")
 
-    uzhm_files = [
-        os.path.join(daily_discharge_dir, f)
-        for f in os.listdir(daily_discharge_dir)
-        if os.path.isfile(os.path.join(daily_discharge_dir, f))
-        and f.endswith(".xlsx")
-        and not f.startswith("~")
-        and re.fullmatch(r"\d+", Path(f).stem)
-    ]
+    # Partition directory into two buckets based on filename stem pattern.
+    wide_matrix_files = []
+    single_river_files = []
+    for f in os.listdir(daily_discharge_dir):
+        full_path = os.path.join(daily_discharge_dir, f)
+        if not os.path.isfile(full_path):
+            continue
+        if not f.endswith(".xlsx"):
+            continue
+        if f.startswith("~"):
+            continue
+        stem = Path(f).stem
+        if re.fullmatch(r"\d+", stem):
+            wide_matrix_files.append(full_path)
+        # Exactly-5-digit prefix matches read_runoff_data_from_single_river_xlsx's
+        # hardcoded filename[:5] (code) and filename[6:-16] (name) slicing.
+        # Do NOT relax to \d+_... or to kghm's f[0].isdigit() without first
+        # generalising the reader's name/code extraction — otherwise 6-digit codes
+        # get silently truncated.
+        elif re.fullmatch(r"\d{5}_.+_SYSTEM", stem):
+            single_river_files.append(full_path)
+        else:
+            logger.debug(
+                f"read_all_runoff_data_from_uzhm_excel: skipping '{f}' — "
+                f"filename does not match wide-matrix or single-river pattern."
+            )
 
-    if not uzhm_files:
-        logger.warning(f"No uzhm wide-matrix Excel files found in '{daily_discharge_dir}'.")
-        return None
+    # Duplicate-code detection — runs before any file I/O, purely from filenames.
+    wide_matrix_codes = {Path(f).stem for f in wide_matrix_files}
+    single_river_codes = {Path(f).stem[:5] for f in single_river_files}
+    for code in wide_matrix_codes & single_river_codes:
+        logger.warning(
+            f"uzhm xlsx ingest: station {code} appears in BOTH wide-matrix and "
+            f"single-river files — both will be ingested, downstream dedup is not "
+            f"performed here"
+        )
 
-    logger.info(f"Reading {len(uzhm_files)} uzhm wide-matrix Excel files")
-    df = parallel_read_excel_files(
-        uzhm_files,
-        read_runoff_data_from_uzhm_wide_xlsx,
-        code_list=code_list,
-        date_col=date_col,
-        discharge_col=discharge_col,
-        name_col=name_col,
-        code_col=code_col,
-    )
+    # Read wide-matrix files in parallel.
+    df_wide = pd.DataFrame()
+    if wide_matrix_files:
+        logger.info(f"Reading {len(wide_matrix_files)} uzhm wide-matrix Excel files")
+        df_wide = parallel_read_excel_files(
+            wide_matrix_files,
+            read_runoff_data_from_uzhm_wide_xlsx,
+            code_list=code_list,
+            date_col=date_col,
+            discharge_col=discharge_col,
+            name_col=name_col,
+            code_col=code_col,
+        )
 
-    if df is None or df.empty:
+    # Read single-river files in parallel.
+    df_sr = pd.DataFrame()
+    if single_river_files:
+        logger.info(f"Reading {len(single_river_files)} uzhm single-river Excel files")
+        df_sr = parallel_read_excel_files(
+            single_river_files,
+            read_runoff_data_from_single_river_xlsx,
+            code_list=code_list,
+            date_col=date_col,
+            discharge_col=discharge_col,
+            name_col=name_col,
+            code_col=code_col,
+        )
+
+    # Empty-safe combine.
+    wide_empty = df_wide is None or (isinstance(df_wide, pd.DataFrame) and df_wide.empty)
+    sr_empty = df_sr is None or (isinstance(df_sr, pd.DataFrame) and df_sr.empty)
+
+    if wide_empty and sr_empty:
         logger.warning("No data found in the uzhm daily discharge directory")
         return None
+    elif wide_empty:
+        result = df_sr
+    elif sr_empty:
+        result = df_wide
+    else:
+        result = pd.concat([df_wide, df_sr], ignore_index=True)
 
-    return df
+    logger.info(
+        f"uzhm xlsx ingest: {len(wide_matrix_files)} wide-matrix + "
+        f"{len(single_river_files)} single-river files, "
+        f"{0 if result is None else len(result)} rows"
+    )
+    return result
 
 
 def parallel_read_excel_files(

--- a/apps/preprocessing_runoff/test/test_src.py
+++ b/apps/preprocessing_runoff/test/test_src.py
@@ -949,7 +949,6 @@ class TestMaintenanceModeGapFilling:
 # ---------------------------------------------------------------------------
 # Tests for uzhm wide-matrix Excel reader
 # ---------------------------------------------------------------------------
-from datetime import date as date_type  # noqa: E402
 
 import openpyxl  # noqa: E402  (appended after existing imports block)
 
@@ -1069,7 +1068,9 @@ class TestUzhmWideMatrixReader:
             assert col in result.columns, f"Missing column: {col}"
 
         # Specific value: Jan 1 2000 should be 832.0
-        jan1 = result[result["date"] == date_type(2000, 1, 1)]
+        # Use pd.Timestamp for comparison — the reader now returns datetime64[ns]
+        # values (pd.Timestamp), so comparing with datetime.date would not match.
+        jan1 = result[result["date"] == pd.Timestamp(2000, 1, 1)]
         assert not jan1.empty, "Expected a row for 2000-01-01"
         assert float(jan1["discharge"].iloc[0]) == 832.0
 
@@ -1156,11 +1157,12 @@ class TestUzhmWideMatrixReader:
         )
 
         # Jan 15 should be absent
-        jan15 = result[result["date"] == date_type(2000, 1, 15)]
+        # Use pd.Timestamp for comparison — the reader now returns datetime64[ns] values.
+        jan15 = result[result["date"] == pd.Timestamp(2000, 1, 15)]
         assert jan15.empty, "date(2000,1,15) with None discharge should be excluded"
 
         # Jan 14 should be present (it has a valid value)
-        jan14 = result[result["date"] == date_type(2000, 1, 14)]
+        jan14 = result[result["date"] == pd.Timestamp(2000, 1, 14)]
         assert not jan14.empty, "date(2000,1,14) should be present"
 
     def test_code_not_in_code_list_returns_empty(self, tmp_path):
@@ -1228,36 +1230,50 @@ class TestUzhmWideMatrixReader:
             "Summary row discharge 500.0 must not appear in output"
         )
 
-    def test_directory_scan_pure_digits_filter(self, tmp_path):
-        """read_all_runoff_data_from_uzhm_excel must ignore non-pure-digit filenames."""
-        fixture_dir = _make_uzhm_fixture(tmp_path)
-
-        # Create a non-pure-digits file that must be ignored
-        dummy_wb = openpyxl.Workbook()
-        dummy_ws = dummy_wb.active
-        dummy_ws.title = "2000"
-        dummy_ws.cell(row=1, column=1, value="10001 Dummy-System")
-        for m in range(1, 13):
-            dummy_ws.cell(row=4, column=m + 1, value=m)
-        for day in range(1, 5):
-            dummy_ws.cell(row=4 + day, column=1, value=day)
-            for m in range(1, 13):
-                dummy_ws.cell(row=4 + day, column=m + 1, value=7777.0)
-        dummy_wb.save(fixture_dir / "10001_Name_SYSTEM.xlsx")
+    def test_directory_scan_pure_digits_goes_to_wide_matrix(self, tmp_path):
+        """A pure-digit stem (19001.xlsx) is routed to the wide-matrix reader."""
+        _build_uzhm_xlsx(
+            tmp_path / "19001.xlsx",
+            "19001 Test-River",
+            {2000: _make_year_data(800.0)},
+        )
 
         orig = os.environ.get("ieasyforecast_daily_discharge_path")
         try:
-            os.environ["ieasyforecast_daily_discharge_path"] = str(fixture_dir)
-            result = src.read_all_runoff_data_from_uzhm_excel(code_list=["16022"])
+            os.environ["ieasyforecast_daily_discharge_path"] = str(tmp_path)
+            result = src.read_all_runoff_data_from_uzhm_excel(code_list=["19001"])
 
             assert result is not None
             assert isinstance(result, pd.DataFrame)
             assert not result.empty
 
-            # Data from the dummy file (discharge 7777.0) must not appear
-            assert 7777.0 not in result["discharge"].values, (
-                "Non-pure-digit file '10001_Name_SYSTEM.xlsx' must be excluded"
+            # The wide-matrix file must contribute rows for code 19001
+            codes_in_result = set(result["code"].unique())
+            assert 19001 in codes_in_result, (
+                "Expected code 19001 from wide-matrix file '19001.xlsx' in result"
             )
+        finally:
+            if orig is None:
+                os.environ.pop("ieasyforecast_daily_discharge_path", None)
+            else:
+                os.environ["ieasyforecast_daily_discharge_path"] = orig
+
+    def test_directory_scan_system_suffix_goes_to_single_river(self, tmp_path):
+        """A SYSTEM-suffix stem (19002_Demo_UZB_SYSTEM.xlsx) is routed to the single-river reader."""
+        _make_single_river_fixture(tmp_path, code="19002", river_name="Demo")
+
+        orig = os.environ.get("ieasyforecast_daily_discharge_path")
+        try:
+            os.environ["ieasyforecast_daily_discharge_path"] = str(tmp_path)
+            result = src.read_all_runoff_data_from_uzhm_excel(code_list=["19002"])
+
+            assert result is not None
+            assert isinstance(result, pd.DataFrame)
+            assert not result.empty
+
+            # The single-river file must contribute rows for code 19002
+            codes_in_result = set(result["code"].unique())
+            assert 19002 in codes_in_result, "Expected code 19002 from single-river file in result"
         finally:
             if orig is None:
                 os.environ.pop("ieasyforecast_daily_discharge_path", None)
@@ -1290,3 +1306,568 @@ class TestUzhmWideMatrixReader:
                 os.environ.pop("ieasyforecast_daily_discharge_path", None)
             else:
                 os.environ["ieasyforecast_daily_discharge_path"] = orig_path
+
+    def test_organization_router_uzhm_mixed_formats(self, tmp_path):
+        """Org router combines wide-matrix and single-river results correctly.
+
+        A directory with one wide-matrix file (19001.xlsx) and one single-river
+        file (19999_Demo_River_UZB_SYSTEM.xlsx) must produce a DataFrame that
+        contains rows for both station codes with correct column names and
+        datetime dtypes.
+        """
+
+        # Wide-matrix file: pure-digit stem
+        _build_uzhm_xlsx(
+            tmp_path / "19001.xlsx",
+            "19001 Test-River",
+            {2000: _make_year_data(800.0)},
+        )
+        # Single-river file: SYSTEM suffix
+        _make_single_river_fixture(tmp_path, code="19999", river_name="Demo_River")
+
+        orig_path = os.environ.get("ieasyforecast_daily_discharge_path")
+        try:
+            os.environ["ieasyforecast_daily_discharge_path"] = str(tmp_path)
+            result = src._read_runoff_data_by_organization(
+                "uzhm",
+                date_col="date",
+                discharge_col="discharge",
+                name_col="name",
+                code_col="code",
+                code_list=["19001", "19999"],
+            )
+
+            assert result is not None
+            assert isinstance(result, pd.DataFrame)
+            assert not result.empty
+
+            for col in ("date", "discharge", "code", "name"):
+                assert col in result.columns, f"Expected column '{col}' in result"
+
+            codes_in_result = set(result["code"].unique())
+            assert 19001 in codes_in_result, (
+                "Expected code 19001 from wide-matrix file '19001.xlsx' in result"
+            )
+            assert 19999 in codes_in_result, "Expected code 19999 from single-river file in result"
+
+            assert result["date"].dtype.kind == "M", (
+                f"Expected datetime64 dtype for 'date' column, got {result['date'].dtype}"
+            )
+        finally:
+            if orig_path is None:
+                os.environ.pop("ieasyforecast_daily_discharge_path", None)
+            else:
+                os.environ["ieasyforecast_daily_discharge_path"] = orig_path
+
+    def test_organization_router_uzhm_logs_summary(self, tmp_path, caplog):
+        """The dispatcher emits a summary INFO log mentioning both format counts.
+
+        After processing a directory with one wide-matrix file and one
+        single-river file, read_all_runoff_data_from_uzhm_excel must emit at
+        least one INFO record matching the pattern
+        ``uzhm xlsx ingest: <N> wide-matrix + <M> single-river .* rows`` where
+        N=1 and M=1.
+        """
+        import logging  # noqa: F811 — already imported later in module; safe here
+        import re as _re
+
+        # Wide-matrix file: pure-digit stem
+        _build_uzhm_xlsx(
+            tmp_path / "19001.xlsx",
+            "19001 Test-River",
+            {2000: _make_year_data(800.0)},
+        )
+        # Single-river file: SYSTEM suffix
+        _make_single_river_fixture(tmp_path, code="19999", river_name="Demo_River")
+
+        orig_path = os.environ.get("ieasyforecast_daily_discharge_path")
+        try:
+            os.environ["ieasyforecast_daily_discharge_path"] = str(tmp_path)
+            with caplog.at_level(logging.INFO):
+                src.read_all_runoff_data_from_uzhm_excel(
+                    date_col="date",
+                    discharge_col="discharge",
+                    name_col="name",
+                    code_col="code",
+                    code_list=["19001", "19999"],
+                )
+        finally:
+            if orig_path is None:
+                os.environ.pop("ieasyforecast_daily_discharge_path", None)
+            else:
+                os.environ["ieasyforecast_daily_discharge_path"] = orig_path
+
+        pattern = _re.compile(r"uzhm xlsx ingest:.*wide-matrix.*single-river.*rows", _re.IGNORECASE)
+        matching_records = [
+            r for r in caplog.records if r.levelno == logging.INFO and pattern.search(r.message)
+        ]
+        assert matching_records, (
+            "Expected at least one INFO record matching "
+            f"'{pattern.pattern}', but none found. "
+            f"Captured log records: {[r.message for r in caplog.records]}"
+        )
+
+        # The matched record must mention count 1 for wide-matrix and 1 for single-river.
+        summary_msg = matching_records[0].message
+        count_pattern = _re.compile(r"(\d+)\s+wide-matrix\s*\+\s*(\d+)\s+single-river")
+        m = count_pattern.search(summary_msg)
+        assert m is not None, (
+            f"Could not extract wide-matrix/single-river counts from: '{summary_msg}'"
+        )
+        wide_count = int(m.group(1))
+        sr_count = int(m.group(2))
+        assert wide_count == 1, (
+            f"Expected 1 wide-matrix file in log, got {wide_count}. Message: '{summary_msg}'"
+        )
+        assert sr_count == 1, (
+            f"Expected 1 single-river file in log, got {sr_count}. Message: '{summary_msg}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fixture helper for single-river xlsx files
+# ---------------------------------------------------------------------------
+
+
+def _build_single_river_xlsx(path, code, river_name, year_data):
+    """
+    Create a single-river-format xlsx file at *path*.
+
+    Mirrors the format produced by
+    ``apps/preprocessing_runoff/dev_code/convert_daily_runoff.py``
+    ``write_single_river_excel()`` and consumed by
+    ``read_runoff_data_from_single_river_xlsx()``.
+
+    Args:
+        path: pathlib.Path — destination file path.  The caller is responsible
+            for using a filename that follows the convention
+            ``{code}_{river_name}_UZB_SYSTEM.xlsx`` (exactly 5-digit code,
+            exactly 16-char suffix ``_UZB_SYSTEM.xlsx``).
+        code: str — 5-digit station code string (used only for documentation;
+            the reader extracts the code from the filename, not the workbook).
+        river_name: str — station name (again for documentation only; extracted
+            from the filename by the reader).
+        year_data: dict mapping year (int) -> list of (date_str, discharge)
+            tuples.  date_str must be in ``dd.mm.YYYY`` format.  discharge may
+            be a float, the string ``"-"``, or None (empty cell).
+    """
+    wb = openpyxl.Workbook()
+    wb.remove(wb.active)  # remove default blank sheet
+
+    for year, rows in year_data.items():
+        ws = wb.create_sheet(title=str(year))
+        # Header row — the reader uses header=0 and overrides column names, so
+        # actual values here don't matter, but we write canonical names for
+        # readability.
+        ws.append(["date", "discharge"])
+        for date_str, discharge in rows:
+            ws.append([date_str, discharge])
+
+    wb.save(path)
+
+
+def _make_single_river_fixture(tmp_path, code="19999", river_name="Demo_River"):
+    """
+    Create a single single-river xlsx file in tmp_path.
+
+    Filename follows the ``{code}_{river_name}_UZB_SYSTEM.xlsx`` convention.
+    Returns the full path to the created file.
+    """
+    filename = f"{code}_{river_name}_UZB_SYSTEM.xlsx"
+    path = tmp_path / filename
+
+    year_data = {
+        2000: [
+            ("01.01.2000", 100.5),
+            ("02.01.2000", 101.5),
+            ("03.01.2000", 102.5),
+        ],
+        2001: [
+            ("01.01.2001", 200.5),
+            ("02.01.2001", 201.5),
+        ],
+    }
+    _build_single_river_xlsx(path, code, river_name, year_data)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Tests for read_runoff_data_from_single_river_xlsx (documenting existing
+# behavior — all tests in this class MUST pass against current src.py)
+# ---------------------------------------------------------------------------
+
+
+import logging  # noqa: E402  (appended after existing imports block)
+
+
+class TestSingleRiverReader:
+    """Unit tests for the single-river xlsx reader (no existing tests before P1)."""
+
+    def test_happy_path(self, tmp_path):
+        """Two-year file: returns rows with correct dtypes and known values."""
+        filepath = _make_single_river_fixture(tmp_path, code="19999", river_name="Demo_River")
+
+        result = src.read_runoff_data_from_single_river_xlsx(str(filepath), code_list=["19999"])
+
+        assert isinstance(result, pd.DataFrame)
+        assert not result.empty
+
+        # Column presence (order-independent)
+        assert {"date", "discharge", "code", "name"} <= set(result.columns)
+
+        # Date dtype must be datetime64
+        assert result["date"].dtype.kind == "M", (
+            f"Expected datetime64 dtype for date column, got {result['date'].dtype}"
+        )
+
+        # Code dtype must be integer
+        assert result["code"].dtype.kind in ("i", "u"), (
+            f"Expected integer dtype for code column, got {result['code'].dtype}"
+        )
+
+        # Discharge dtype must be float
+        assert result["discharge"].dtype.kind == "f", (
+            f"Expected float dtype for discharge column, got {result['discharge'].dtype}"
+        )
+
+        # Specific-row assertion: Jan 2 2000 should have discharge 101.5
+        jan2 = result[result["date"] == pd.Timestamp("2000-01-02")]
+        assert not jan2.empty, "Expected a row for 2000-01-02"
+        assert float(jan2["discharge"].iloc[0]) == 101.5
+
+        # Rows from both years are present
+        years = result["date"].dt.year.unique()
+        assert 2000 in years
+        assert 2001 in years
+
+        # Total row count: 3 + 2 = 5
+        assert len(result) == 5
+
+    def test_code_list_filter_excludes(self, tmp_path, caplog):
+        """File with code 19999 is skipped when code_list contains 19001 only."""
+        filepath = _make_single_river_fixture(tmp_path, code="19999", river_name="Demo")
+
+        with caplog.at_level(logging.DEBUG, logger="src"):
+            result = src.read_runoff_data_from_single_river_xlsx(str(filepath), code_list=["19001"])
+
+        assert isinstance(result, pd.DataFrame)
+        assert result.empty
+
+        # A debug log mentioning "not in code_list" must be emitted
+        assert any(
+            "not in code_list" in record.message.lower()
+            or "not in code_list" in record.getMessage().lower()
+            for record in caplog.records
+        ), (
+            "Expected a debug log message mentioning 'not in code_list' when "
+            "code 19999 is excluded by code_list=['19001']"
+        )
+
+    def test_code_list_filter_includes(self, tmp_path):
+        """File with code 19999 is included when code_list=['19999']."""
+        filepath = _make_single_river_fixture(tmp_path, code="19999", river_name="Demo")
+
+        result = src.read_runoff_data_from_single_river_xlsx(str(filepath), code_list=["19999"])
+
+        assert isinstance(result, pd.DataFrame)
+        assert not result.empty
+
+    def test_missing_values_handled(self, tmp_path):
+        """Rows with '-' or empty discharge cells become NaN in output."""
+        path = tmp_path / "19876_MissingTest_UZB_SYSTEM.xlsx"
+        year_data = {
+            2000: [
+                ("01.01.2000", 50.5),
+                ("02.01.2000", "-"),  # explicit dash — must become NaN
+                ("03.01.2000", None),  # empty cell — must become NaN
+                ("04.01.2000", 55.5),
+            ],
+        }
+        _build_single_river_xlsx(path, "19876", "MissingTest", year_data)
+
+        result = src.read_runoff_data_from_single_river_xlsx(str(path), code_list=["19876"])
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 4  # all rows returned, even with NaN
+
+        discharges = result.sort_values("date")["discharge"].values
+        # Jan 1: 50.5
+        assert float(discharges[0]) == 50.5
+        # Jan 2: NaN (from "-")
+        assert pd.isna(discharges[1]), "Expected NaN for '-' discharge"
+        # Jan 3: NaN (from empty cell)
+        assert pd.isna(discharges[2]), "Expected NaN for empty discharge cell"
+        # Jan 4: 55.5
+        assert float(discharges[3]) == 55.5
+
+    def test_file_not_found(self, tmp_path):
+        """Nonexistent file path raises FileNotFoundError."""
+        nonexistent = str(tmp_path / "99999_NoFile_UZB_SYSTEM.xlsx")
+
+        with pytest.raises(FileNotFoundError):
+            src.read_runoff_data_from_single_river_xlsx(nonexistent, code_list=["99999"])
+
+
+# ---------------------------------------------------------------------------
+# Tests for the new dispatch behavior of read_all_runoff_data_from_uzhm_excel
+# (these MUST fail against current src.py — they describe P2's new behavior)
+# ---------------------------------------------------------------------------
+
+
+class TestUzhmExcelDispatch:
+    """
+    Dispatch tests for read_all_runoff_data_from_uzhm_excel.
+
+    ALL tests in this class are expected to FAIL against current src.py.
+    They pin the behavior that P2 will implement.  Assertion-level failures
+    (not import/collection errors) confirm the gap.
+    """
+
+    def _make_wide_fixture(self, tmp_path, code="19001"):
+        """Create a minimal wide-matrix xlsx in tmp_path and return path."""
+        year_data = {2000: _make_year_data(800.0)}
+        _build_uzhm_xlsx(
+            tmp_path / f"{code}.xlsx",
+            f"{code} Test-River",
+            year_data,
+        )
+        return tmp_path / f"{code}.xlsx"
+
+    def _make_single_river_in_dir(self, directory, code="19999", river_name="Demo_River"):
+        """Create a single-river xlsx in directory and return path."""
+        filename = f"{code}_{river_name}_UZB_SYSTEM.xlsx"
+        path = directory / filename
+        year_data = {
+            2000: [
+                ("01.01.2000", 300.5),
+                ("02.01.2000", 301.5),
+            ],
+        }
+        _build_single_river_xlsx(path, code, river_name, year_data)
+        return path
+
+    def test_uzhm_excel_dispatches_single_river_format(self, tmp_path):
+        """Dir has both formats; result must contain rows for both codes."""
+        self._make_wide_fixture(tmp_path, code="19001")
+        self._make_single_river_in_dir(tmp_path, code="19999", river_name="Demo_River")
+
+        orig = os.environ.get("ieasyforecast_daily_discharge_path")
+        try:
+            os.environ["ieasyforecast_daily_discharge_path"] = str(tmp_path)
+            result = src.read_all_runoff_data_from_uzhm_excel(code_list=["19001", "19999"])
+
+            assert result is not None
+            assert isinstance(result, pd.DataFrame)
+            assert not result.empty
+
+            codes_in_result = set(result["code"].unique())
+            assert 19001 in codes_in_result, "Expected code 19001 (wide-matrix) in result"
+            assert 19999 in codes_in_result, (
+                "Expected code 19999 (single-river) in result — "
+                "single-river dispatch not yet implemented (P2)"
+            )
+        finally:
+            if orig is None:
+                os.environ.pop("ieasyforecast_daily_discharge_path", None)
+            else:
+                os.environ["ieasyforecast_daily_discharge_path"] = orig
+
+    def test_uzhm_excel_single_river_only(self, tmp_path):
+        """Dir has only a single-river file; result has code 19999."""
+        self._make_single_river_in_dir(tmp_path, code="19999", river_name="Demo_River")
+
+        orig = os.environ.get("ieasyforecast_daily_discharge_path")
+        try:
+            os.environ["ieasyforecast_daily_discharge_path"] = str(tmp_path)
+            result = src.read_all_runoff_data_from_uzhm_excel(code_list=["19999"])
+
+            assert result is not None
+            assert isinstance(result, pd.DataFrame)
+            assert not result.empty
+
+            codes_in_result = set(result["code"].unique())
+            assert 19999 in codes_in_result, (
+                "Expected code 19999 (single-river) in result — "
+                "single-river dispatch not yet implemented (P2)"
+            )
+        finally:
+            if orig is None:
+                os.environ.pop("ieasyforecast_daily_discharge_path", None)
+            else:
+                os.environ["ieasyforecast_daily_discharge_path"] = orig
+
+    def test_uzhm_excel_skips_unknown_filename_pattern(self, tmp_path):
+        """Dir has a valid wide-matrix file and a garbage-named file; no exception raised."""
+        self._make_wide_fixture(tmp_path, code="19001")
+
+        # Create a garbage file with wide-matrix *content* but unrecognised name
+        garbage_path = tmp_path / "garbage_file.xlsx"
+        _build_uzhm_xlsx(
+            garbage_path,
+            "19002 Garbage-River",
+            {2000: _make_year_data(400.0)},
+        )
+
+        orig = os.environ.get("ieasyforecast_daily_discharge_path")
+        try:
+            os.environ["ieasyforecast_daily_discharge_path"] = str(tmp_path)
+            # Should not raise; data for 19001 returned; garbage data (400-range) absent
+            result = src.read_all_runoff_data_from_uzhm_excel(code_list=["19001", "19002"])
+
+            assert result is not None
+            assert isinstance(result, pd.DataFrame)
+            assert not result.empty
+
+            # Data from garbage file uses base_value=400 → discharge > 400
+            # Data from wide-matrix 19001 uses base_value=800 → discharge > 800
+            # Garbage file's code 19002 must NOT appear in result
+            codes_in_result = set(result["code"].unique())
+            assert 19002 not in codes_in_result, (
+                "Garbage file 'garbage_file.xlsx' must be skipped — unknown filename pattern"
+            )
+        finally:
+            if orig is None:
+                os.environ.pop("ieasyforecast_daily_discharge_path", None)
+            else:
+                os.environ["ieasyforecast_daily_discharge_path"] = orig
+
+    def test_uzhm_excel_ignores_excel_temp_files(self, tmp_path):
+        """Temp file ~$19001.xlsx must be skipped; no duplicate rows from it."""
+        self._make_wide_fixture(tmp_path, code="19001")
+
+        # Create a zero-byte temp file (as Excel would create it)
+        temp_file = tmp_path / "~$19001.xlsx"
+        temp_file.write_bytes(b"")
+
+        orig = os.environ.get("ieasyforecast_daily_discharge_path")
+        try:
+            os.environ["ieasyforecast_daily_discharge_path"] = str(tmp_path)
+            result = src.read_all_runoff_data_from_uzhm_excel(code_list=["19001"])
+
+            assert result is not None
+            assert isinstance(result, pd.DataFrame)
+            assert not result.empty
+
+            # Count rows with code 19001; should come from exactly one file
+            n_rows = len(result[result["code"] == 19001])
+            # Wide-matrix for year 2000 has at most 366 rows; temp file would double it
+            # We assert no duplication by checking the result is sensible (< 500 rows)
+            assert n_rows < 500, (
+                f"Too many rows ({n_rows}) for code 19001 — temp file may have been read"
+            )
+        finally:
+            if orig is None:
+                os.environ.pop("ieasyforecast_daily_discharge_path", None)
+            else:
+                os.environ["ieasyforecast_daily_discharge_path"] = orig
+
+    def test_uzhm_excel_date_dtype_is_datetime64(self, tmp_path):
+        """Combined result from both formats must have datetime64 date column."""
+        self._make_wide_fixture(tmp_path, code="19001")
+        self._make_single_river_in_dir(tmp_path, code="19999", river_name="Demo_River")
+
+        orig = os.environ.get("ieasyforecast_daily_discharge_path")
+        try:
+            os.environ["ieasyforecast_daily_discharge_path"] = str(tmp_path)
+            result = src.read_all_runoff_data_from_uzhm_excel(code_list=["19001", "19999"])
+
+            assert result is not None
+            assert isinstance(result, pd.DataFrame)
+            assert not result.empty
+
+            assert result["date"].dtype.kind == "M", (
+                f"Expected datetime64[ns] for date column, got {result['date'].dtype} — "
+                "wide-matrix reader returns datetime.date objects (P2 Part A) and "
+                "single-river dispatch not yet implemented (P2 Part B)"
+            )
+        finally:
+            if orig is None:
+                os.environ.pop("ieasyforecast_daily_discharge_path", None)
+            else:
+                os.environ["ieasyforecast_daily_discharge_path"] = orig
+
+    def test_uzhm_excel_column_set(self, tmp_path):
+        """Combined result must have exactly columns {date, discharge, code, name}."""
+        self._make_wide_fixture(tmp_path, code="19001")
+        self._make_single_river_in_dir(tmp_path, code="19999", river_name="Demo_River")
+
+        orig = os.environ.get("ieasyforecast_daily_discharge_path")
+        try:
+            os.environ["ieasyforecast_daily_discharge_path"] = str(tmp_path)
+            result = src.read_all_runoff_data_from_uzhm_excel(code_list=["19001", "19999"])
+
+            assert result is not None
+            assert isinstance(result, pd.DataFrame)
+            assert not result.empty
+
+            assert set(result.columns) == {"date", "discharge", "code", "name"}, (
+                f"Expected column set exactly {{'date', 'discharge', 'code', 'name'}}, "
+                f"got {set(result.columns)} — "
+                "single-river dispatch not yet implemented (P2)"
+            )
+        finally:
+            if orig is None:
+                os.environ.pop("ieasyforecast_daily_discharge_path", None)
+            else:
+                os.environ["ieasyforecast_daily_discharge_path"] = orig
+
+    def test_uzhm_excel_warns_on_duplicate_code(self, tmp_path, caplog):
+        """When both 19001.xlsx and 19001_Demo_UZB_SYSTEM.xlsx exist, warn about duplicate."""
+        # Wide-matrix file for 19001
+        self._make_wide_fixture(tmp_path, code="19001")
+
+        # Single-river file for the same code 19001
+        sr_path = tmp_path / "19001_Demo_UZB_SYSTEM.xlsx"
+        year_data = {2000: [("01.01.2000", 500.0)]}
+        _build_single_river_xlsx(sr_path, "19001", "Demo", year_data)
+
+        orig = os.environ.get("ieasyforecast_daily_discharge_path")
+        try:
+            os.environ["ieasyforecast_daily_discharge_path"] = str(tmp_path)
+            with caplog.at_level(logging.WARNING):
+                src.read_all_runoff_data_from_uzhm_excel(code_list=["19001"])
+
+            warning_messages = [
+                r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING
+            ]
+            assert any("19001" in msg for msg in warning_messages), (
+                "Expected a WARNING mentioning code 19001 for duplicate across "
+                "wide-matrix and single-river formats — "
+                "duplicate detection not yet implemented (P2)"
+            )
+        finally:
+            if orig is None:
+                os.environ.pop("ieasyforecast_daily_discharge_path", None)
+            else:
+                os.environ["ieasyforecast_daily_discharge_path"] = orig
+
+    def test_uzhm_excel_routes_six_digit_stem_to_neither(self, tmp_path):
+        """A 6-digit-prefix single-river file must NOT be routed to any reader."""
+        # 6-digit prefix: reader would silently extract '12345' from '123456_...'[:5]
+        six_digit_path = tmp_path / "123456_Demo_UZB_SYSTEM.xlsx"
+        year_data = {2000: [("01.01.2000", 999.0)]}
+        _build_single_river_xlsx(six_digit_path, "123456", "Demo", year_data)
+
+        orig = os.environ.get("ieasyforecast_daily_discharge_path")
+        try:
+            os.environ["ieasyforecast_daily_discharge_path"] = str(tmp_path)
+            # Pass both possible codes; neither should yield data from this file
+            result = src.read_all_runoff_data_from_uzhm_excel(code_list=["12345", "123456"])
+
+            # Either None or empty DataFrame — the 6-digit file must be skipped
+            if result is not None and not result.empty:
+                # Verify no rows came from the 6-digit file (discharge 999.0)
+                assert 999.0 not in result["discharge"].values, (
+                    "File '123456_Demo_UZB_SYSTEM.xlsx' (6-digit prefix) must be "
+                    "skipped — the \\d{5} width constraint in P2 must be enforced"
+                )
+                # Neither code must appear in result
+                codes_in_result = set(result["code"].unique())
+                assert 12345 not in codes_in_result and 123456 not in codes_in_result, (
+                    "6-digit-prefix file must not route any code into the result"
+                )
+        finally:
+            if orig is None:
+                os.environ.pop("ieasyforecast_daily_discharge_path", None)
+            else:
+                os.environ["ieasyforecast_daily_discharge_path"] = orig

--- a/doc/plans/issues/high_prio_gi_draft_preprocessing_runoff_uzhm_single_river.md
+++ b/doc/plans/issues/high_prio_gi_draft_preprocessing_runoff_uzhm_single_river.md
@@ -1,0 +1,247 @@
+# Dispatch single-river xlsx alongside wide-matrix under uzhm
+
+## Status — draft 2026-04-23 (revised after critical review)
+
+## Problem
+
+Under `_read_runoff_data_by_organization()` (`apps/preprocessing_runoff/src/src.py:3147`), the `uzhm` branch dispatches only to `read_all_runoff_data_from_uzhm_excel()` (`src.py:837`), which scans for files with pure-digit filename stems (e.g. `19001.xlsx`) and invokes the wide-matrix reader only. But on the uzhm deployment the `daily_runoff/` folder contains **two** xlsx formats:
+
+1. **Wide-matrix format** — filename pattern: `<code>.xlsx` (pure digits). One sheet per year, day × month matrix. Read by `read_runoff_data_from_uzhm_wide_xlsx()` (`src.py:728`).
+2. **Single-river format** — filename pattern: `<code>_<name>_UZB_SYSTEM.xlsx` (suffix is exactly 16 chars including `.xlsx`). Sheets with `dd.mm.YYYY` date + discharge columns. Format produced by `apps/preprocessing_runoff/dev_code/convert_daily_runoff.py` (see line 229 — suffix length is hardcoded). Reader `read_runoff_data_from_single_river_xlsx()` already exists at `src.py:633` and is used by kghm/tjhm/demo — but is **not** wired into the uzhm dispatch.
+
+The `_UZB_SYSTEM.xlsx` suffix was intentionally chosen so this file would be **excluded** from the wide-matrix filename filter — see the archive note at `doc/plans/issues/archive/high_prio_gi_draft_prepq_uzhm_wide_matrix_adapter.md:226-235`. The exclusion was added; the corresponding dispatch to the single-river reader was not.
+
+**Symptom:** single-river-format stations silently fail to ingest on uzhm. No error is logged; the data is simply absent from the preprocessing DB and therefore absent from the dashboard.
+
+**Mirror exists:** `read_all_runoff_data_from_excel()` (`src.py:1066-1126`, used by kghm/tjhm/demo) already dispatches both patterns in parallel via `parallel_read_excel_files()` and concatenates the results. The same pattern will be applied to the uzhm path, with the refinements listed below.
+
+## Hazards identified during critical review
+
+Before implementation, this plan must address the following real risks:
+
+1. **Date dtype mismatch.** `read_runoff_data_from_uzhm_wide_xlsx()` builds records with `datetime.date(y, m, d)` (`src.py:821`) — producing **object** dtype after `pd.DataFrame(records)`. `read_runoff_data_from_single_river_xlsx()` uses `pd.to_datetime(...).dt.normalize()` (`src.py:714`) — producing **datetime64[ns]** dtype. A naive `pd.concat` coerces the date column to **object** dtype, which will silently break downstream code expecting `datetime64[ns]` (`.dt` accessors, date arithmetic, API payload serialization). This is a latent bug that surfaces only on uzhm because the kghm multi-river reader already uses `pd.read_excel` and returns `datetime64[ns]` — so kghm's concat is type-consistent and ours is not.
+
+2. **`read_runoff_data_from_single_river_xlsx()` has zero existing tests.** The reader is in production for kghm/tjhm/demo and hardcodes `filename[:5]` for station code and `filename[6:-16]` for station name. Any deviation from the 5-digit code + 16-char suffix convention silently corrupts the extracted name or drops the file. We are about to rely on it for uzhm production data.
+
+3. **Restrictive vs permissive filename pattern — with a width constraint matching the reader.** The kghm mirror uses `f[0].isdigit()` (permissive — anything starting with a digit that isn't pure-digit). For uzhm we will use `^\d{5}_.+_SYSTEM$` because `dev_code/convert_daily_runoff.py:229` explicitly produces `_UZB_SYSTEM.xlsx` AND the single-river reader hardcodes `filename[:5]` / `filename[6:-16]` (i.e. exactly 5-digit code, exactly 16-char suffix). Using `\d+` instead of `\d{5}` would let a file like `123456_X_UZB_SYSTEM.xlsx` reach the reader, where `filename[:5]="12345"` silently drops the last digit of the station code. The restrictive width constraint must be documented in a code comment so the constraint and the reader's slicing stay in sync.
+
+4. **Duplicate station code across formats.** If both `19001.xlsx` and `19001_Foo_UZB_SYSTEM.xlsx` exist in the directory (e.g. during a migration), both ingest with the same code and potentially overlapping date ranges. No dedup happens in the uzhm path today; downstream DB write behavior depends on the API. We will emit a `logger.warning` at dispatch time surfacing the collision, without changing ingest behavior. Duplicate detection must extract codes the same way each reader does: `Path(f).stem` for wide-matrix, `Path(f).stem[:5]` for single-river — otherwise the warning could miss real dupes or fire on false positives.
+
+5. **Downstream station filter.** It is not yet verified that `_read_runoff_data_by_organization`'s return value isn't further filtered by organization or station whitelist before the DB write. If it is, single-river-format stations could still be invisible after this fix. This is resolved in **P0**.
+
+6. **Existing negative-control test becomes semantically obsolete.** `test_directory_scan_pure_digits_filter` (`test_src.py:1231-1266`) creates a file with a `<code>_Name_SYSTEM.xlsx` filename in wide-matrix *content* to assert that the wide-matrix directory scan rejects non-pure-digit filenames. Under the new dispatch, that filename now matches `^\d{5}_.+_SYSTEM$` and is routed to the single-river reader, where it's filtered out because its code isn't in the test's `code_list`. The test's assertion still passes, but only by accident. This test must be updated in P2 to reflect the new behavior, or split into two tests that make the new routing explicit.
+
+## Goal
+
+Extend `read_all_runoff_data_from_uzhm_excel()` to scan both filename patterns, dispatch each to the correct reader, normalize date dtype, detect duplicate codes, and concatenate results — mirroring the kghm/demo path with the refinements above. Fix the wide-matrix reader's date dtype at the source so the schema is consistent across readers. Add missing unit tests for the single-river reader.
+
+## Scope
+
+**Files allowed to modify:**
+- `apps/preprocessing_runoff/src/src.py` — two functions only:
+  - `read_all_runoff_data_from_uzhm_excel()` (`src.py:837`) — add single-river dispatch, summary log, duplicate-code warning.
+  - `read_runoff_data_from_uzhm_wide_xlsx()` (`src.py:728`) — narrow change to line 821 only, replacing `date(year, month_idx, day)` with `pd.Timestamp(year, month_idx, day)` so the date column dtype becomes `datetime64[ns]`. No other changes inside this function.
+- `apps/preprocessing_runoff/test/test_src.py` — additions only.
+
+**Explicitly out of scope:**
+- `_read_runoff_data_by_organization()` — no changes.
+- `read_runoff_data_from_single_river_xlsx()` — no signature or behavior changes. New tests for it, but no code edits.
+- Any other reader (`read_runoff_data_from_multiple_rivers_xlsx`, `read_all_runoff_data_from_excel`, CSV readers).
+- Google Sheets ingestion path.
+- `parallel_read_excel_files()` — no changes (per-file success logging is a follow-up).
+- Station library config — user is responsible for ensuring station entries exist in `config_all_stations_library.json` on the server.
+
+**Station codes in fixtures:** use placeholder codes `19001`, `19002`, `19999` — **no real operational station codes** in tests, fixtures, or this plan document.
+
+## Phases
+
+### P0 — Downstream trace (research only)
+
+**Goal:** Confirm that data returned from `_read_runoff_data_by_organization(organization="uzhm", ...)` is not filtered by any station-level whitelist before being written to the preprocessing DB. If a filter is found, its criteria must be documented so we can verify station codes from single-river files will survive it.
+
+**Files:** read-only. No modifications.
+
+**Depends on:** none.
+
+**Agents:** 1 Explore agent.
+
+**Agent prompt scope:**
+- Start at `_read_runoff_data_by_organization` (`src.py:3119`) and trace every caller. Follow the return value through any post-processing, filtering, dedup, and API write steps until the data either reaches the preprocessing API or is persisted to disk.
+- Report: list of transformations applied, any station-code filters encountered, any dtype assumptions on the date column.
+- Explicitly answer: **does any downstream step assume `datetime64[ns]` for the date column** (e.g. via `.dt` accessors, Pandas date arithmetic, JSON serialization that hits `pd.Timestamp.isoformat`, SQL type binding)? This is load-bearing for P2's dtype fix.
+- Conclude with a pass/fail: "A station code newly returned from the dispatcher (e.g. from a single-river file) WILL / WILL NOT appear in the preprocessing DB, assuming the station exists in `config_all_stations_library.json`."
+
+**Acceptance:**
+- Research report with file:line citations.
+- If a filter is found, its criteria are explicit (what it allows, what it rejects).
+- Date-column dtype assumption downstream is called out explicitly (yes/no, and if yes where).
+
+### P1 — Regression tests (passing) + dispatch tests (failing)
+
+**Goal:** Two distinct sets of tests. (a) Regression/documentation tests for the currently-untested single-river reader — these must pass immediately. (b) Dispatch tests describing the new behavior — these must fail against current `src.py` to confirm the gap.
+
+**Files:** `apps/preprocessing_runoff/test/test_src.py` (additions only).
+
+**Depends on:** P0.
+
+**Agents:** 1 Sonnet 4.6, worktree isolation.
+
+**Agent prompt scope:**
+
+*Fixture helpers (additions):*
+- `_build_single_river_xlsx(path, code, river_name, year_data)` — writes a workbook matching what `read_runoff_data_from_single_river_xlsx()` (`src.py:633`) expects. Read that reader first to confirm sheet layout (header row, column names, `dd.mm.YYYY` date format). Filename must follow `{code}_{name}_UZB_SYSTEM.xlsx` convention (exactly 5-digit code, exactly 16-char suffix).
+- **Preferred alternative** if feasible: import and use `write_single_river_excel` from `apps/preprocessing_runoff/dev_code/convert_daily_runoff.py` as the fixture generator. That way tests exercise the actual producer's output format, not our interpretation of the reader's contract. If this requires inputs the tests can't easily synthesize, fall back to the manual helper.
+- Reuse the in-memory openpyxl fixture pattern from `test_src.py:954-998` (see `_build_uzhm_xlsx`, `_make_uzhm_fixture`).
+
+*New test class `TestSingleRiverReader`* (direct unit tests for `read_runoff_data_from_single_river_xlsx` — this reader has NO existing tests):
+- `test_happy_path`: one file, two year sheets, returns expected rows with `datetime64[ns]` date dtype, `int` code, `float` discharge.
+- `test_code_list_filter_excludes`: file `19999_Demo_UZB_SYSTEM.xlsx` but `code_list=["19001"]` → empty DataFrame returned, debug-log "not in code_list" emitted.
+- `test_code_list_filter_includes`: file `19999_Demo_UZB_SYSTEM.xlsx` with `code_list=["19999"]` → data returned.
+- `test_missing_values_handled`: sheet contains `"-"` and empty cells → converted to NaN.
+- `test_file_not_found`: nonexistent path → `FileNotFoundError` raised.
+
+*New `TestUzhmExcelDispatch` class (these MUST fail against current `src.py` — they describe the new behavior):*
+- `test_uzhm_excel_dispatches_single_river_format`: fixture dir has `19001.xlsx` (wide-matrix) AND `19999_Demo_River_UZB_SYSTEM.xlsx` (single-river). Assert returned DataFrame has rows for both codes `19001` and `19999`.
+- `test_uzhm_excel_single_river_only`: fixture dir has only `19999_Demo_River_UZB_SYSTEM.xlsx`. Assert data for `19999` is returned.
+- `test_uzhm_excel_skips_unknown_filename_pattern`: fixture dir has `garbage_file.xlsx` (no code extractable). Assert it is skipped — no exception, no data for it.
+- `test_uzhm_excel_ignores_excel_temp_files`: fixture dir has `~$19001.xlsx` and `19001.xlsx`. Assert temp file is skipped.
+- `test_uzhm_excel_date_dtype_is_datetime64`: fixture dir has one wide-matrix file and one single-river file. Assert the returned DataFrame's `date` column dtype is `datetime64[ns]` (not `object`). **Fails twice today**: once because single-river dispatch doesn't happen (P2 fixes it), and in the mixed case also because wide-matrix returns `datetime.date` objects (P2 Part A fixes this).
+- `test_uzhm_excel_column_set`: fixture with both formats. Assert the returned DataFrame's columns are exactly `{"date", "discharge", "code", "name"}` (set equality, not order). Locks the contract against silent schema drift from concat.
+- `test_uzhm_excel_warns_on_duplicate_code`: fixture dir has both `19001.xlsx` and `19001_Demo_UZB_SYSTEM.xlsx`. Using `caplog`, assert a warning is emitted mentioning code `19001` appears in both formats. Data ingestion behavior itself is not asserted (both are ingested; downstream is out of scope).
+- `test_uzhm_excel_routes_six_digit_stem_to_neither`: fixture dir has `123456_Demo_UZB_SYSTEM.xlsx` (6-digit code — violates the reader's `[:5]` slicing contract). Assert it is skipped (not routed to the single-river reader). This pins the regex width constraint from Hazard #3.
+
+*Do NOT modify `src.py` in this phase.*
+
+Run `SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_runoff`. Expected outcomes at end of P1:
+- All existing `TestUzhmWideMatrixReader` tests pass (unchanged).
+- All new `TestSingleRiverReader` tests pass (they document existing behavior).
+- All new `TestUzhmExcelDispatch` tests fail with clear assertion messages (not import/collection errors).
+
+**Acceptance:**
+- Existing `TestUzhmWideMatrixReader` tests all pass.
+- `TestSingleRiverReader` tests all pass.
+- `TestUzhmExcelDispatch` tests all fail with assertion-level errors (confirming the gap and the expected P2 change).
+- `_build_single_river_xlsx` helper (or the imported `write_single_river_excel` path) is present and produces files that the single-river reader can parse — verified by `TestSingleRiverReader` tests.
+
+### P2 — Implement dispatch + dtype fix + duplicate warning
+
+**Goal:** Extend `read_all_runoff_data_from_uzhm_excel()` to scan both patterns in parallel, normalize date dtype at the source in the wide-matrix reader, emit a duplicate-code warning, and concatenate results with a consistent schema.
+
+**Files:**
+- `apps/preprocessing_runoff/src/src.py` — `read_all_runoff_data_from_uzhm_excel()` (`src.py:837`) and a minimal edit to `read_runoff_data_from_uzhm_wide_xlsx()` line 821.
+
+**Depends on:** P1.
+
+**Agents:** 1 Sonnet 4.6, worktree isolation.
+
+**Agent prompt scope:**
+
+*Part A — narrow dtype fix in `read_runoff_data_from_uzhm_wide_xlsx`:*
+- At `src.py:821`, change:
+  ```python
+  date_col: date(year, month_idx, day),
+  ```
+  to:
+  ```python
+  date_col: pd.Timestamp(year, month_idx, day),
+  ```
+- No other changes to this function. Imports: `pd` is already imported; if `date` import becomes unused, leave it (out of scope to clean up).
+- This makes the wide-matrix reader return `datetime64[ns]` for the date column, matching the single-river reader and eliminating the concat-coercion hazard.
+
+*Part B — dispatch in `read_all_runoff_data_from_uzhm_excel`:*
+- Mirror the pattern at `read_all_runoff_data_from_excel()` (`src.py:1066-1126`), with these specifics:
+  - Partition the directory listing using `re.fullmatch` on `Path(f).stem`:
+    - **wide-matrix bucket:** `^\d+$` (e.g. `19001`).
+    - **single-river bucket:** `^\d{5}_.+_SYSTEM$` (e.g. `19999_Demo_River_UZB_SYSTEM`) — **5-digit code constraint is load-bearing**, it pins the regex to the single-river reader's hardcoded `filename[:5]` slicing.
+    - Temp files (`~$...`) and anything else: skip with `logger.debug`.
+  - **Inline comment** above the single-river regex: "Exactly-5-digit constraint matches `read_runoff_data_from_single_river_xlsx`'s hardcoded `filename[:5]` and `filename[6:-16]` slicing. Do NOT relax to `\\d+_...` or to kghm's `f[0].isdigit()` without first generalising the reader's name/code extraction — otherwise 6-digit codes get silently truncated."
+  - **Duplicate-code detection (runs BEFORE any file reading, purely from filename metadata):** extract codes using each reader's convention — wide-matrix: `Path(f).stem`; single-river: `Path(f).stem[:5]`. For each code appearing in both buckets, emit `logger.warning(f"uzhm xlsx ingest: station {code} appears in BOTH wide-matrix and single-river files — both will be ingested, downstream dedup is not performed here")`. Ingest proceeds regardless; no filtering.
+  - Call `parallel_read_excel_files()` for each non-empty bucket with the appropriate reader. Both readers get the same `code_list` passed through.
+  - Empty-safe concat: handle all four cases (both empty → return `None` with warning; one empty → return the other; both non-empty → `pd.concat([df_wide, df_sr], ignore_index=True)`).
+  - Summary log at the end: `logger.info(f"uzhm xlsx ingest: {n_wide} wide-matrix + {n_sr} single-river files, {0 if result is None else len(result)} rows")`.
+- **Do NOT** change the signature of `read_all_runoff_data_from_uzhm_excel` or of either reader.
+- **Do NOT** modify `_read_runoff_data_by_organization` or any other function.
+
+*Part C — update the now-semantically-obsolete negative-control test:*
+- `test_directory_scan_pure_digits_filter` (`test_src.py:1231-1266`) was written to verify the wide-matrix filename filter rejects non-pure-digit stems. Under the new dispatch its fixture file `10001_Name_SYSTEM.xlsx` now matches the single-river bucket. The test assertion still passes (via `code_list` filter), but its intent is no longer what the code does. Replace it with two tests:
+  1. `test_directory_scan_pure_digits_goes_to_wide_matrix`: fixture with `19001.xlsx`; assert only wide-matrix reader sees it. (Can be asserted indirectly: data parses in wide-matrix shape.)
+  2. `test_directory_scan_system_suffix_goes_to_single_river`: fixture with `19002_Name_UZB_SYSTEM.xlsx` in single-river *content*; assert it is routed to the single-river reader and parses successfully when its code is in `code_list`.
+- Delete the old `test_directory_scan_pure_digits_filter` after the replacements are added.
+
+Re-run `SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_runoff`. All tests (existing + P1 + Part C replacements) must pass.
+
+**Acceptance:**
+- All P1 dispatch tests now pass (dtype, column set, duplicate warning, 6-digit-stem skip).
+- All pre-existing `TestUzhmWideMatrixReader` tests still pass. **Agent must actually run them and confirm** — do not assume the dtype change is transparent. Pay specific attention to:
+  - `test_happy_path` line 1072: `result[result["date"] == date_type(2000, 1, 1)]` (pandas coerces `date` vs `datetime64[ns]` equality, but verify the row is actually returned).
+  - `test_none_discharge_excluded` lines 1159-1164: same equality pattern.
+  - `test_invalid_dates_excluded` lines 1098-1131: `.apply(lambda d: d.year)` — works for both `date` and `pd.Timestamp`, so should be unaffected.
+- Part C test replacements present; old `test_directory_scan_pure_digits_filter` removed.
+- Diff in `src.py` is confined to `read_all_runoff_data_from_uzhm_excel` and the single-line dtype fix at line 821. Nothing else in the file touched.
+- Signatures of `read_all_runoff_data_from_uzhm_excel`, `read_runoff_data_from_uzhm_wide_xlsx`, `read_runoff_data_from_single_river_xlsx` unchanged.
+- No changes to imports that aren't strictly required.
+
+### P3 — Integration test via organization router
+
+**Goal:** Verify end-to-end that `_read_runoff_data_by_organization(organization="uzhm", ...)` returns data from both formats with correct dtype.
+
+**Files:** `apps/preprocessing_runoff/test/test_src.py` — additions only.
+
+**Depends on:** P2.
+
+**Agents:** 1 Sonnet 4.6, worktree isolation.
+
+**Agent prompt scope:**
+- Add a sibling to `test_organization_router_uzhm` (`test_src.py:1267-1292`) called `test_organization_router_uzhm_mixed_formats`:
+  - Fixture directory contains one wide-matrix xlsx (`19001.xlsx`) and one single-river xlsx (`19999_Demo_River_UZB_SYSTEM.xlsx`).
+  - Call `_read_runoff_data_by_organization(organization="uzhm", ...)`.
+  - Assert returned DataFrame contains rows for both station codes.
+  - Assert date column dtype is `datetime64[ns]`.
+- Add `test_uzhm_excel_logs_summary` using `caplog`: both formats present → assert the summary log line from P2 is emitted with both counts and total row count.
+- **Do NOT** modify `_read_runoff_data_by_organization` or `src.py`.
+
+**Acceptance:**
+- New tests pass.
+- `SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_runoff` → zero failures, zero unexpected skips.
+- `SAPPHIRE_TEST_ENV=True bash run_tests.sh` (full suite) → zero failures, zero unexpected skips.
+
+## Final verification (orchestrator)
+
+After P3 completes:
+
+1. `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_runoff` — zero failures, zero unexpected skips.
+2. `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh` — full suite, zero failures, zero unexpected skips.
+3. Orchestrator-level deliberation on the combined diff:
+   - `apps/preprocessing_runoff/src/src.py`: only the two scoped functions touched.
+   - `apps/preprocessing_runoff/test/test_src.py`: additions only.
+   - Line 821 dtype change: `date(...)` → `pd.Timestamp(...)`, nothing else in the wide-matrix reader.
+   - Summary log, duplicate-code warning, and restrictive-pattern comment all present as specified.
+   - No real station codes in any fixture.
+4. Hand off to user for server verification:
+   - Restore the previously-renamed file on the server to its original `<code>_<Name>_UZB_SYSTEM.xlsx` form (the file that was temporarily renamed to a pure-digit stem during the investigation).
+   - Confirm an entry for that station code exists in `config_all_stations_library.json` on the server.
+   - Deploy this branch; rerun the preprocessing_runoff init workflow.
+   - Confirm the new summary log line appears and lists the single-river file count.
+   - Confirm that station's data appears in the dashboard alongside the wide-matrix stations.
+
+## Out of scope / follow-ups
+
+- Per-file success logging in `parallel_read_excel_files()` (would help operators trace silent-skip cases — separate issue).
+- Format sniffing (detecting single-river vs wide-matrix from sheet structure rather than filename) — not needed; filename convention is reliable and documented.
+- Relaxing the single-river reader's hardcoded `filename[:5]` / `filename[6:-16]` slicing — defer until a second uzhm naming convention actually appears; flagged here as a known fragility.
+- Dedup of overlapping (code, date) rows when a station has both formats — out of scope; flagged via warning log only.
+- Station library entry validation — user to confirm the station code has an entry in `config_all_stations_library.json` on server before server test.
+- `read_runoff_data_from_single_river_xlsx` iterates `xls.sheet_names` without filtering (`src.py:703`) — unlike the wide-matrix reader, it does not skip non-data sheets like "Summary". Safe in practice because `convert_daily_runoff.py` produces year-only sheets, but a hand-edited file with a summary tab would be silently included. Flag as known fragility.
+
+## Dependency graph
+
+```json
+{
+  "phases": {
+    "P0": { "depends_on": [], "parallel_agents": 1 },
+    "P1": { "depends_on": ["P0"], "parallel_agents": 1 },
+    "P2": { "depends_on": ["P1"], "parallel_agents": 1 },
+    "P3": { "depends_on": ["P2"], "parallel_agents": 1 }
+  }
+}
+```


### PR DESCRIPTION
## Summary

- Extend `read_all_runoff_data_from_uzhm_excel` to scan both pure-digit filename stems AND `<code>_<name>_SYSTEM.xlsx` patterns, dispatching each to the appropriate reader — mirrors the existing kghm/demo multi-format dispatch. Restrictive `^\d{5}_.+_SYSTEM$` regex pinned to the single-river reader's hardcoded `filename[:5]` / `filename[6:-16]` slicing (see inline comment).
- Normalize wide-matrix reader output to `datetime64[ns]` (`pd.Timestamp` instead of `datetime.date`) so the concatenated frame has a uniform date dtype regardless of which reader produced it. The downstream pipeline already re-normalizes at `src.py:3561`, but doing it at the reader keeps the schema consistent and makes it testable at the dispatcher boundary.
- Warn when the same station code appears in both formats; ingest proceeds without dedup.
- Add the first unit tests for `read_runoff_data_from_single_river_xlsx` (previously zero-tested despite being in production for kghm/tjhm/demo).

Unblocks ingestion of `UZB_SYSTEM`-format single-river xlsx files on the uzhm deployment (the Zeravshan station), which were silently skipped under the previous wide-matrix-only dispatch.

Planning doc with the critical-review hazards captured in-commit: `doc/plans/issues/high_prio_gi_draft_preprocessing_runoff_uzhm_single_river.md`.

## Test plan

- [x] `SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_runoff` → 296 passed, 0 failed, 0 skipped (up from 280 before P1 added coverage).
- [x] Full local app suite → 11 modules pass, 4 pre-existing service skips (missing `.venv`, unrelated).
- [x] Local dispatcher run against real uzhm data (`~/Documents/GitHub/uzb_data_forecast_tools/daily_runoff/`) → 4 wide-matrix + 1 single-river files, 43846 rows, 5 unique station codes including the previously-missing Zeravshan station, `date` dtype `datetime64[ns]`. Summary log line confirmed.
- [ ] Server-side: rename the file back to its original `<code>_<Name>_UZB_SYSTEM.xlsx` form; rerun preprocessing_runoff init; verify the summary log appears and the Zeravshan station's data now renders in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)