### PR TITLE
Fix ML skill metric archive split + dashboard long-horizon rendering

### DIFF
--- a/apps/forecast_dashboard/src/db.py
+++ b/apps/forecast_dashboard/src/db.py
@@ -34,6 +34,10 @@ def _horizon_in_year_col(horizon: str) -> str:
         return "decad_in_year"
     if horizon == "month":
         return "month_in_year"
+    if horizon == "quarter":
+        return "quarter_in_year"
+    if horizon == "season":
+        return "season_in_year"
     return "pentad_in_year"
 
 
@@ -427,7 +431,7 @@ def get_forecast_stats(horizon, station) -> pd.DataFrame:
         "end_date": f"{CURRENT_YEAR}-12-31",
         "limit": 1000,
     })
-    if df.empty or "model_type" not in df.columns:
+    if df.empty or "model_type" not in df.columns or "horizon_in_year" not in df.columns:
         logger.warning("get_forecast_stats: no skill-metric data for station %s", code)
         return pd.DataFrame(columns=[
             "code", _horizon_in_year_col(horizon),
@@ -473,7 +477,7 @@ def get_forecast_stats_all(horizon) -> pd.DataFrame:
         ])
 
     df = pd.concat(frames, ignore_index=True)
-    if "model_type" not in df.columns:
+    if "model_type" not in df.columns or "horizon_in_year" not in df.columns:
         return pd.DataFrame(columns=[
             "code", _horizon_in_year_col(horizon),
             "model_short", "model_long",
@@ -555,7 +559,7 @@ def get_long_forecasts_quarter(station=None, horizon_value=1) -> pd.DataFrame:
             "model_short", "model_long",
             "forecasted_discharge", "flag",
             "Q5", "Q25", "Q75", "Q95", "E[Q]",
-            "valid_from", "month_in_year",
+            "valid_from", "month_in_year", "quarter_in_year",
         ])
 
     df.rename(columns={
@@ -568,6 +572,7 @@ def get_long_forecasts_quarter(station=None, horizon_value=1) -> pd.DataFrame:
     df.drop(columns=["id", "horizon_type", "horizon_value"], inplace=True, errors="ignore")
     df["valid_from"] = pd.to_datetime(df["valid_from"])
     df["month_in_year"] = df["valid_from"].dt.month
+    df["quarter_in_year"] = ((df["valid_from"].dt.month - 1) // 3 + 1)
     df["Date"] = df["date"]
     df["year"] = df["date"].dt.year
     # Keep only the latest-by-date row per (code, model_short)
@@ -601,7 +606,7 @@ def get_long_forecasts_season(station=None) -> pd.DataFrame:
             "model_short", "model_long",
             "forecasted_discharge", "flag",
             "Q5", "Q25", "Q75", "Q95", "E[Q]",
-            "valid_from", "month_in_year",
+            "valid_from", "month_in_year", "season_in_year",
         ])
 
     df.rename(columns={
@@ -614,6 +619,7 @@ def get_long_forecasts_season(station=None) -> pd.DataFrame:
     df.drop(columns=["id", "horizon_type", "horizon_value"], inplace=True, errors="ignore")
     df["valid_from"] = pd.to_datetime(df["valid_from"])
     df["month_in_year"] = df["valid_from"].dt.month
+    df["season_in_year"] = 1
     df["Date"] = df["date"]
     df["year"] = df["date"].dt.year
     # Keep only the latest-by-date row per (code, model_short)
@@ -737,6 +743,24 @@ def _get_data_monthly(station, all_stations, add_labels, i18n_models) -> dict:
 def _get_data_quarter(station, all_stations, add_labels, i18n_models) -> dict:
     """Load data for quarterly horizon — only long forecasts + daily hydrograph."""
     forecasts_all = i18n_models(add_labels(get_long_forecasts_quarter(station)))
+    forecast_stats = i18n_models(get_forecast_stats("quarter", station))
+
+    hin = _horizon_in_year_col("quarter")
+    merge_keys = ["code", hin, "model_short"]
+    can_merge = (
+        not forecasts_all.empty
+        and not forecast_stats.empty
+        and all(k in forecasts_all.columns for k in merge_keys)
+        and all(k in forecast_stats.columns for k in merge_keys)
+    )
+    if can_merge:
+        forecasts_all = forecasts_all.merge(
+            forecast_stats,
+            on=merge_keys,
+            how="left",
+            suffixes=("", "_stats"),
+        )
+
     return {
         "hydrograph_day_all":    add_labels(get_hydrograph_day_all(station)),
         "hydrograph_pentad_all": pd.DataFrame(),
@@ -746,13 +770,31 @@ def _get_data_quarter(station, all_stations, add_labels, i18n_models) -> dict:
         "ml_forecast":           pd.DataFrame(),
         "linreg_predictor":      pd.DataFrame(),
         "forecasts_all":         forecasts_all,
-        "forecast_stats":        pd.DataFrame(),
+        "forecast_stats":        forecast_stats,
     }
 
 
 def _get_data_season(station, all_stations, add_labels, i18n_models) -> dict:
     """Load data for seasonal horizon — only long forecasts + daily hydrograph."""
     forecasts_all = i18n_models(add_labels(get_long_forecasts_season(station)))
+    forecast_stats = i18n_models(get_forecast_stats("season", station))
+
+    hin = _horizon_in_year_col("season")
+    merge_keys = ["code", hin, "model_short"]
+    can_merge = (
+        not forecasts_all.empty
+        and not forecast_stats.empty
+        and all(k in forecasts_all.columns for k in merge_keys)
+        and all(k in forecast_stats.columns for k in merge_keys)
+    )
+    if can_merge:
+        forecasts_all = forecasts_all.merge(
+            forecast_stats,
+            on=merge_keys,
+            how="left",
+            suffixes=("", "_stats"),
+        )
+
     return {
         "hydrograph_day_all":    add_labels(get_hydrograph_day_all(station)),
         "hydrograph_pentad_all": pd.DataFrame(),
@@ -762,5 +804,5 @@ def _get_data_season(station, all_stations, add_labels, i18n_models) -> dict:
         "ml_forecast":           pd.DataFrame(),
         "linreg_predictor":      pd.DataFrame(),
         "forecasts_all":         forecasts_all,
-        "forecast_stats":        pd.DataFrame(),
+        "forecast_stats":        forecast_stats,
     }

--- a/apps/forecast_dashboard/src/db.py
+++ b/apps/forecast_dashboard/src/db.py
@@ -708,6 +708,24 @@ def _get_data_monthly(station, all_stations, add_labels, i18n_models) -> dict:
             suffixes=("", "_stats"),
         )
 
+    long_forecasts_quarter = i18n_models(add_labels(get_long_forecasts_quarter(station, horizon_value=1)))
+    quarter_forecast_stats = i18n_models(get_forecast_stats("quarter", station))
+    quarter_hin = _horizon_in_year_col("quarter")
+    quarter_merge_keys = ["code", quarter_hin, "model_short"]
+    can_merge_quarter = (
+        not long_forecasts_quarter.empty
+        and not quarter_forecast_stats.empty
+        and all(k in long_forecasts_quarter.columns for k in quarter_merge_keys)
+        and all(k in quarter_forecast_stats.columns for k in quarter_merge_keys)
+    )
+    if can_merge_quarter:
+        long_forecasts_quarter = long_forecasts_quarter.merge(
+            quarter_forecast_stats,
+            on=quarter_merge_keys,
+            how="left",
+            suffixes=("", "_stats"),
+        )
+
     data = {
         "hydrograph_day_all":   add_labels(get_hydrograph_day_all(station)),
         "hydrograph_pentad_all": pd.DataFrame(),
@@ -719,7 +737,7 @@ def _get_data_monthly(station, all_stations, add_labels, i18n_models) -> dict:
         "forecasts_all":        forecasts_all,
         "forecast_stats":       forecast_stats,
         "long_forecasts_m0":    pd.DataFrame(),
-        "long_forecasts_quarter": i18n_models(add_labels(get_long_forecasts_quarter(station, horizon_value=1))),
+        "long_forecasts_quarter": long_forecasts_quarter,
     }
     if "month_0" in supported_modes:
         m0 = i18n_models(add_labels(get_long_forecasts(station, horizon_value=0)))

--- a/apps/forecast_dashboard/tests/test_db.py
+++ b/apps/forecast_dashboard/tests/test_db.py
@@ -57,6 +57,12 @@ class TestHorizonInYearCol:
     def test_month(self):
         assert db._horizon_in_year_col("month") == "month_in_year"
 
+    def test_quarter(self):
+        assert db._horizon_in_year_col("quarter") == "quarter_in_year"
+
+    def test_season(self):
+        assert db._horizon_in_year_col("season") == "season_in_year"
+
 
 # ── _resolve_station ──────────────────────────────────────────────────────
 
@@ -127,6 +133,68 @@ _SKILL_METRIC_RECORD = {
     "fhv": None,
     "flv": None,
 }
+
+_QUARTER_FORECAST_RECORD_19999 = {
+    "id": 20,
+    "horizon_type": "quarter",
+    "horizon_value": 1,
+    "code": "19999",
+    "date": "2026-03-22",
+    "model_type": "LR_Base",
+    "model_type_description": "Linear regression base",
+    "valid_from": "2026-04-01",
+    "valid_to": "2026-06-30",
+    "flag": 0,
+    "composition": "",
+    "q": 200.0,
+    "q_obs": None,
+    "q_xgb": None,
+    "q_lgbm": None,
+    "q_catboost": None,
+    "q_loc": None,
+    "q05": 180.0,
+    "q10": 185.0,
+    "q25": 190.0,
+    "q50": 200.0,
+    "q75": 210.0,
+    "q90": 215.0,
+    "q95": 220.0,
+}
+
+_SEASON_FORECAST_RECORD_19999 = {
+    **_QUARTER_FORECAST_RECORD_19999,
+    "id": 30,
+    "horizon_type": "season",
+    "horizon_value": 1,
+    "valid_to": "2026-09-30",
+    "q": 300.0,
+    "q05": 270.0,
+    "q95": 330.0,
+}
+
+
+def _skill_metric_record_19999(horizon, horizon_in_year, model_type, delta):
+    return {
+        "id": 100 + int(delta * 10),
+        "horizon_type": horizon,
+        "horizon_in_year": horizon_in_year,
+        "code": "19999",
+        "model_type": model_type,
+        "model_type_description": model_type,
+        "date": "2026-03-15",
+        "sdivsigma": 0.5 + delta,
+        "nse": 0.8,
+        "delta": delta,
+        "accuracy": 90.0 + delta,
+        "mae": 1.0 + delta,
+        "n_pairs": 12,
+        "crps": None,
+        "pbias": None,
+        "kgelf": None,
+        "nse_log": None,
+        "fhv": None,
+        "flv": None,
+    }
 
 
 def _make_mock_response(json_data, status_code=200):
@@ -208,6 +276,112 @@ class TestGetForecastStats:
 
         assert len(result) == 1
         assert result["delta"].iloc[0] == 2.0
+
+    @pytest.mark.parametrize(
+        ("horizon", "period_col", "period_value"),
+        [
+            ("quarter", "quarter_in_year", 2),
+            ("season", "season_in_year", 1),
+        ],
+    )
+    def test_long_horizons_rename_horizon_in_year(
+        self, horizon, period_col, period_value, monkeypatch
+    ):
+        """Quarter and season stats use horizon-specific period keys."""
+        records = [
+            _skill_metric_record_19999(horizon, period_value, "LR_Base", 1.0)
+        ]
+
+        def mock_get(url, **kwargs):
+            return _make_mock_response(records)
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        result = db.get_forecast_stats(horizon, "19999")
+
+        assert period_col in result.columns
+        assert result[period_col].iloc[0] == period_value
+        assert "pentad_in_year" not in result.columns
+        assert "delta" in result.columns
+        assert "sdivsigma" in result.columns
+        assert "mae" in result.columns
+        assert "accuracy" in result.columns
+
+    @pytest.mark.parametrize(
+        ("horizon", "period_col"),
+        [
+            ("quarter", "quarter_in_year"),
+            ("season", "season_in_year"),
+        ],
+    )
+    def test_long_horizons_empty_stats_keep_period_key(
+        self, horizon, period_col, monkeypatch
+    ):
+        """Empty skill-metric responses still declare the right merge key."""
+
+        def mock_get(url, **kwargs):
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        result = db.get_forecast_stats(horizon, "19999")
+
+        assert result.empty
+        assert period_col in result.columns
+        assert "pentad_in_year" not in result.columns
+
+
+class TestGetForecastStatsAll:
+    @pytest.mark.parametrize(
+        ("horizon", "period_col", "period_value"),
+        [
+            ("quarter", "quarter_in_year", 2),
+            ("season", "season_in_year", 1),
+        ],
+    )
+    def test_long_horizons_page_and_rename(
+        self, horizon, period_col, period_value, monkeypatch
+    ):
+        """All-station stats use the same horizon-specific period keys."""
+        records = [
+            _skill_metric_record_19999(horizon, period_value, "LR_Base", 1.0)
+        ]
+
+        def mock_get(url, **kwargs):
+            limit = kwargs["params"]["limit"]
+            assert limit == 1000
+            return _make_mock_response(records)
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        result = db.get_forecast_stats_all(horizon)
+
+        assert period_col in result.columns
+        assert result[period_col].iloc[0] == period_value
+        assert "pentad_in_year" not in result.columns
+
+    @pytest.mark.parametrize(
+        ("horizon", "period_col"),
+        [
+            ("quarter", "quarter_in_year"),
+            ("season", "season_in_year"),
+        ],
+    )
+    def test_long_horizons_empty_all_stats_keep_period_key(
+        self, horizon, period_col, monkeypatch
+    ):
+        """Empty all-station stats declare the right period key."""
+
+        def mock_get(url, **kwargs):
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        result = db.get_forecast_stats_all(horizon)
+
+        assert result.empty
+        assert period_col in result.columns
+        assert "pentad_in_year" not in result.columns
 
 
 # ── _get_data_monthly / get_data ──────────────────────────────────────────
@@ -406,6 +580,28 @@ class TestGetLongForecastsQuarter:
         assert result.empty
         assert "forecasted_discharge" in result.columns
 
+    def test_quarter_in_year_computed_from_valid_from(self, monkeypatch):
+        def mock_get(url, **kwargs):
+            return _make_mock_response([_QUARTER_FORECAST_RECORD_19999])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        result = db.get_long_forecasts_quarter(station="19999")
+
+        assert "quarter_in_year" in result.columns
+        assert result["quarter_in_year"].iloc[0] == 2
+
+    def test_empty_api_response_declares_quarter_key(self, monkeypatch):
+        def mock_get(url, **kwargs):
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        result = db.get_long_forecasts_quarter(station="19999")
+
+        assert result.empty
+        assert "quarter_in_year" in result.columns
+
 
 class TestGetLongForecastsSeason:
     def test_renames_and_latest_dedup(self, monkeypatch):
@@ -434,6 +630,28 @@ class TestGetLongForecastsSeason:
 
         assert result.empty
         assert "forecasted_discharge" in result.columns
+
+    def test_season_in_year_is_single_bucket(self, monkeypatch):
+        def mock_get(url, **kwargs):
+            return _make_mock_response([_SEASON_FORECAST_RECORD_19999])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        result = db.get_long_forecasts_season(station="19999")
+
+        assert "season_in_year" in result.columns
+        assert result["season_in_year"].iloc[0] == 1
+
+    def test_empty_api_response_declares_season_key(self, monkeypatch):
+        def mock_get(url, **kwargs):
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        result = db.get_long_forecasts_season(station="19999")
+
+        assert result.empty
+        assert "season_in_year" in result.columns
 
 
 # ── _get_data_quarter / _get_data_season ─────────────────────────────────
@@ -473,18 +691,103 @@ class TestGetDataQuarter:
                     "forecasts_all", "forecast_stats"):
             assert key in data, f"Missing key: {key}"
 
-    def test_forecast_stats_is_empty(self, monkeypatch):
-        """forecast_stats is always empty for quarter horizon."""
+    def test_forecast_stats_populated_and_merged(self, monkeypatch):
+        """Quarter skill metrics populate forecast_stats and merge into forecasts_all."""
+        forecast = _QUARTER_FORECAST_RECORD_19999
+        skill = _skill_metric_record_19999("quarter", 2, "LR_Base", 1.0)
 
         def mock_get(url, **kwargs):
-            return _make_mock_response([_QUARTER_FORECAST_RECORD])
+            if "/long-forecast/" in url:
+                return _make_mock_response([forecast])
+            if "/skill-metric/" in url:
+                return _make_mock_response([skill])
+            return _make_mock_response([])
 
         monkeypatch.setattr(requests, "get", mock_get)
         self._patch_processing(monkeypatch)
 
-        data = db.get_data("quarter", "99001", self._all_stations_df())
+        data = db.get_data(
+            "quarter",
+            "19999",
+            pd.DataFrame({"code": ["19999"], "station_labels": ["Test River B"]}),
+        )
+
+        assert not data["forecast_stats"].empty
+        fa = data["forecasts_all"]
+        assert "delta" in fa.columns
+        assert "sdivsigma" in fa.columns
+        assert "mae" in fa.columns
+        assert "accuracy" in fa.columns
+        row = fa[(fa["code"] == "19999") & (fa["model_short"] == "LR_Base")]
+        assert len(row) == 1
+        assert row["quarter_in_year"].iloc[0] == 2
+        assert row["delta"].iloc[0] == 1.0
+        assert row["sdivsigma"].iloc[0] == 1.5
+        assert row["mae"].iloc[0] == 2.0
+        assert row["accuracy"].iloc[0] == 91.0
+
+    def test_partial_skill_metrics_preserve_unmatched_forecast_row(self, monkeypatch):
+        """LR_SM stays present with NaN metrics when only LR_Base has skill data."""
+        forecasts = [
+            _QUARTER_FORECAST_RECORD_19999,
+            {
+                **_QUARTER_FORECAST_RECORD_19999,
+                "id": 21,
+                "model_type": "LR_SM",
+                "model_type_description": "Linear regression snowmelt",
+                "q": 210.0,
+            },
+        ]
+        skills = [_skill_metric_record_19999("quarter", 2, "LR_Base", 2.0)]
+
+        def mock_get(url, **kwargs):
+            if "/long-forecast/" in url:
+                return _make_mock_response(forecasts)
+            if "/skill-metric/" in url:
+                return _make_mock_response(skills)
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+        self._patch_processing(monkeypatch)
+
+        data = db.get_data(
+            "quarter",
+            "19999",
+            pd.DataFrame({"code": ["19999"], "station_labels": ["Test River B"]}),
+        )
+
+        fa = data["forecasts_all"]
+        assert set(fa["model_short"]) == {"LR_Base", "LR_SM"}
+        base = fa[fa["model_short"] == "LR_Base"].iloc[0]
+        sm = fa[fa["model_short"] == "LR_SM"].iloc[0]
+        assert base["delta"] == 2.0
+        assert base["sdivsigma"] == 2.5
+        assert pd.isna(sm["delta"])
+        assert pd.isna(sm["sdivsigma"])
+        assert pd.isna(sm["mae"])
+        assert pd.isna(sm["accuracy"])
+
+    def test_no_skill_metrics_still_returns_forecasts(self, monkeypatch):
+        """Empty quarter skill metrics do not block forecast rows."""
+
+        def mock_get(url, **kwargs):
+            if "/long-forecast/" in url:
+                return _make_mock_response([_QUARTER_FORECAST_RECORD_19999])
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+        self._patch_processing(monkeypatch)
+
+        data = db.get_data(
+            "quarter",
+            "19999",
+            pd.DataFrame({"code": ["19999"], "station_labels": ["Test River B"]}),
+        )
 
         assert data["forecast_stats"].empty
+        assert not data["forecasts_all"].empty
+        assert "forecasted_discharge" in data["forecasts_all"].columns
+        assert "delta" not in data["forecasts_all"].columns
 
     def test_no_m0_key(self, monkeypatch):
         """long_forecasts_m0 key must not be present for quarter horizon."""
@@ -549,18 +852,74 @@ class TestGetDataSeason:
                     "forecasts_all", "forecast_stats"):
             assert key in data, f"Missing key: {key}"
 
-    def test_forecast_stats_is_empty(self, monkeypatch):
-        """forecast_stats is always empty for season horizon."""
+    def test_forecast_stats_populated_and_merged(self, monkeypatch):
+        """Season skill metrics populate forecast_stats and merge into forecasts_all."""
+        forecasts = [
+            _SEASON_FORECAST_RECORD_19999,
+            {
+                **_SEASON_FORECAST_RECORD_19999,
+                "id": 31,
+                "model_type": "LR_SM",
+                "model_type_description": "Linear regression snowmelt",
+                "q": 310.0,
+            },
+        ]
+        skills = [
+            _skill_metric_record_19999("season", 1, "LR_Base", 1.0),
+            _skill_metric_record_19999("season", 1, "LR_SM", 3.0),
+        ]
 
         def mock_get(url, **kwargs):
-            return _make_mock_response([_SEASON_FORECAST_RECORD])
+            if "/long-forecast/" in url:
+                return _make_mock_response(forecasts)
+            if "/skill-metric/" in url:
+                return _make_mock_response(skills)
+            return _make_mock_response([])
 
         monkeypatch.setattr(requests, "get", mock_get)
         self._patch_processing(monkeypatch)
 
-        data = db.get_data("season", "99001", self._all_stations_df())
+        data = db.get_data(
+            "season",
+            "19999",
+            pd.DataFrame({"code": ["19999"], "station_labels": ["Test River B"]}),
+        )
+
+        assert not data["forecast_stats"].empty
+        fa = data["forecasts_all"]
+        assert "delta" in fa.columns
+        assert "sdivsigma" in fa.columns
+        assert "mae" in fa.columns
+        assert "accuracy" in fa.columns
+        assert set(fa["model_short"]) == {"LR_Base", "LR_SM"}
+        base = fa[fa["model_short"] == "LR_Base"].iloc[0]
+        sm = fa[fa["model_short"] == "LR_SM"].iloc[0]
+        assert base["season_in_year"] == 1
+        assert base["delta"] == 1.0
+        assert sm["delta"] == 3.0
+        assert sm["sdivsigma"] == 3.5
+
+    def test_no_skill_metrics_still_returns_forecasts(self, monkeypatch):
+        """Empty season skill metrics do not block forecast rows."""
+
+        def mock_get(url, **kwargs):
+            if "/long-forecast/" in url:
+                return _make_mock_response([_SEASON_FORECAST_RECORD_19999])
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+        self._patch_processing(monkeypatch)
+
+        data = db.get_data(
+            "season",
+            "19999",
+            pd.DataFrame({"code": ["19999"], "station_labels": ["Test River B"]}),
+        )
 
         assert data["forecast_stats"].empty
+        assert not data["forecasts_all"].empty
+        assert "forecasted_discharge" in data["forecasts_all"].columns
+        assert "delta" not in data["forecasts_all"].columns
 
     def test_no_m0_key(self, monkeypatch):
         """long_forecasts_m0 key must not be present for season horizon."""

--- a/apps/forecast_dashboard/tests/test_db.py
+++ b/apps/forecast_dashboard/tests/test_db.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 import requests
 from src import db
+from src import vizualization
 
 # ── _convert_na_to_nan ─────────────────────────────────────────────────────
 
@@ -948,3 +949,118 @@ class TestGetDataSeason:
         data = db.get_data("season", "99001", self._all_stations_df())
 
         assert "forecasted_discharge" in data["forecasts_all"].columns
+
+
+class TestSeasonSummaryRendering:
+    """Deterministic data-layer plus summary-table checks for season metrics."""
+
+    def _patch_processing(self, monkeypatch):
+        def add_labels(df, stations):
+            if df.empty:
+                return df
+            return df.assign(station_labels="Test River B")
+
+        monkeypatch.setattr("src.db.processing.add_labels_to_hydrograph", add_labels)
+        monkeypatch.setattr(
+            "src.db.processing.internationalize_forecast_model_names",
+            lambda fn, df, **kw: df,
+        )
+
+    def _model_selection(self):
+        selection = MagicMock()
+        selection.options = {
+            "LR Base": "LR_Base",
+            "LR SM": "LR_SM",
+        }
+        return selection
+
+    def _summary_table(self, forecasts_all):
+        return vizualization.create_forecast_summary_table(
+            lambda value: value,
+            "season",
+            forecasts_all,
+            "Test River B",
+            "2026-03-22",
+            self._model_selection(),
+            "delta",
+            0,
+        )
+
+    def test_season_summary_table_renders_skill_metrics(self, monkeypatch):
+        forecasts = [
+            _SEASON_FORECAST_RECORD_19999,
+            {
+                **_SEASON_FORECAST_RECORD_19999,
+                "id": 31,
+                "model_type": "LR_SM",
+                "model_type_description": "Linear regression snowmelt",
+                "q": 310.0,
+            },
+        ]
+        skills = [
+            _skill_metric_record_19999("season", 1, "LR_Base", 1.0),
+            _skill_metric_record_19999("season", 1, "LR_SM", 3.0),
+        ]
+
+        def mock_get(url, **kwargs):
+            if "/long-forecast/" in url:
+                return _make_mock_response(forecasts)
+            if "/skill-metric/" in url:
+                return _make_mock_response(skills)
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+        self._patch_processing(monkeypatch)
+
+        data = db.get_data(
+            "season",
+            "19999",
+            pd.DataFrame({"code": ["19999"], "station_labels": ["Test River B"]}),
+        )
+        table = self._summary_table(data["forecasts_all"])
+
+        assert set(table["Model"]) == {"LR_Base", "LR_SM"}
+        base = table[table["Model"] == "LR_Base"].iloc[0]
+        sm = table[table["Model"] == "LR_SM"].iloc[0]
+        assert base["Accuracy"] == 91.0
+        assert base["δ"] == 1.0
+        assert base["s/σ"] == 1.5
+        assert base["MAE"] == 2.0
+        assert sm["Accuracy"] == 93.0
+        assert sm["δ"] == 3.0
+        assert sm["s/σ"] == 3.5
+        assert sm["MAE"] == 4.0
+
+    def test_season_summary_table_without_skill_metrics_does_not_crash(
+        self, monkeypatch
+    ):
+        forecasts = [
+            _SEASON_FORECAST_RECORD_19999,
+            {
+                **_SEASON_FORECAST_RECORD_19999,
+                "id": 31,
+                "model_type": "LR_SM",
+                "model_type_description": "Linear regression snowmelt",
+                "q": 310.0,
+            },
+        ]
+
+        def mock_get(url, **kwargs):
+            if "/long-forecast/" in url:
+                return _make_mock_response(forecasts)
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+        self._patch_processing(monkeypatch)
+
+        data = db.get_data(
+            "season",
+            "19999",
+            pd.DataFrame({"code": ["19999"], "station_labels": ["Test River B"]}),
+        )
+        table = self._summary_table(data["forecasts_all"])
+
+        assert set(table["Model"]) == {"LR_Base", "LR_SM"}
+        for column in ("Accuracy", "δ", "s/σ", "MAE"):
+            assert column in table.columns
+            assert table[column].isna().all()

--- a/apps/forecast_dashboard/tests/test_db.py
+++ b/apps/forecast_dashboard/tests/test_db.py
@@ -419,6 +419,173 @@ class TestGetDataMonthly:
             {"code": ["99001"], "station_labels": ["Test River A"]}
         )
 
+    def _all_stations_19999_df(self):
+        return pd.DataFrame(
+            {"code": ["19999"], "station_labels": ["Test Reservoir B"]}
+        )
+
+    def _monthly_forecast_19999(self):
+        return {
+            **_LONG_FORECAST_RECORD,
+            "id": 40,
+            "code": "19999",
+            "model_type": "LR_Base",
+            "model_type_description": "Linear regression base",
+            "q": 150.0,
+        }
+
+    def test_merges_quarter_skill_metrics_into_monthly_quarter_frame(self, monkeypatch):
+        """Month tab data enriches long_forecasts_quarter without changing forecasts_all."""
+        monthly_forecast = self._monthly_forecast_19999()
+        monthly_skill = _skill_metric_record_19999("month", 4, "LR_Base", 3.0)
+        quarter_skill = _skill_metric_record_19999("quarter", 2, "LR_Base", 4.0)
+
+        def mock_get(url, **kwargs):
+            params = kwargs.get("params", {})
+            if "/long-forecast/" in url and params.get("horizon_type") == "month":
+                return _make_mock_response([monthly_forecast])
+            if "/long-forecast/" in url and params.get("horizon_type") == "quarter":
+                return _make_mock_response([_QUARTER_FORECAST_RECORD_19999])
+            if "/skill-metric/" in url and params.get("horizon") == "month":
+                return _make_mock_response([monthly_skill])
+            if "/skill-metric/" in url and params.get("horizon") == "quarter":
+                return _make_mock_response([quarter_skill])
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+        self._patch_processing(monkeypatch)
+
+        data = db.get_data("month", "19999", self._all_stations_19999_df())
+
+        fa = data["forecasts_all"]
+        month_row = fa[(fa["code"] == "19999") & (fa["model_short"] == "LR_Base")]
+        assert len(month_row) == 1
+        assert month_row["month_in_year"].iloc[0] == 4
+        assert month_row["delta"].iloc[0] == 3.0
+        assert month_row["sdivsigma"].iloc[0] == 3.5
+        assert month_row["mae"].iloc[0] == 4.0
+        assert month_row["accuracy"].iloc[0] == 93.0
+
+        quarter = data["long_forecasts_quarter"]
+        quarter_row = quarter[
+            (quarter["code"] == "19999") & (quarter["model_short"] == "LR_Base")
+        ]
+        assert len(quarter_row) == 1
+        assert quarter_row["quarter_in_year"].iloc[0] == 2
+        assert quarter_row["delta"].iloc[0] == 4.0
+        assert quarter_row["sdivsigma"].iloc[0] == 4.5
+        assert quarter_row["mae"].iloc[0] == 5.0
+        assert quarter_row["accuracy"].iloc[0] == 94.0
+
+    def test_monthly_quarter_frame_preserves_unmatched_rows_with_nan_metrics(
+        self, monkeypatch
+    ):
+        """Unmatched quarter forecast models stay present with NaN skill metrics."""
+        monthly_forecast = self._monthly_forecast_19999()
+        monthly_skill = _skill_metric_record_19999("month", 4, "LR_Base", 1.0)
+        quarter_forecasts = [
+            _QUARTER_FORECAST_RECORD_19999,
+            {
+                **_QUARTER_FORECAST_RECORD_19999,
+                "id": 41,
+                "model_type": "LR_SM",
+                "model_type_description": "Linear regression snowmelt",
+                "q": 220.0,
+            },
+        ]
+        quarter_skill = _skill_metric_record_19999("quarter", 2, "LR_Base", 2.0)
+
+        def mock_get(url, **kwargs):
+            params = kwargs.get("params", {})
+            if "/long-forecast/" in url and params.get("horizon_type") == "month":
+                return _make_mock_response([monthly_forecast])
+            if "/long-forecast/" in url and params.get("horizon_type") == "quarter":
+                return _make_mock_response(quarter_forecasts)
+            if "/skill-metric/" in url and params.get("horizon") == "month":
+                return _make_mock_response([monthly_skill])
+            if "/skill-metric/" in url and params.get("horizon") == "quarter":
+                return _make_mock_response([quarter_skill])
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+        self._patch_processing(monkeypatch)
+
+        data = db.get_data("month", "19999", self._all_stations_19999_df())
+
+        quarter = data["long_forecasts_quarter"]
+        assert set(quarter["model_short"]) == {"LR_Base", "LR_SM"}
+        base = quarter[quarter["model_short"] == "LR_Base"].iloc[0]
+        sm = quarter[quarter["model_short"] == "LR_SM"].iloc[0]
+        assert base["delta"] == 2.0
+        assert base["sdivsigma"] == 2.5
+        assert pd.isna(sm["delta"])
+        assert pd.isna(sm["sdivsigma"])
+        assert pd.isna(sm["mae"])
+        assert pd.isna(sm["accuracy"])
+
+    def test_monthly_quarter_frame_no_matching_skill_rows_preserves_forecasts(
+        self, monkeypatch
+    ):
+        """Quarter forecasts are not dropped when quarter skill rows do not match."""
+        monthly_forecast = self._monthly_forecast_19999()
+        monthly_skill = _skill_metric_record_19999("month", 4, "LR_Base", 1.0)
+        unmatched_quarter_skill = _skill_metric_record_19999(
+            "quarter", 3, "LR_Base", 2.0
+        )
+
+        def mock_get(url, **kwargs):
+            params = kwargs.get("params", {})
+            if "/long-forecast/" in url and params.get("horizon_type") == "month":
+                return _make_mock_response([monthly_forecast])
+            if "/long-forecast/" in url and params.get("horizon_type") == "quarter":
+                return _make_mock_response([_QUARTER_FORECAST_RECORD_19999])
+            if "/skill-metric/" in url and params.get("horizon") == "month":
+                return _make_mock_response([monthly_skill])
+            if "/skill-metric/" in url and params.get("horizon") == "quarter":
+                return _make_mock_response([unmatched_quarter_skill])
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+        self._patch_processing(monkeypatch)
+
+        data = db.get_data("month", "19999", self._all_stations_19999_df())
+
+        quarter = data["long_forecasts_quarter"]
+        assert len(quarter) == 1
+        assert quarter["forecasted_discharge"].iloc[0] == 200.0
+        assert quarter["quarter_in_year"].iloc[0] == 2
+        assert pd.isna(quarter["delta"].iloc[0])
+        assert pd.isna(quarter["sdivsigma"].iloc[0])
+        assert pd.isna(quarter["mae"].iloc[0])
+        assert pd.isna(quarter["accuracy"].iloc[0])
+
+    def test_empty_monthly_quarter_frame_does_not_synthesize_rows(self, monkeypatch):
+        """Empty quarter long forecasts do not crash or create merged rows."""
+        monthly_forecast = self._monthly_forecast_19999()
+        monthly_skill = _skill_metric_record_19999("month", 4, "LR_Base", 1.0)
+        quarter_skill = _skill_metric_record_19999("quarter", 2, "LR_Base", 2.0)
+
+        def mock_get(url, **kwargs):
+            params = kwargs.get("params", {})
+            if "/long-forecast/" in url and params.get("horizon_type") == "month":
+                return _make_mock_response([monthly_forecast])
+            if "/long-forecast/" in url and params.get("horizon_type") == "quarter":
+                return _make_mock_response([])
+            if "/skill-metric/" in url and params.get("horizon") == "month":
+                return _make_mock_response([monthly_skill])
+            if "/skill-metric/" in url and params.get("horizon") == "quarter":
+                return _make_mock_response([quarter_skill])
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+        self._patch_processing(monkeypatch)
+
+        data = db.get_data("month", "19999", self._all_stations_19999_df())
+
+        assert data["long_forecasts_quarter"].empty
+        assert "forecasted_discharge" in data["long_forecasts_quarter"].columns
+        assert "quarter_in_year" in data["long_forecasts_quarter"].columns
+
     def test_merges_skill_metrics_into_forecasts(self, monkeypatch):
         """Skill metric columns (delta, sdivsigma, mae, accuracy) appear in forecasts_all."""
         self._make_dispatch_mock(monkeypatch)

--- a/apps/postprocessing_forecasts/src/data_reader.py
+++ b/apps/postprocessing_forecasts/src/data_reader.py
@@ -1581,8 +1581,9 @@ def _read_ml_forecasts_pp_api(
 ) -> pd.DataFrame | None:
     """Read ML forecasts from postprocessing API.
 
-    Tries horizon='day' first (current pipeline writes daily targets),
-    then falls back to horizon=horizon_type (transition period).
+    Reads both horizon='day' (current pipeline writes daily targets) and
+    horizon=horizon_type (migrated period archive), then keeps period rows
+    only before each station/model's first DAY issue date.
 
     Args:
         model: Model short name (e.g. 'TFT', 'TiDE').
@@ -1594,6 +1595,152 @@ def _read_ml_forecasts_pp_api(
     Returns:
         Raw DataFrame from API, or None if unavailable.
     """
+
+    def _fetch_archive(try_horizon: str) -> pd.DataFrame | None:
+        all_records = []
+        batch_size = 1000
+
+        if codes is not None:
+            for code in codes:
+                skip = 0
+                kwargs = {
+                    "horizon": try_horizon,
+                    "model": model,
+                    "code": code,
+                }
+                if start_date:
+                    kwargs["start_date"] = start_date
+                if end_date:
+                    kwargs["end_date"] = end_date
+                while True:
+                    df_batch = client.read_short_term_forecasts(
+                        **kwargs, skip=skip, limit=batch_size
+                    )
+                    if df_batch is None or df_batch.empty:
+                        break
+                    all_records.append(df_batch)
+                    if len(df_batch) < batch_size:
+                        break
+                    skip += batch_size
+        else:
+            skip = 0
+            kwargs = {
+                "horizon": try_horizon,
+                "model": model,
+            }
+            if start_date:
+                kwargs["start_date"] = start_date
+            if end_date:
+                kwargs["end_date"] = end_date
+            while True:
+                df_batch = client.read_short_term_forecasts(**kwargs, skip=skip, limit=batch_size)
+                if df_batch is None or df_batch.empty:
+                    break
+                all_records.append(df_batch)
+                if len(df_batch) < batch_size:
+                    break
+                skip += batch_size
+
+        if not all_records:
+            return None
+
+        return pd.concat(all_records, ignore_index=True)
+
+    def _working_archive(df: pd.DataFrame) -> pd.DataFrame:
+        work = _clean_code_column(df.copy())
+        if "date" in work.columns:
+            work["date"] = pd.to_datetime(work["date"])
+        if "model_type" in work.columns:
+            work["_pp036_model_type_key"] = work["model_type"].astype(str)
+        else:
+            work["_pp036_model_type_key"] = model
+        return work
+
+    def _merge_archives_by_day_cutover(
+        day_df: pd.DataFrame | None,
+        period_df: pd.DataFrame | None,
+    ) -> pd.DataFrame | None:
+        day_rows = 0 if day_df is None else len(day_df)
+        period_rows = 0 if period_df is None else len(period_df)
+
+        if (day_df is None or day_df.empty) and (period_df is None or period_df.empty):
+            logger.debug(
+                "Read ML forecasts for %s (%s): day_rows=0, period_rows=0, "
+                "retained_period_rows=0, final_rows=0",
+                model,
+                horizon_type,
+            )
+            return None
+
+        if day_df is None or day_df.empty:
+            logger.debug(
+                "Read ML forecasts for %s (%s): day_rows=0, period_rows=%d, "
+                "retained_period_rows=%d, final_rows=%d",
+                model,
+                horizon_type,
+                period_rows,
+                period_rows,
+                period_rows,
+            )
+            return period_df
+
+        if period_df is None or period_df.empty:
+            logger.debug(
+                "Read ML forecasts for %s (%s): day_rows=%d, period_rows=0, "
+                "retained_period_rows=0, final_rows=%d",
+                model,
+                horizon_type,
+                day_rows,
+                day_rows,
+            )
+            return day_df
+
+        day_work = _working_archive(day_df)
+        period_work = _working_archive(period_df)
+        pair_cols = ["code", "_pp036_model_type_key"]
+
+        first_day = day_work.groupby(pair_cols)["date"].min()
+        first_period = period_work.groupby(pair_cols)["date"].min()
+
+        for pair, first_day_date in first_day.items():
+            if pair not in first_period:
+                continue
+            first_period_date = first_period[pair]
+            if first_day_date < first_period_date:
+                logger.warning(
+                    "DAY ML archive for %s code=%s model_type=%s starts at %s "
+                    "before period archive starts at %s",
+                    model,
+                    pair[0],
+                    pair[1],
+                    first_day_date.date(),
+                    first_period_date.date(),
+                )
+
+        period_with_cutover = period_work.merge(
+            first_day.rename("_pp036_first_day_date"),
+            left_on=pair_cols,
+            right_index=True,
+            how="left",
+        )
+        retain_period = period_with_cutover["_pp036_first_day_date"].isna() | (
+            period_with_cutover["date"] < period_with_cutover["_pp036_first_day_date"]
+        )
+        retained_period = period_df.loc[retain_period.to_numpy()].copy()
+        final = pd.concat([retained_period, day_df], ignore_index=True)
+
+        logger.debug(
+            "Read ML forecasts for %s (%s): day_rows=%d, period_rows=%d, "
+            "retained_period_rows=%d, final_rows=%d",
+            model,
+            horizon_type,
+            day_rows,
+            period_rows,
+            len(retained_period),
+            len(final),
+        )
+        return final
+
     if not SAPPHIRE_API_AVAILABLE:
         logger.debug("sapphire-api-client not installed, skipping API read")
         return None
@@ -1616,72 +1763,9 @@ def _read_ml_forecasts_pp_api(
         start_date = f"{start_year}-01-01" if start_year is not None else None
         end_date = f"{end_year}-12-31" if end_year is not None else None
 
-        # Try "day" horizon first (current pipeline stores daily
-        # targets)
-        for try_horizon in ["day", api_horizon]:
-            all_records = []
-            batch_size = 1000
-
-            if codes is not None:
-                for code in codes:
-                    skip = 0
-                    kwargs = {
-                        "horizon": try_horizon,
-                        "model": model,
-                        "code": code,
-                    }
-                    if start_date:
-                        kwargs["start_date"] = start_date
-                    if end_date:
-                        kwargs["end_date"] = end_date
-                    while True:
-                        df_batch = client.read_short_term_forecasts(
-                            **kwargs, skip=skip, limit=batch_size
-                        )
-                        if df_batch is None or df_batch.empty:
-                            break
-                        all_records.append(df_batch)
-                        if len(df_batch) < batch_size:
-                            break
-                        skip += batch_size
-            else:
-                skip = 0
-                kwargs = {
-                    "horizon": try_horizon,
-                    "model": model,
-                }
-                if start_date:
-                    kwargs["start_date"] = start_date
-                if end_date:
-                    kwargs["end_date"] = end_date
-                while True:
-                    df_batch = client.read_short_term_forecasts(
-                        **kwargs, skip=skip, limit=batch_size
-                    )
-                    if df_batch is None or df_batch.empty:
-                        break
-                    all_records.append(df_batch)
-                    if len(df_batch) < batch_size:
-                        break
-                    skip += batch_size
-
-            if all_records:
-                logger.debug(
-                    "Read ML forecasts for %s with horizon=%s",
-                    model,
-                    try_horizon,
-                )
-                return pd.concat(all_records, ignore_index=True)
-
-            # No data for this horizon; try next
-            if try_horizon == "day":
-                logger.debug(
-                    "No 'day' ML data for %s, trying '%s'",
-                    model,
-                    api_horizon,
-                )
-
-        return None
+        day_records = _fetch_archive("day")
+        period_records = _fetch_archive(api_horizon)
+        return _merge_archives_by_day_cutover(day_records, period_records)
 
     except Exception as e:
         logger.error(

--- a/apps/postprocessing_forecasts/tests/test_data_reader.py
+++ b/apps/postprocessing_forecasts/tests/test_data_reader.py
@@ -2656,76 +2656,8 @@ class TestReadLrForecastsPpApi:
 class TestReadMlForecastsPpApi:
     """Tests for _read_ml_forecasts_pp_api()."""
 
-    def test_tries_day_horizon_first(self):
-        """Tries horizon='day' first, returns if data found."""
-        mock_client = MagicMock()
-        mock_client.readiness_check.return_value = True
-        mock_client.read_short_term_forecasts.return_value = pd.DataFrame(
-            {
-                "code": ["10001"],
-                "date": ["2024-01-05"],
-                "forecasted_discharge": [50.0],
-            }
-        )
-
-        with (
-            patch("src.data_reader.SAPPHIRE_API_AVAILABLE", True),
-            patch.dict(
-                os.environ,
-                {
-                    "SAPPHIRE_API_ENABLED": "true",
-                },
-            ),
-            patch(
-                "src.data_reader.SapphirePostprocessingClient",
-                create=True,
-                return_value=mock_client,
-            ),
-        ):
-            result = _read_ml_forecasts_pp_api("TFT", "pentad")
-            assert result is not None
-            # Should have called with horizon="day"
-            call_args = mock_client.read_short_term_forecasts.call_args_list
-            assert call_args[0][1]["horizon"] == "day"
-
-    def test_falls_back_to_horizon_type(self):
-        """Falls back to horizon_type when 'day' returns nothing."""
-        mock_client = MagicMock()
-        mock_client.readiness_check.return_value = True
-
-        day_empty = pd.DataFrame()
-        pentad_data = pd.DataFrame(
-            {
-                "code": ["10001"],
-                "date": ["2024-01-05"],
-                "forecasted_discharge": [50.0],
-            }
-        )
-        mock_client.read_short_term_forecasts.side_effect = [
-            day_empty,  # day horizon: empty
-            pentad_data,  # pentad horizon: has data
-        ]
-
-        with (
-            patch("src.data_reader.SAPPHIRE_API_AVAILABLE", True),
-            patch.dict(
-                os.environ,
-                {
-                    "SAPPHIRE_API_ENABLED": "true",
-                },
-            ),
-            patch(
-                "src.data_reader.SapphirePostprocessingClient",
-                create=True,
-                return_value=mock_client,
-            ),
-        ):
-            result = _read_ml_forecasts_pp_api("TFT", "pentad")
-            assert result is not None
-            assert len(result) == 1
-
-    def test_returns_none_when_both_horizons_empty(self):
-        """Returns None when both day and horizon_type return nothing."""
+    def test_returns_none_when_archives_empty(self):
+        """Returns None when both day and period archives return nothing."""
         mock_client = MagicMock()
         mock_client.readiness_check.return_value = True
         mock_client.read_short_term_forecasts.return_value = pd.DataFrame()
@@ -2746,6 +2678,11 @@ class TestReadMlForecastsPpApi:
         ):
             result = _read_ml_forecasts_pp_api("TFT", "pentad")
             assert result is None
+            horizons = [
+                call.kwargs["horizon"]
+                for call in mock_client.read_short_term_forecasts.call_args_list
+            ]
+            assert set(horizons) == {"day", "pentad"}
 
     def test_returns_none_when_api_unavailable(self):
         """Returns None when API is unavailable."""

--- a/apps/postprocessing_forecasts/tests/test_data_reader_ml_aggregation.py
+++ b/apps/postprocessing_forecasts/tests/test_data_reader_ml_aggregation.py
@@ -50,6 +50,70 @@ class TestPentadTargetFiltering:
         # q95 mean: (15+30+45+60+75)/5 = 45.0
         assert result["q95"].iloc[0] == pytest.approx(45.0)
 
+    def test_mixed_day_and_period_rows_keep_expected_boundary_coverage(self):
+        """PP-036: period rows with date+1 sentinel pass through with day fans."""
+        day_targets = pd.DataFrame(
+            {
+                "code": ["19999"] * 5,
+                "date": ["2024-01-10"] * 5,
+                "target": [
+                    "2024-01-11",
+                    "2024-01-12",
+                    "2024-01-13",
+                    "2024-01-14",
+                    "2024-01-15",
+                ],
+                "forecasted_discharge": [10.0, 20.0, 30.0, 40.0, 50.0],
+                "horizon_type": ["day"] * 5,
+            }
+        )
+        period_row = pd.DataFrame(
+            {
+                "code": ["19999"],
+                "date": ["2024-01-05"],
+                "target": ["2024-01-06"],
+                "forecasted_discharge": [101.0],
+                "horizon_type": ["pentad"],
+            }
+        )
+        non_boundary_row = pd.DataFrame(
+            {
+                "code": ["19999"],
+                "date": ["2024-01-07"],
+                "target": ["2024-01-08"],
+                "forecasted_discharge": [777.0],
+                "horizon_type": ["day"],
+            }
+        )
+        out_of_period_row = pd.DataFrame(
+            {
+                "code": ["19999"],
+                "date": ["2024-01-10"],
+                "target": ["2024-01-16"],
+                "forecasted_discharge": [888.0],
+                "horizon_type": ["day"],
+            }
+        )
+        raw = pd.concat(
+            [period_row, day_targets, non_boundary_row, out_of_period_row],
+            ignore_index=True,
+        )
+
+        result = _normalize_ml_forecasts(raw, "TFT", "pentad")
+
+        assert set(result["code"]) == {"19999"}
+        assert set(result["date"].dt.strftime("%Y-%m-%d")) == {
+            "2024-01-05",
+            "2024-01-10",
+        }
+        assert set(result["model_short"]) == {"TFT"}
+
+        by_date = {
+            row.date.strftime("%Y-%m-%d"): row.forecasted_discharge for row in result.itertuples()
+        }
+        assert by_date["2024-01-05"] == pytest.approx(101.0)
+        assert by_date["2024-01-10"] == pytest.approx(30.0)
+
     def test_pentad6_february_3_day_period(self):
         """Worst case: pentad 6 of Feb (3 days: 26-28), 3 of 6 targets outside."""
         # Boundary date Feb 25 → pentad 6 covers Feb 26-28 (non-leap)

--- a/apps/postprocessing_forecasts/tests/test_ml_horizon_archive_split.py
+++ b/apps/postprocessing_forecasts/tests/test_ml_horizon_archive_split.py
@@ -1,0 +1,311 @@
+"""PP-036 archive-union contract tests for ML forecast reads."""
+
+import os
+import sys
+from dataclasses import dataclass, field
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.data_reader import _normalize_ml_forecasts, _read_ml_forecasts_pp_api
+
+STATION_CODE = "19999"
+
+
+@dataclass
+class FakePostprocessingClient:
+    """In-memory postprocessing client keyed by (horizon, skip)."""
+
+    pages: dict[tuple[str, int], pd.DataFrame]
+    calls: list[dict] = field(default_factory=list)
+
+    def readiness_check(self):
+        return True
+
+    def read_short_term_forecasts(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        horizon = kwargs["horizon"]
+        skip = kwargs["skip"]
+        page = self.pages.get((horizon, skip), pd.DataFrame())
+        return page.copy()
+
+
+def _period_row(date, value, horizon_type="pentad"):
+    return pd.DataFrame(
+        {
+            "code": [STATION_CODE],
+            "date": [date],
+            "target": [(pd.Timestamp(date) + pd.Timedelta(days=1)).strftime("%Y-%m-%d")],
+            "forecasted_discharge": [value],
+            "horizon_type": [horizon_type],
+        }
+    )
+
+
+def _day_fan(date, values):
+    start = pd.Timestamp(date) + pd.Timedelta(days=1)
+    return pd.DataFrame(
+        {
+            "code": [STATION_CODE] * len(values),
+            "date": [date] * len(values),
+            "target": [
+                (start + pd.Timedelta(days=i)).strftime("%Y-%m-%d") for i in range(len(values))
+            ],
+            "forecasted_discharge": values,
+            "horizon_type": ["day"] * len(values),
+        }
+    )
+
+
+def _read_with_fake_client(
+    pages,
+    horizon_type="pentad",
+    start_year=2024,
+    end_year=2024,
+):
+    fake_client = FakePostprocessingClient(pages=pages)
+    with (
+        patch("src.data_reader.SAPPHIRE_API_AVAILABLE", True),
+        patch.dict(os.environ, {"SAPPHIRE_API_ENABLED": "true"}),
+        patch(
+            "src.data_reader.SapphirePostprocessingClient",
+            create=True,
+            return_value=fake_client,
+        ),
+    ):
+        result = _read_ml_forecasts_pp_api(
+            "TFT",
+            horizon_type,
+            codes=[STATION_CODE],
+            start_year=start_year,
+            end_year=end_year,
+        )
+    return result, fake_client
+
+
+def _called_horizons(fake_client):
+    return [call["horizon"] for call in fake_client.calls if call["skip"] == 0]
+
+
+def _assert_called_archives(fake_client, expected):
+    assert set(_called_horizons(fake_client)) == set(expected)
+
+
+def _assert_single_code_date_model(result, expected_dates):
+    keys = result[["code", "date", "model_short"]].drop_duplicates()
+    assert len(keys) == len(result)
+    actual = set(
+        zip(
+            keys["code"],
+            keys["date"].dt.strftime("%Y-%m-%d"),
+            keys["model_short"],
+            strict=True,
+        )
+    )
+    assert actual == {(STATION_CODE, date, "TFT") for date in expected_dates}
+
+
+class TestMlHorizonArchiveSplit:
+    """PP-036: DAY archive and period archive form a cutover union."""
+
+    @pytest.mark.parametrize(
+        ("horizon_type", "api_horizon", "issue_date", "value"),
+        [
+            ("pentad", "pentad", "2024-01-05", 101.0),
+            ("decad", "decade", "2024-01-10", 202.0),
+        ],
+    )
+    def test_period_history_without_day_rows_is_returned_and_normalized(
+        self,
+        horizon_type,
+        api_horizon,
+        issue_date,
+        value,
+    ):
+        period_rows = _period_row(issue_date, value, horizon_type=api_horizon)
+
+        raw, fake_client = _read_with_fake_client(
+            {
+                ("day", 0): pd.DataFrame(),
+                (api_horizon, 0): period_rows,
+            },
+            horizon_type=horizon_type,
+        )
+
+        assert_frame_equal(raw.reset_index(drop=True), period_rows)
+        _assert_called_archives(fake_client, ["day", api_horizon])
+
+        result = _normalize_ml_forecasts(raw, "TFT", horizon_type)
+        _assert_single_code_date_model(result, [issue_date])
+        assert result["forecasted_discharge"].iloc[0] == pytest.approx(value)
+
+    @pytest.mark.parametrize(
+        ("horizon_type", "api_horizon", "issue_date", "values", "expected"),
+        [
+            (
+                "pentad",
+                "pentad",
+                "2024-01-05",
+                [10.0, 20.0, 30.0, 40.0, 50.0],
+                30.0,
+            ),
+            ("decad", "decade", "2024-01-10", list(range(10, 110, 10)), 55.0),
+        ],
+    )
+    def test_day_history_without_period_rows_is_returned_unchanged(
+        self,
+        horizon_type,
+        api_horizon,
+        issue_date,
+        values,
+        expected,
+    ):
+        day_rows = _day_fan(issue_date, values)
+
+        raw, fake_client = _read_with_fake_client(
+            {
+                ("day", 0): day_rows,
+                (api_horizon, 0): pd.DataFrame(),
+            },
+            horizon_type=horizon_type,
+        )
+
+        assert_frame_equal(raw.reset_index(drop=True), day_rows)
+        _assert_called_archives(fake_client, ["day", api_horizon])
+
+        result = _normalize_ml_forecasts(raw, "TFT", horizon_type)
+        _assert_single_code_date_model(result, [issue_date])
+        assert result["forecasted_discharge"].iloc[0] == pytest.approx(expected)
+
+    def test_day_and_period_same_issue_date_uses_day_without_duplicate(self):
+        day_rows = _day_fan("2024-01-05", [10.0, 20.0, 30.0, 40.0, 50.0])
+        period_rows = _period_row("2024-01-05", 900.0)
+
+        raw, fake_client = _read_with_fake_client(
+            {
+                ("day", 0): day_rows,
+                ("pentad", 0): period_rows,
+            }
+        )
+
+        _assert_called_archives(fake_client, ["day", "pentad"])
+        result = _normalize_ml_forecasts(raw, "TFT", "pentad")
+
+        _assert_single_code_date_model(result, ["2024-01-05"])
+        assert result["forecasted_discharge"].iloc[0] == pytest.approx(30.0)
+
+    def test_period_rows_do_not_fill_day_era_outage_dates(self):
+        day_rows = pd.concat(
+            [
+                _day_fan("2024-01-05", [10.0, 20.0, 30.0, 40.0, 50.0]),
+                _day_fan("2024-01-15", [60.0, 70.0, 80.0, 90.0, 100.0]),
+            ],
+            ignore_index=True,
+        )
+        period_rows = _period_row("2024-01-10", 777.0)
+
+        raw, fake_client = _read_with_fake_client(
+            {
+                ("day", 0): day_rows,
+                ("pentad", 0): period_rows,
+            }
+        )
+
+        _assert_called_archives(fake_client, ["day", "pentad"])
+        result = _normalize_ml_forecasts(raw, "TFT", "pentad")
+
+        _assert_single_code_date_model(result, ["2024-01-05", "2024-01-15"])
+        assert "2024-01-10" not in set(result["date"].dt.strftime("%Y-%m-%d"))
+
+    def test_no_ml_history_in_either_archive_preserves_none(self):
+        raw, fake_client = _read_with_fake_client(
+            {
+                ("day", 0): pd.DataFrame(),
+                ("pentad", 0): pd.DataFrame(),
+            }
+        )
+
+        assert raw is None
+        _assert_called_archives(fake_client, ["day", "pentad"])
+
+    def test_recalc_straddling_day_cutover_uses_older_period_and_newer_day_rows(self):
+        day_rows = _day_fan("2024-01-10", [20.0, 30.0, 40.0, 50.0, 60.0])
+        period_rows = _period_row("2024-01-05", 111.0)
+
+        raw, fake_client = _read_with_fake_client(
+            {
+                ("day", 0): day_rows,
+                ("pentad", 0): period_rows,
+            },
+            start_year=2023,
+            end_year=2024,
+        )
+
+        _assert_called_archives(fake_client, ["day", "pentad"])
+        result = _normalize_ml_forecasts(raw, "TFT", "pentad")
+
+        _assert_single_code_date_model(result, ["2024-01-05", "2024-01-10"])
+        by_date = {
+            row.date.strftime("%Y-%m-%d"): row.forecasted_discharge for row in result.itertuples()
+        }
+        assert by_date["2024-01-05"] == pytest.approx(111.0)
+        assert by_date["2024-01-10"] == pytest.approx(40.0)
+
+    @pytest.mark.parametrize(
+        ("horizon_type", "api_horizon", "issue_date", "values"),
+        [
+            ("pentad", "pentad", "2024-01-05", [1.0, 2.0, 3.0, 4.0, 5.0]),
+            ("decad", "decade", "2024-01-10", list(range(1, 11))),
+        ],
+    )
+    def test_api_call_sequence_reads_day_and_requested_period_archive(
+        self,
+        horizon_type,
+        api_horizon,
+        issue_date,
+        values,
+    ):
+        raw, fake_client = _read_with_fake_client(
+            {
+                ("day", 0): _day_fan(issue_date, values),
+                (api_horizon, 0): pd.DataFrame(),
+            },
+            horizon_type=horizon_type,
+        )
+
+        assert raw is not None
+        _assert_called_archives(fake_client, ["day", api_horizon])
+        for call in fake_client.calls:
+            assert call["code"] == STATION_CODE
+            assert call["model"] == "TFT"
+            assert call["start_date"] == "2024-01-01"
+            assert call["end_date"] == "2024-12-31"
+
+    def test_paginates_both_archives_before_building_union(self):
+        day_page_1 = _day_fan("2024-01-10", [1.0] * 1000)
+        day_page_2 = _day_fan("2024-01-15", [2.0])
+        period_page_1 = _period_row("2024-01-05", 3.0)
+        period_page_1 = pd.concat([period_page_1] * 1000, ignore_index=True)
+        period_page_2 = _period_row("2024-01-01", 4.0)
+
+        raw, fake_client = _read_with_fake_client(
+            {
+                ("day", 0): day_page_1,
+                ("day", 1000): day_page_2,
+                ("pentad", 0): period_page_1,
+                ("pentad", 1000): period_page_2,
+            },
+            start_year=2023,
+            end_year=2024,
+        )
+
+        assert raw is not None
+        calls = [(call["horizon"], call["skip"]) for call in fake_client.calls]
+        assert ("day", 0) in calls
+        assert ("day", 1000) in calls
+        assert ("pentad", 0) in calls
+        assert ("pentad", 1000) in calls

--- a/apps/postprocessing_forecasts/tests/test_ml_horizon_archive_split.py
+++ b/apps/postprocessing_forecasts/tests/test_ml_horizon_archive_split.py
@@ -5,12 +5,15 @@ import sys
 from dataclasses import dataclass, field
 from unittest.mock import patch
 
+import numpy as np
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import setup_library as sl
+from src import data_reader, skill_metrics
 from src.data_reader import _normalize_ml_forecasts, _read_ml_forecasts_pp_api
 
 STATION_CODE = "19999"
@@ -20,7 +23,7 @@ STATION_CODE = "19999"
 class FakePostprocessingClient:
     """In-memory postprocessing client keyed by (horizon, skip)."""
 
-    pages: dict[tuple[str, int], pd.DataFrame]
+    pages: dict[tuple, pd.DataFrame]
     calls: list[dict] = field(default_factory=list)
 
     def readiness_check(self):
@@ -29,8 +32,34 @@ class FakePostprocessingClient:
     def read_short_term_forecasts(self, **kwargs):
         self.calls.append(dict(kwargs))
         horizon = kwargs["horizon"]
+        model = kwargs.get("model")
         skip = kwargs["skip"]
-        page = self.pages.get((horizon, skip), pd.DataFrame())
+        page = self.pages.get(
+            (horizon, model, skip), self.pages.get((horizon, skip), pd.DataFrame())
+        )
+        return page.copy()
+
+    def read_lr_forecasts(self, **kwargs):
+        return pd.DataFrame()
+
+
+@dataclass
+class FakePreprocessingClient:
+    """In-memory preprocessing client for observed runoff rows."""
+
+    runoff: pd.DataFrame
+
+    def readiness_check(self):
+        return True
+
+    def read_runoff(self, **kwargs):
+        skip = kwargs["skip"]
+        if skip > 0:
+            return pd.DataFrame()
+        page = self.runoff
+        code = kwargs.get("code")
+        if code is not None:
+            page = page[page["code"].astype(str) == str(code)]
         return page.copy()
 
 
@@ -59,6 +88,39 @@ def _day_fan(date, values):
             "horizon_type": ["day"] * len(values),
         }
     )
+
+
+def _period_rows(dates, values, horizon_type, model):
+    rows = []
+    for date, value in zip(dates, values, strict=True):
+        rows.append(
+            {
+                "code": STATION_CODE,
+                "date": date.strftime("%Y-%m-%d"),
+                "target": (date + pd.Timedelta(days=1)).strftime("%Y-%m-%d"),
+                "forecasted_discharge": value,
+                "horizon_type": horizon_type,
+                "model_type": model,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _day_rows(dates, values, model, fan_length):
+    rows = []
+    for date, value in zip(dates, values, strict=True):
+        for offset in range(fan_length):
+            rows.append(
+                {
+                    "code": STATION_CODE,
+                    "date": date.strftime("%Y-%m-%d"),
+                    "target": (date + pd.Timedelta(days=offset + 1)).strftime("%Y-%m-%d"),
+                    "forecasted_discharge": value,
+                    "horizon_type": "day",
+                    "model_type": model,
+                }
+            )
+    return pd.DataFrame(rows)
 
 
 def _read_with_fake_client(
@@ -309,3 +371,166 @@ class TestMlHorizonArchiveSplit:
         assert ("day", 1000) in calls
         assert ("pentad", 0) in calls
         assert ("pentad", 1000) in calls
+
+
+class TestMlHorizonArchiveSplitIntegration:
+    """PP-036 full reader + skill metric integration coverage."""
+
+    @pytest.mark.parametrize(
+        ("horizon_type", "api_horizon", "issue_day", "fan_length", "config_fixture"),
+        [
+            ("pentad", "pentad", 5, 5, "pentad_config"),
+            ("decad", "decade", 10, 10, "decad_config"),
+        ],
+    )
+    def test_recalc_inputs_use_period_history_and_ne_partial_averages(
+        self,
+        request,
+        horizon_type,
+        api_horizon,
+        issue_day,
+        fan_length,
+        config_fixture,
+    ):
+        config = request.getfixturevalue(config_fixture)
+        period_dates = pd.to_datetime([f"{year}-01-{issue_day:02d}" for year in range(2010, 2024)])
+        day_dates = pd.to_datetime(["2024-01-05" if horizon_type == "pentad" else "2024-01-10"])
+        all_dates = period_dates.append(day_dates)
+
+        observed_values = {date: 100.0 + idx for idx, date in enumerate(all_dates)}
+        observed = pd.DataFrame(
+            {
+                "code": [STATION_CODE] * len(all_dates),
+                "date": [date.strftime("%Y-%m-%d") for date in all_dates],
+                "discharge": [observed_values[date] for date in all_dates],
+                "delta": [20.0] * len(all_dates),
+                "horizon_type": [api_horizon] * len(all_dates),
+            }
+        )
+
+        tft_period_values = [observed_values[date] + 1.0 for date in period_dates]
+        tide_period_dates = period_dates[1:]
+        tide_period_values = [observed_values[date] + 3.0 for date in tide_period_dates]
+        day_date = day_dates[0]
+        day_values = {
+            "TFT": observed_values[day_date] + 1.0,
+            "TiDE": observed_values[day_date] + 3.0,
+            "TSMixer": observed_values[day_date] + 5.0,
+        }
+
+        postprocessing_client = FakePostprocessingClient(
+            pages={
+                ("day", "TFT", 0): _day_rows(day_dates, [day_values["TFT"]], "TFT", fan_length),
+                (api_horizon, "TFT", 0): _period_rows(
+                    period_dates,
+                    tft_period_values,
+                    api_horizon,
+                    "TFT",
+                ),
+                ("day", "TiDE", 0): _day_rows(
+                    day_dates,
+                    [day_values["TiDE"]],
+                    "TiDE",
+                    fan_length,
+                ),
+                (api_horizon, "TiDE", 0): _period_rows(
+                    tide_period_dates,
+                    tide_period_values,
+                    api_horizon,
+                    "TiDE",
+                ),
+                ("day", "TSMixer", 0): _day_rows(
+                    day_dates,
+                    [day_values["TSMixer"]],
+                    "TSMixer",
+                    fan_length,
+                ),
+                (api_horizon, "TSMixer", 0): pd.DataFrame(),
+            }
+        )
+        preprocessing_client = FakePreprocessingClient(observed)
+
+        with (
+            patch("src.data_reader.SAPPHIRE_API_AVAILABLE", True),
+            patch.dict(
+                os.environ,
+                {
+                    "SAPPHIRE_API_ENABLED": "true",
+                    "SAPPHIRE_SKILL_METRICS_START_YEAR": "2010",
+                    "SAPPHIRE_SKILL_METRICS_YEAR": "2026",
+                    "ieasyhydroforecast_run_ML_models": "true",
+                    "ieasyhydroforecast_available_ML_models": "TFT,TIDE,TSMIXER",
+                },
+            ),
+            patch(
+                "src.data_reader.SapphirePostprocessingClient",
+                create=True,
+                return_value=postprocessing_client,
+            ),
+            patch(
+                "src.data_reader.SapphirePreprocessingClient",
+                create=True,
+                return_value=preprocessing_client,
+            ),
+        ):
+            observed_df, modelled_df = data_reader.read_observed_and_modelled_data(
+                horizon_type,
+                codes=[STATION_CODE],
+                start_year=2010,
+                end_year=2024,
+            )
+
+            if horizon_type == "pentad":
+                modelled_with_ne = sl.calculate_neural_ensemble_forecast(modelled_df)
+            else:
+                modelled_with_ne = sl.calculate_neural_ensemble_forecast_decade(modelled_df)
+
+            skill_stats, _, _ = skill_metrics.calculate_skill_metrics(
+                config,
+                observed_df,
+                modelled_with_ne,
+                exclude_models=["EM"],
+            )
+
+        tft_skill = skill_stats[
+            (skill_stats["code"] == STATION_CODE) & (skill_stats["model_short"] == "TFT")
+        ]
+        assert not tft_skill.empty
+        assert tft_skill["n_pairs"].max() >= 15
+
+        ne_rows = modelled_with_ne[modelled_with_ne["model_short"] == "NE"].copy()
+        assert not ne_rows.empty
+
+        value_lookup = {
+            (row.date, row.model_short): row.forecasted_discharge
+            for row in modelled_df.itertuples()
+        }
+
+        first_period_date = period_dates[0]
+        first_ne = ne_rows[ne_rows["date"] == first_period_date]
+        assert len(first_ne) == 1
+        assert first_ne["forecasted_discharge"].iloc[0] == pytest.approx(
+            value_lookup[(first_period_date, "TFT")]
+        )
+
+        two_model_date = period_dates[1]
+        two_model_ne = ne_rows[ne_rows["date"] == two_model_date]
+        expected_two_model = np.mean(
+            [
+                value_lookup[(two_model_date, "TFT")],
+                value_lookup[(two_model_date, "TiDE")],
+            ]
+        )
+        assert len(two_model_ne) == 1
+        assert two_model_ne["forecasted_discharge"].iloc[0] == pytest.approx(expected_two_model)
+
+        day_ne = ne_rows[ne_rows["date"] == day_date]
+        expected_day = np.mean(
+            [
+                value_lookup[(day_date, "TFT")],
+                value_lookup[(day_date, "TiDE")],
+                value_lookup[(day_date, "TSMixer")],
+            ]
+        )
+        assert len(day_ne) == 1
+        assert day_ne["forecasted_discharge"].iloc[0] == pytest.approx(expected_day)

--- a/doc/plans/issues/archive/high_prio_gi_draft_dashboard_long_horizon_skill_summary.md
+++ b/doc/plans/issues/archive/high_prio_gi_draft_dashboard_long_horizon_skill_summary.md
@@ -1,0 +1,507 @@
+# Dashboard long-horizon skill metrics missing from summary table
+
+| Field | Value |
+|---|---|
+| Module | `forecast_dashboard` |
+| Priority | High |
+| Status | **Completed (2026-05-31)** |
+| Branch | `fix_postprocessing_skill_metrics` |
+| Labels | `bug`, `dashboard`, `forecast_dashboard`, `skill-metrics`, `tajik-deployment` |
+
+## Completion Summary
+
+Implemented on branch `fix_postprocessing_skill_metrics` alongside PP-036. Five commits across four phases:
+
+| Commit | Phase | Content |
+|---|---|---|
+| `ba4dee8` | P1 | Tests-first: quarter/season period keys, stats renames, guarded merges, partial-coverage (LR_Base/LR_SM split), replacement of obsolete `test_forecast_stats_is_empty` locking tests |
+| `0f96d1e` | P2 | `apps/forecast_dashboard/src/db.py` data-layer fix: `_horizon_in_year_col` cases for quarter/season, `quarter_in_year = ((valid_from.dt.month - 1) // 3 + 1)`, `season_in_year = 1` (constant by design), `get_forecast_stats(...)` fetch + merge in `_get_data_quarter` / `_get_data_season` |
+| `dd2da96` | P3 | Integration assertion: season summary table renders populated `accuracy`, `delta`, `sdivsigma`, `mae` for LR_Base / LR_SM |
+| `85d6aeb` | P4a | Tests for `_get_data_monthly()` enrichment of `long_forecasts_quarter` (the data path the reservoir quarterly card consumes on the month tab). Includes monthly `forecasts_all` byte-identity regression guard |
+| `65e9662` | P4b | `_get_data_monthly()` quarter skill merge into `long_forecasts_quarter`, reusing the existing `can_merge` guard and merge kwargs (+19/-1 in `db.py`) |
+
+**Final test run:** 288 passed, 0 failed, 0 unexpected skips.
+
+**Red-phase verifications:**
+
+- **2026-05-31 (P1-P3):** reverting `0f96d1e` produced 18 expected failures across P1 + P3 assertions; no Type-II errors; no non-fix-related failures.
+- **2026-05-31 (P4):** reverting `65e9662` produced exactly 3 P4a failures (all `KeyError: 'delta'` on `long_forecasts_quarter`), all P1-P3 tests stayed green, no Type-II errors. The unrelated Playwright `errors` observed in some runs are macOS sandbox browser-launch issues tracked under [`low_prio_gi_draft_infra_playwright_sandbox_browser_launch.md`](low_prio_gi_draft_infra_playwright_sandbox_browser_launch.md).
+
+**Deferred to deployment time:** operator runs the plan's operational check on a real stack — for season: navigate to the season tab for a station with seasonal LR_Base skill data and observe populated metric columns in the summary table; for reservoir quarter: navigate to the month tab for a reservoir station with quarter LR_Base skill data and observe populated metric columns on the quarterly card. Discover stations via `/api/postprocessing/skill-metric/?horizon={season|quarter}&model_type=LR_Base&limit=5`.
+
+**Decisions worth preserving:**
+
+- **Reservoir quarter on month tab was the actual Tajik visible-impact target for the quarter side.** The original plan's framing — "quarter is hidden in the UI, so the quarter data-layer fix is preemptive plumbing" — was wrong. Quarter is rendered on the month tab for reservoirs via `long_forecasts_quarter` (commit `1b6715c`). P4 was added 2026-05-31 to close this gap, caught after P1-P3 red-phase verification by user review.
+- **Quarter-tab exposure remains deferred.** `dashboard/widgets.py:89-96` was not modified. The quarter tab is still hidden; the quarter data-layer fix in `_get_data_quarter` lands proactively for whenever the quarter tab is exposed in a future plan.
+- **Dedicated skill chart / skill table for long horizons was deferred.** `create_skill_table()` and `plot_forecast_skill()` are still pentad/decade-only (`vizualization.py:4637-4647`); enabling them for long horizons requires formatter and period-key work beyond this fix.
+- **Mixed-fixture station-code transition (`19999` for new tests; existing `99001` fixtures preserved)** is intentional and documented in the plan body. Consolidation is a separate cleanup if desired.
+
+## Summary
+
+Quarter and season skill metrics exist in the postprocessing DB, but the
+dashboard data layer did not merge them into long-horizon forecast frames. The
+visible wins are seasonal summary-table rows for `LR_Base` and `LR_SM`, plus
+the reservoir quarterly card rendered on the month tab via
+`long_forecasts_quarter`, showing `accuracy`, `delta`, `sdivsigma`, and `mae`
+once the data layer supplies those columns.
+
+## Scope
+
+In scope:
+- Render skill metrics in the summary table for `season` and `quarter` horizons
+  by fixing the dashboard data layer.
+- Add quarter data-layer support for both the hidden quarter tab path and the
+  visible reservoir quarterly card on the month tab. The card consumes
+  `long_forecasts_quarter`, which is populated by `_get_data_monthly()`.
+
+Out of scope:
+- Do not expose quarter in `apps/forecast_dashboard/dashboard/widgets.py:89-96`;
+  quarter-tab exposure remains deferred, but the existing reservoir
+  quarter-on-month-tab card is in scope for P4.
+- Do not edit `sapphire/services/`.
+- Do not edit `_read_long_forecasts_api()`, the skill-metric writer, or the
+  recalculation pipeline.
+- Do not add dependencies, compatibility shims, feature flags, or opt-out
+  toggles.
+
+## Investigation Anchors
+
+- `_horizon_in_year_col()` currently maps only decade and month; quarter and
+  season fall through to `pentad_in_year`
+  (`apps/forecast_dashboard/src/db.py:32-37`).
+- `_horizon_in_year_col()` has 13 current call sites in
+  `apps/forecast_dashboard/src/db.py`:
+  - `db.py:189`: declares the empty `get_hydrograph_pentad_all()` period-key
+    column.
+  - `db.py:197`: renames hydrograph API `horizon_in_year` to the local
+    period-key column.
+  - `db.py:327`: declares the empty `get_linreg_predictor()` period-key
+    column.
+  - `db.py:332`: renames LR predictor API `horizon_in_year` to the local
+    period-key column.
+  - `db.py:339`: sets `hin` for `get_forecasts_all()` forecast merge/schema
+    handling.
+  - `db.py:433`: declares empty `get_forecast_stats()` skill-metric schema.
+  - `db.py:437`: renames skill-metric API `horizon_in_year` in
+    `get_forecast_stats()`.
+  - `db.py:442`: deduplicates `get_forecast_stats()` on
+    `(code, period_key, model_short)`.
+  - `db.py:471`: declares empty `get_forecast_stats_all()` schema when no
+    pages are returned.
+  - `db.py:478`: declares empty `get_forecast_stats_all()` schema when
+    `model_type` is absent.
+  - `db.py:482`: renames skill-metric API `horizon_in_year` in
+    `get_forecast_stats_all()`.
+  - `db.py:487`: deduplicates `get_forecast_stats_all()` on
+    `(code, period_key, model_short)`.
+  - `db.py:644`: sets `hin` for the generic short-horizon `get_data()` branch.
+- No-regression argument: None of these call sites is reached today with
+  `horizon="quarter"` or `horizon="season"`. The router in `get_data()` at
+  `db.py:637-642` dispatches long horizons to `_get_data_monthly` /
+  `_get_data_quarter` / `_get_data_season` before the generic branch at
+  `db.py:644`. The helpers `get_forecasts_all`, `get_hydrograph_pentad_all`,
+  `get_linreg_predictor`, and `get_forecast_stats_all` are not invoked with
+  quarter or season by any current caller — verified by reading
+  `plot_manager.py:198-203` and `plot_manager.py:424`. Line-number drift:
+  the reviewer cited `db.py:639-642`; current code has the month dispatch at
+  `db.py:637-638` and quarter/season dispatch at `db.py:639-642`.
+- The month skill-metric rename site is already generic:
+  `get_forecast_stats()` renames `horizon_in_year` to
+  `_horizon_in_year_col(horizon)` at
+  `apps/forecast_dashboard/src/db.py:436-438`, and
+  `get_forecast_stats_all()` mirrors it at
+  `apps/forecast_dashboard/src/db.py:481-482`. Once the helper knows quarter
+  and season, both functions work for those horizons without public signature
+  changes; their empty schemas and dedup keys also call the same helper at
+  `apps/forecast_dashboard/src/db.py:432-442` and
+  `apps/forecast_dashboard/src/db.py:468-488`.
+- The monthly working template computes `month_in_year` from `valid_from` at
+  `apps/forecast_dashboard/src/db.py:528-529` and merges stats into
+  `forecasts_all` with a `can_merge` guard at
+  `apps/forecast_dashboard/src/db.py:685-703`.
+- Quarter and season long forecasts currently compute only `month_in_year`
+  (`apps/forecast_dashboard/src/db.py:569-570`,
+  `apps/forecast_dashboard/src/db.py:615-616`) and `_get_data_quarter()` /
+  `_get_data_season()` return literal empty `forecast_stats`
+  (`apps/forecast_dashboard/src/db.py:737-765`).
+- Existing dashboard unit coverage belongs in
+  `apps/forecast_dashboard/tests/test_db.py`: helper mapping at lines 47-58,
+  month skill rename at lines 175-210, monthly merge at lines 216-338,
+  quarter/season long-forecast coverage at lines 381-436, and current
+  quarter/season `get_data()` tests at lines 442-591.
+- The summary renderer already preserves or creates the four metric columns for
+  long horizons at `apps/forecast_dashboard/src/vizualization.py:3082-3099`; no
+  rendering code change is needed for the summary table.
+- `_get_data_monthly()` loads monthly forecasts into `forecasts_all` and, for
+  every station, loads quarterly forecasts into `long_forecasts_quarter` via
+  `get_long_forecasts_quarter(station, horizon_value=1)` at
+  `apps/forecast_dashboard/src/db.py:685-741`. The existing month merge only
+  enriches `forecasts_all`; it does not enrich `long_forecasts_quarter`.
+- The reservoir quarterly card on the month tab is rendered by
+  `apps/forecast_dashboard/dashboard/plot_manager.py:322-389`. It reads
+  `DataManager.long_forecasts_quarter`, gates display on `horizon == "month"`
+  and Russian reservoir marker `вдхр`, filters by `station_labels`, then calls
+  `create_forecast_summary_tabulator()` with the filtered quarterly frame.
+  Therefore the data-layer fix can be unconditional; reservoir visibility is a
+  rendering-layer concern.
+- `DataManager.long_forecasts_quarter` is a thin accessor over the data key at
+  `apps/forecast_dashboard/dashboard/data_manager.py:163-165`.
+- Current `apps/forecast_dashboard/tests/test_db.py` covers month merges into
+  `forecasts_all`, optional `long_forecasts_m0` merges, quarter/season period
+  keys, and `_get_data_quarter()` / `_get_data_season()` skill merges. It does
+  not assert that `_get_data_monthly()` enriches `long_forecasts_quarter`.
+
+## Optional Dedicated Skill Table Decision
+
+Defer. The guards in `apps/forecast_dashboard/dashboard/plot_manager.py:197-203`
+and `apps/forecast_dashboard/dashboard/plot_manager.py:423-428` are small, but
+the formatter is not long-horizon ready: `create_skill_table()` maps every
+non-pentad horizon to `decad_in_year` / `decad_in_month`
+(`apps/forecast_dashboard/src/vizualization.py:4637-4647`) and then calls
+`add_month_pentad_per_month_to_df()` (`apps/forecast_dashboard/src/vizualization.py:4648-4652`).
+That is not evidence that quarter `n_pairs`, `accuracy`, or season period keys
+render correctly without new formatter logic. Leave the guards intact.
+
+## Phase P1 - Tests First
+
+**Goal**: Add failing tests that lock down quarter/season period keys, stats
+renames, guarded merges, no-skill behavior, and existing month/pentad/decade
+behavior before implementation.
+
+**Files allowed**:
+- `apps/forecast_dashboard/tests/test_db.py`
+
+**Forbidden**:
+- `sapphire/services/`
+- Public API signature changes
+- Any file outside the allow-list
+- Any production-code change
+
+**Depends on**: none
+
+**Agents**: 1 Sonnet 4.6 general-purpose agent, isolation: `worktree`.
+
+**Agent instructions**:
+- Do NOT change any existing function signatures, data flow logic, or control flow.
+- Add tests only. New quarter/season test fixtures use station code `19999`.
+  Do not modify the existing `99001` fixtures elsewhere in `tests/test_db.py`
+  — they cover unrelated cases and migrating them is out of scope for this
+  fix. Test files may contain both codes during this transition; consolidate
+  to `19999` in a separate cleanup if desired.
+- Mock API responses; do not call the real API. Use fixed date strings in
+  fixtures; do not introduce `date.today()`.
+- Model the `/skill-metric/` payload with the live 18-column schema confirmed
+  by the investigator. It must include API `horizon_in_year` and the
+  dashboard-relevant fields `model_type`, `model_type_description`,
+  `sdivsigma`, `nse`, `delta`, `accuracy`, `mae`, and `n_pairs`.
+- Replace test_forecast_stats_is_empty at tests/test_db.py:476-487 (Quarter)
+  and :552-563 (Season) with assertions that forecast_stats is populated and
+  that forecasts_all carries delta, sdivsigma, mae, accuracy for the matching
+  (code, period_key, model_short) row.
+- Test where skill data exists for LR_Base but not LR_SM. Assert: the LR_SM
+  forecast row is preserved with NaN values in delta, sdivsigma, mae,
+  accuracy; the LR_Base forecast row carries populated metric values; the
+  can_merge guard does not collapse the LR_SM row.
+- Add named failing assertions for:
+  - `_horizon_in_year_col("quarter") == "quarter_in_year"` and
+    `_horizon_in_year_col("season") == "season_in_year"`.
+  - `get_forecast_stats("quarter", "19999")` and
+    `get_forecast_stats("season", "19999")` rename API `horizon_in_year` to
+    the horizon-specific column and do not expose `pentad_in_year`.
+  - `get_forecast_stats_all("quarter")` and `get_forecast_stats_all("season")`
+    page and rename through the same helper.
+  - `get_long_forecasts_quarter("19999")` includes `quarter_in_year`; derive
+    April `valid_from` as quarter 2.
+  - `get_long_forecasts_season("19999")` includes `season_in_year == 1`.
+  - `get_data("quarter", "19999", ...)` and `get_data("season", "19999", ...)`
+    merge metrics into `forecasts_all` for matching `LR_Base` and `LR_SM` rows.
+  - No-skill responses for a station/model leave forecasts available, do not
+    crash, and do not require metric columns to exist before the summary
+    renderer adds NaNs.
+  - Existing month tests still assert the same `month_in_year` behavior and
+    metric merge; pentad and decade helper mapping remains unchanged. The
+    existing assertions at `tests/test_db.py:50-58`
+    (`_horizon_in_year_col("pentad") == "pentad_in_year"`,
+    `("decade") == "decad_in_year"`) must continue to pass without
+    modification — name them explicitly as must-not-weaken regression guards.
+
+**Acceptance criteria**:
+- Running the new/changed tests against current code fails because quarter and
+  season map to `pentad_in_year`, quarter/season long forecasts lack their
+  period keys, and `_get_data_quarter()` / `_get_data_season()` return empty
+  `forecast_stats`.
+- Existing month assertions are not weakened.
+- No production files are modified.
+
+## Phase P2 - Data Layer Implementation
+
+**Goal**: Make quarter and season data paths supply skill metrics to
+`forecasts_all` using the same guarded merge pattern as month.
+
+**Files allowed**:
+- `apps/forecast_dashboard/src/db.py`
+
+**Forbidden**:
+- `sapphire/services/`
+- Public API signature changes
+- Any file outside the allow-list
+- `apps/forecast_dashboard/dashboard/widgets.py`
+- `_read_long_forecasts_api()`, skill-metric writer code, and recalculation
+  pipeline code
+
+**Depends on**: P1
+
+**Agents**: 1 Sonnet 4.6 general-purpose agent, isolation: `worktree`.
+
+**Agent instructions**:
+- Do NOT change any existing function signatures, data flow logic, or control flow.
+- Modify only the specific behavior described here.
+- Add explicit `_horizon_in_year_col()` cases for `quarter` and `season`.
+- In `get_long_forecasts_quarter()`, add `quarter_in_year` from
+  `valid_from.dt.month` using calendar quarters. Use the formula
+  `((valid_from.dt.month - 1) // 3 + 1)` so April → 2, July → 3, etc.
+  Preserve existing output fields unless tests require only additive changes.
+- In `get_long_forecasts_season()`, add `season_in_year = 1`. The value is
+  constant by design: season is a single-bucket horizon in the data model
+  (one season per year-station-model combination), so the period key is
+  always 1. This is not a bug or placeholder — do not parameterize.
+  Preserve existing output fields unless tests require only additive changes.
+- Ensure empty quarter/season long-forecast DataFrames declare the new period
+  key columns.
+- In `_get_data_quarter()` and `_get_data_season()`, fetch
+  `get_forecast_stats("quarter", station)` / `get_forecast_stats("season", station)`,
+  pass through `i18n_models`, and merge into `forecasts_all` on
+  `["code", _horizon_in_year_col(horizon), "model_short"]` with the same
+  `can_merge` guard used by month.
+- Do not add `date.today()` or equivalent business-logic date defaults.
+
+**Acceptance criteria**:
+- P1 tests pass.
+- `get_forecast_stats()` and `get_forecast_stats_all()` return
+  `quarter_in_year` / `season_in_year` for those horizons because the existing
+  `horizon_in_year` rename now resolves correctly.
+- Quarter and season no-skill paths return forecast data without crashing.
+- Month behavior remains unchanged; pentad/decade behavior remains unchanged.
+
+## Phase P3 - Rendering Verification
+
+**Goal**: Assert that the season summary table renders the merged skill columns
+for `LR_Base` and `LR_SM`, with no summary-renderer code change expected.
+
+**Files allowed**:
+- `apps/forecast_dashboard/tests/test_db.py`
+- `apps/forecast_dashboard/tests/test_integration.py`
+
+**Forbidden**:
+- `sapphire/services/`
+- Public API signature changes
+- Any file outside the allow-list
+- Production rendering code
+
+**Depends on**: P2
+
+**Agents**: 1 Sonnet 4.6 general-purpose agent, isolation: `worktree`.
+
+**Agent instructions**:
+- Do NOT change any existing function signatures, data flow logic, or control flow.
+- Prefer a deterministic mocked integration assertion that builds season data
+  through `db.get_data("season", "19999", ...)` and passes the resulting
+  `forecasts_all` into `vizualization.create_forecast_summary_table()`.
+- Assert the rendered table has populated `Accuracy`, `δ`, `s/σ`, and `MAE`
+  cells for `LR_Base` and `LR_SM`.
+- If extending the existing Playwright suite, reuse the current
+  `apps/forecast_dashboard/tests/test_integration.py` long-horizon flow; do
+  not invent a new browser harness. Keep all new deterministic fixtures on
+  station `19999`.
+- Keep the dedicated skill chart/table assertions skipped for long horizons.
+
+**Acceptance criteria**:
+- The summary-table assertion proves that merged season skill metrics survive
+  the data layer and renderer.
+- The no-skill rendering path still produces a summary table with NaN/empty
+  metric cells rather than a crash.
+- Existing long-horizon Playwright behavior is not weakened.
+
+## Phase P4a - Reservoir Quarter-On-Month Tests
+
+**Goal**: Add failing data-layer tests proving `_get_data_monthly()` enriches
+`long_forecasts_quarter` with quarter skill metrics for the reservoir quarterly
+card path while preserving existing monthly behavior.
+
+P4 was added 2026-05-31 after a user-flagged gap in scope: the quarterly card
+on the month tab (commit 1b6715c, reservoir-only rendering) consumes
+`long_forecasts_quarter` but the prior P2 fix only addressed
+`_get_data_quarter`.
+
+**Files allowed**:
+- `apps/forecast_dashboard/tests/test_db.py`
+- A new `apps/forecast_dashboard/tests/test_*.py` file only if
+  `test_db.py` becomes unwieldy
+
+**Forbidden**:
+- `sapphire/services/`
+- Public API signature changes
+- Any file outside the allow-list
+- Any production-code change
+- Rendering-layer code
+
+**Depends on**: P2. P3 is not a hard prerequisite, although it has already
+landed in practice.
+
+**Agents**: 1 Sonnet 4.6 general-purpose agent, isolation: `worktree`.
+
+**Agent instructions**:
+- Do NOT change any existing function signatures, data flow logic, or control flow.
+- Add tests first. Use station code `19999` for all new fixtures and assertions.
+  Leave existing `99001` fixtures elsewhere unchanged.
+- Mock API responses; do not call the real API. Use fixed date strings in
+  fixtures; do not introduce `date.today()`.
+- Test `_get_data_monthly()` / `get_data("month", "19999", ...)`, not the
+  rendering layer. Do not model reservoir flags; the data key is loaded for
+  every station and reservoir filtering happens later in plot/bulletin code.
+- Add a test where monthly skill rows and quarter skill rows are both present.
+  Assert:
+  - `forecasts_all` still carries the same monthly metric columns and values as
+    before P4, proving the existing month merge is unchanged.
+  - `long_forecasts_quarter` carries `delta`, `sdivsigma`, `mae`, and
+    `accuracy` for matching quarter `LR_Base` rows.
+  - The quarter merge key is `quarter_in_year`, and the month merge for
+    `LR_Base` still uses `month_in_year`.
+- Add a partial-coverage test where quarter skill rows exist for `LR_Base` but
+  not for another quarter model emitted for the station. Assert the unmatched
+  forecast row is preserved with NaN values in `delta`, `sdivsigma`, `mae`, and
+  `accuracy`.
+- Add a no-quarter-skill test. Follow existing month no-skill behavior: if the
+  quarter stats frame is empty and the guarded merge does not run,
+  `long_forecasts_quarter` must preserve forecast rows and need not contain
+  metric columns.
+- Add an empty-quarter-forecast test. Assert empty `long_forecasts_quarter`
+  does not crash `_get_data_monthly()` and does not create degenerate merged
+  rows.
+- The tests must fail on current post-P3 code because
+  `long_forecasts_quarter` lacks merged quarter metric columns while
+  `forecasts_all` continues to pass the monthly assertions.
+
+**Acceptance criteria**:
+- P4a tests fail pre-P4b in named ways tied to missing quarter metrics on
+  `long_forecasts_quarter`.
+- Existing month, quarter-tab, and season tests are not weakened.
+- No production files are modified.
+
+## Phase P4b - Monthly Data-Layer Quarter Merge
+
+**Goal**: Wire quarter skill metrics into `_get_data_monthly()` for the
+`long_forecasts_quarter` frame using the P2 infrastructure.
+
+**Files allowed**:
+- `apps/forecast_dashboard/src/db.py`
+
+**Forbidden**:
+- `sapphire/services/`
+- Public API signature changes
+- Any file outside the allow-list
+- Rendering-layer code
+- `_get_data_quarter()` or `_get_data_season()` changes
+- Helper extraction or broad refactors
+
+**Depends on**: P4a and P2. P3 is not a hard prerequisite, although it has
+already landed in practice.
+
+**Agents**: 1 Sonnet 4.6 general-purpose agent, isolation: `worktree`.
+
+**Agent instructions**:
+- Do NOT change any existing function signatures, data flow logic, or control flow.
+- Modify only `_get_data_monthly()`.
+- After loading `long_forecasts_quarter`, fetch
+  `get_forecast_stats("quarter", station)` and pass it through `i18n_models`.
+- Merge quarter skill metrics into `long_forecasts_quarter` with the same
+  `can_merge` guard pattern already used for monthly `forecasts_all` and
+  optional `long_forecasts_m0`.
+- Use `_horizon_in_year_col("quarter")` for the quarter period key and merge on
+  `["code", quarter_key, "model_short"]`.
+- Keep the existing monthly `forecast_stats` value and monthly merges
+  unchanged. Do not reuse month stats for quarter forecasts.
+- Do not add `date.today()` or equivalent business-logic date defaults.
+
+**Acceptance criteria**:
+- P4a tests pass post-P4b and fail pre-P4b.
+- `_get_data_monthly()` returns `long_forecasts_quarter` with `delta`,
+  `sdivsigma`, `mae`, and `accuracy` populated when quarter skill rows exist
+  for the station/model.
+- Station without quarter skill data preserves `long_forecasts_quarter`
+  forecasts without crashing.
+- Empty `long_forecasts_quarter` does not crash or produce degenerate rows.
+- Existing P1+P2+P3 tests continue to pass without modification.
+- `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh forecast_dashboard`
+  passes with zero unexpected skips.
+- Operational acceptance for deploy engineer: navigate to the month tab for a
+  reservoir station on a running stack with quarter `LR_Base` skill data,
+  confirm the quarterly card displays populated skill columns. Discover a
+  suitable station via
+  `/api/postprocessing/skill-metric/?horizon=quarter&model_type=LR_Base&limit=5`;
+  do not hard-code or document a real station code.
+
+## Whole-Fix Acceptance
+
+- `SAPPHIRE_TEST_ENV=True bash run_tests.sh forecast_dashboard` passes with
+  zero failures and zero unexpected skips.
+- Operational check: open the dashboard on a running local stack, pick any
+  station on the running stack that has `LR_Base`/`LR_SM` seasonal forecasts
+  (query `/api/postprocessing/skill-metric/?horizon=season&model_type=LR_Base&limit=5`
+  to find one), navigate to the season tab for that station, and observe that
+  `accuracy`, `delta`, `sdivsigma`, and `mae` columns are populated in the
+  summary table for `LR_Base` and `LR_SM` rows. Do not commit the real code
+  anywhere.
+- Operational check: on the same running stack, query
+  `/api/postprocessing/skill-metric/?horizon=quarter&model_type=LR_Base&limit=5`
+  to discover a reservoir station with quarter skill data, navigate to its
+  month tab, and observe that the quarterly card shows populated skill columns.
+  Do not name or commit a real station code.
+
+## Risks And Deferred Work
+
+- Quarter remains hidden in the dashboard horizon selector
+  (`apps/forecast_dashboard/dashboard/widgets.py:89-96`), so direct quarter-tab
+  exposure remains deferred. However, quarter forecasts are already visible on
+  the month tab for reservoir stations via `long_forecasts_quarter`; P4 covers
+  that existing visible path.
+- The dedicated skill chart and dedicated skill table remain intentionally
+  deferred for long horizons. `plot_forecast_skill()` and `create_skill_table()`
+  are pentad/decade-specific today, and the existing plot-manager guards should
+  stay intact.
+- Adding a second skill-metric API call inside `_get_data_monthly()` doubles
+  skill-metric requests for the month tab. The volume is small (per-station,
+  one extra call), so this is acceptable but should be watched if the month tab
+  is later bulk-loaded.
+- The quarterly card on the month tab is reservoir-only at the rendering layer;
+  the data-layer quarter merge runs for every station. Extra metric columns on
+  non-reservoir quarterly frames are inert.
+- The tests must not rely on live Tajik/Kyrgyz station codes. Use `19999` for
+  automated fixtures and reserve real station discovery for the operational
+  check only.
+- Shared-helper mutation risk: _horizon_in_year_col is shared by 13 call sites
+  across src/db.py. Today none of them is invoked with quarter or season (see
+  caller enumeration in Investigation Anchors). If a future caller passes
+  either horizon expecting pentad_in_year (the prior default), behavior will
+  silently change. Reviewers of any future code that adds a quarter/season
+  call site must consult this helper.
+- Pagination ceiling: get_forecast_stats (src/db.py:421-444) is single-page
+  with limit=1000 and no pagination loop. Per-station quarter/season skill
+  volumes are well below this today (≤ ~50 rows per station), so the fix is
+  correct as designed. If per-station skill rows ever exceed 1000 (e.g., from
+  finer horizon-in-year granularity or per-day instead of per-period rows),
+  the dashboard will silently see a subset.
+
+## Dependency Graph
+
+```json
+{
+  "phases": {
+    "P1": { "depends_on": [], "parallel_agents": 1 },
+    "P2": { "depends_on": ["P1"], "parallel_agents": 1 },
+    "P3": { "depends_on": ["P2"], "parallel_agents": 1 },
+    "P4a": { "depends_on": ["P2"], "parallel_agents": 1 },
+    "P4b": { "depends_on": ["P4a", "P2"], "parallel_agents": 1 }
+  }
+}
+```

--- a/doc/plans/issues/archive/high_prio_gi_draft_ltf_seasonal_quarterly_q_null.md
+++ b/doc/plans/issues/archive/high_prio_gi_draft_ltf_seasonal_quarterly_q_null.md
@@ -1,10 +1,29 @@
 # LT seasonal/quarterly hindcasts: `q` field null for LR models, blocking skill computation
 
-**Status**: Draft (PP-028b prevents the KeyError crash but does NOT produce skill metrics for affected models — q and q50 are both None at row level, so the downstream fallback yields NaN which gets dropped)
+**Status**: **Resolved (2026-05-29)** — no code change required; archived as superseded by current data state.
 **Module**: long_term_forecasting
-**Priority**: High (seasonal/quarterly skill metrics still zero for all LR models)
+**Priority**: High (historical)
 **Labels**: `bug`, `long-term-forecasting`, `skill-metrics`
 **Assigned**: @sandrohuni
+
+## Resolution note (2026-05-29)
+
+A live audit of the running kghm postprocessing stack confirmed this issue no longer reproduces as written:
+
+- **`q` is populated** for LR_Base, LR_SM, LR_SM_DT, and LR_SM_ROF on monthly, quarterly, and seasonal hindcast rows. `q`-null fraction is under 3% across these models (likely incidental missing-input rows, not the systemic absence the original problem statement described).
+- **`q50` is still null** for nearly all non-MC long forecasts, but `apps/postprocessing_forecasts/src/skill_metrics.py:1090` resolves point forecasts as `q` first with `q50` as fallback. With `q` populated, skill calculation proceeds normally.
+- For most models, `q50` is semantically equal to `q` (same point estimate), so the null `q50` carries no information loss and breaks no downstream consumer that uses `q`.
+- Skill metrics for LR_Base and LR_SM are present in the DB for all three long-term horizons. Tajik deployment scope only requires seasonal forecasts for these two models, so the current emit set is sufficient.
+
+What remains unresolved but is no longer high priority:
+- **q50 backfill** — if any downstream consumer ever requires `q50` directly (rather than via the `q` → `q50` fallback), q50 should be backfilled to equal q for models where they are definitionally the same. Low priority; only actionable if a concrete consumer is identified.
+- **Seasonal model coverage gap** — GBT, SM_GBT, MC_ALD, LR_SM_DT, LR_SM_ROF have no seasonal long_forecasts upstream. Out of scope for Tajik (only LR_Base + LR_SM needed). Track separately if other deployments need broader seasonal model coverage.
+
+The remaining real concern surfaced by the audit is **dashboard quarter/season skill visibility** (`apps/forecast_dashboard/src/db.py:737–765` returns empty `forecast_stats` for quarter and season). That is tracked under a separate plan.
+
+---
+
+## Original plan (historical, retained for context)
 
 ---
 

--- a/doc/plans/issues/archive/high_prio_gi_draft_pp_ml_skill_horizon_archive_split.md
+++ b/doc/plans/issues/archive/high_prio_gi_draft_pp_ml_skill_horizon_archive_split.md
@@ -4,9 +4,29 @@
 |---|---|
 | Module | `postprocessing_forecasts` |
 | Priority | High |
-| Status | Draft |
-| Branch | `fix_postprocessing_skill_metrics` |
+| Status | **Completed (2026-05-28)** |
+| Branch | `fix_postprocessing_skill_metrics` (pushed) |
 | Labels | `bug`, `skill-metrics`, `api-integration`, `tajik-deployment` |
+
+## Completion Summary
+
+Implemented on branch `fix_postprocessing_skill_metrics` and pushed. Three commits:
+
+| Commit | Phase | Content |
+|---|---|---|
+| `a32a11f` | P1 | Archive-union regression tests (replaces DAY-first assertions in `test_data_reader.py`; adds `test_ml_horizon_archive_split.py`; adds direct `_normalize_ml_forecasts` mixed-frame test) |
+| `c228122` | P2 | Cutover merge implementation in `apps/postprocessing_forecasts/src/data_reader.py` (+147/-63 lines; signature preserved) |
+| `755addf` | P3 | Integration test exercising the recalc path end-to-end, plus NEURAL_ENSEMBLE mixed-coverage numeric-mean assertions |
+
+**Final test run:** 1330 passed, 0 failed, 0 unexpected skips, 2 warnings.
+
+**Red-phase verification:** confirmed 2026-05-28 that the new tests genuinely guard the fix — reverting P2 alone produces 10 failures (8 P1 + 2 P3), all PP-036-related, no Type-II errors, no scope bleed. See "Red-Phase Verification Log" at the bottom of this document for procedure and counts.
+
+**Deferred to deployment time (P4):** operator runs the archive probe, staging recalc, and API/SQL `n_pairs >= 15` assertions from the P4 section against a real postgres-backed deployment before treating PP-036 as deployed on Tajik. Not a release blocker for this branch; tracked as part of the Tajik pre-deploy validation.
+
+**Decisions worth preserving:**
+- The LR byte-identical baseline assertion was dropped in favour of relying on the P2 file allow-list and orchestrator deliberation. The "LR path regression" Risks bullet documents the rationale.
+- The `first_day_date` cutover is computed per `(code, model_type)` after `_clean_code_column()` to keep `_normalize_ml_forecasts()` archive-agnostic.
 
 ## Problem Statement
 

--- a/doc/plans/issues/high_prio_gi_draft_pp_ml_skill_horizon_archive_split.md
+++ b/doc/plans/issues/high_prio_gi_draft_pp_ml_skill_horizon_archive_split.md
@@ -1,0 +1,336 @@
+# PP-036: ML skill metrics starved by DAY horizon short-circuit
+
+| Field | Value |
+|---|---|
+| Module | `postprocessing_forecasts` |
+| Priority | High |
+| Status | Draft |
+| Branch | `fix_postprocessing_skill_metrics` |
+| Labels | `bug`, `skill-metrics`, `api-integration`, `tajik-deployment` |
+
+## Problem Statement
+
+ML pentad/decade skill metrics are recalculated from too little history because `_read_ml_forecasts_pp_api` stops at the first non-empty archive. The current code says it will try `horizon="day"` first and "then falls back" to the requested period horizon (`apps/postprocessing_forecasts/src/data_reader.py:1582-1586`), but the control flow returns immediately when DAY has any rows:
+
+```python
+# apps/postprocessing_forecasts/src/data_reader.py:1621-1674
+for try_horizon in ["day", api_horizon]:
+    ...
+    if all_records:
+        logger.debug(
+            "Read ML forecasts for %s with horizon=%s",
+            model,
+            try_horizon,
+        )
+        return pd.concat(all_records, ignore_index=True)
+```
+
+Because operational DAY rows exist for TFT, TiDE, and TSMixer while the longer migrated PENTAD/DECADE archive also exists, recalculation reads only the short DAY-era subset. `calculate_skill_metrics()` then merges simulated and observed rows on `["code", "date"]` (`apps/postprocessing_forecasts/src/skill_metrics.py:1802-1806`) and groups by period, code, and model (`apps/postprocessing_forecasts/src/skill_metrics.py:1813-1824`), so each period-level group can end up with only the recent DAY-era pairs instead of the full migrated history.
+
+## Investigation Findings
+
+The bug still lives in `apps/postprocessing_forecasts/src/data_reader.py`. `_read_ml_forecasts_pp_api()` is defined at `apps/postprocessing_forecasts/src/data_reader.py:1575`, maps `horizon_type="decad"` to API `horizon="decade"` at `apps/postprocessing_forecasts/src/data_reader.py:1614`, builds optional `start_date`/`end_date` at `apps/postprocessing_forecasts/src/data_reader.py:1616-1617`, then loops over `["day", api_horizon]` at `apps/postprocessing_forecasts/src/data_reader.py:1621`. The early return at `apps/postprocessing_forecasts/src/data_reader.py:1668-1674` confirms the draft's root-cause description.
+
+Production callers are confined to `apps/postprocessing_forecasts/src/data_reader.py`: `read_individual_model_forecasts()` calls `_read_ml_forecasts_pp_api()` for each configured ML model at `apps/postprocessing_forecasts/src/data_reader.py:2149-2152`; `read_observed_and_modelled_data()` calls `read_individual_model_forecasts()` at `apps/postprocessing_forecasts/src/data_reader.py:2270-2274`; and `read_individual_model_forecasts_for_dates()` delegates back to `read_individual_model_forecasts()` with year bounds at `apps/postprocessing_forecasts/src/data_reader.py:2204-2213`. Tests import or patch the private reader at `apps/postprocessing_forecasts/tests/test_data_reader.py:14-28` and `apps/postprocessing_forecasts/tests/test_data_reader.py:2919-2966`.
+
+The postprocessing API can filter forecasts by one horizon per request. `GET /forecast/` accepts a single `horizon` query parameter (`sapphire/services/postprocessing/app/main.py:71-83`) and passes it to `crud.get_forecast()` (`sapphire/services/postprocessing/app/main.py:87-99`), where `Forecast.horizon_type == horizon` is applied when present (`sapphire/services/postprocessing/app/crud.py:79-82`). The schema and model field are both `horizon_type` (`sapphire/services/postprocessing/app/schemas.py:8-16`, `sapphire/services/postprocessing/app/models.py:57-70`), and the enum includes `DAY`, `PENTAD`, and `DECADE` (`sapphire/services/postprocessing/app/models.py:9-17`). The client should make two explicit requests (`day` plus `pentad` or `decade`) rather than relying on an unfiltered API call. Do not change anything under `sapphire/services/`.
+
+The short-term recalculation path starts in `bin/yearly_skill_metrics_recalculation.sh`, which delegates to `run_skill_metrics_recalc_once` at `bin/yearly_skill_metrics_recalculation.sh:96-100`; the helper runs `uv run recalculate_skill_metrics.py` in the postprocessing container at `bin/utils/run_skill_metrics_recalc.sh:71-87`. Luigi has the same annual path in `YearlySkillRecalculation`, setting `SAPPHIRE_PREDICTION_MODE=BOTH` and running the same entry point at `apps/pipeline/pipeline_docker.py:1974-2003`. New-site backfill also invokes the same helper in mode `BOTH` at `bin/initialize_site_backfill.sh:419-459`.
+
+Inside the Python entry point, `_run_short_term_recalc()` calls `data_reader.read_observed_and_modelled_data(config.name, codes=codes)` at `apps/postprocessing_forecasts/recalculate_skill_metrics.py:122-131`, derives the Neural Ensemble from whatever ML rows were loaded at `apps/postprocessing_forecasts/recalculate_skill_metrics.py:146-151`, and calls `skill_metrics.calculate_skill_metrics()` at `apps/postprocessing_forecasts/recalculate_skill_metrics.py:153-163`. Scoped dashboard-triggered recalculation also runs `uv run recalculate_skill_metrics.py` with `SAPPHIRE_RECALC_STATION_CODE` at `apps/forecast_dashboard/src/vizualization.py:4035-4050`; `_read_station_codes()` honors that override at `apps/postprocessing_forecasts/recalculate_skill_metrics.py:97-109`.
+
+Operational short-term postprocessing reads only the current year for forecast creation (`apps/postprocessing_forecasts/postprocessing_operational.py:121-128`) and reads already-calculated skill metrics (`apps/postprocessing_forecasts/postprocessing_operational.py:132-140`), so the destructive write happens during recalculation, not normal daily forecast display. Maintenance gap filling uses `read_individual_model_forecasts_for_dates()` at `apps/postprocessing_forecasts/postprocessing_maintenance.py:255-267`; it benefits from the same reader fix but does not recalculate historical skill metrics.
+
+The repository confirms the structural archive split but not the deployment-specific DAY start date. The short-term data-flow document says ML writes `forecasts` rows with `horizon_type=day` and daily targets (`doc/data_flow_short_term.md:99-104`, `doc/data_flow_short_term.md:131-135`). The postprocessing migrator maps ML forecast CSV rows into `horizon_type="day"` for the current `forecast` migrator path (`sapphire/services/postprocessing/app/data_migrator.py:359-378`, `sapphire/services/postprocessing/app/data_migrator.py:1020-1037`), and the bulk migration utility transforms historical ML CSVs into `horizon_type="DAY"` (`apps/machine_learning/bulk_migrate_forecasts.py:90-118`). None of the checked code or docs proves "DAY starts around April 2024" for the running Kyrgyz deployment; that remains an operator-confirmed data fact.
+
+Forecast-date rule audit: the PP-036 fix surface in `_read_ml_forecasts_pp_api()` does not call `date.today()` today and must not add one. There are existing date-today usages elsewhere in the recalc path: `recalculate_skill_metrics.py` defaults the skill-metric year from `dt.date.today().year` at `apps/postprocessing_forecasts/recalculate_skill_metrics.py:211`, long-term/default ranges use it at `apps/postprocessing_forecasts/recalculate_skill_metrics.py:239-246`, `286-293`, `333-340`, and `380-387`, and `calculate_skill_metrics()` uses `dt.date.today().year - 20` as the default filter start at `apps/postprocessing_forecasts/src/skill_metrics.py:1796-1800`. These are pre-existing cleanup candidates; PP-036 should avoid expanding the date surface and should set date/range environment explicitly in tests.
+
+Existing test coverage is partial and currently encodes the bad fallback contract. `TestReadMlForecastsPpApi` asserts "tries DAY first" and "falls back to horizon_type" at `apps/postprocessing_forecasts/tests/test_data_reader.py:2656-2754`, but it does not assert reading both archives. `_normalize_ml_forecasts()` has extensive period-target aggregation coverage in `apps/postprocessing_forecasts/tests/test_data_reader_ml_aggregation.py:1-17`, including pentad target filtering (`apps/postprocessing_forecasts/tests/test_data_reader_ml_aggregation.py:23-51`) and dual pentad/decade boundary behavior (`apps/postprocessing_forecasts/tests/test_data_reader_ml_aggregation.py:438-455`). Recalc workflow tests cover that the entry point calls `calculate_skill_metrics()` and saves results (`apps/postprocessing_forecasts/tests/test_recalc_workflow.py:167-198`), while scoped recalc already uses placeholder station code `19999` in tests (`apps/postprocessing_forecasts/tests/test_scoped_skill_recalc.py:121-124`, `apps/postprocessing_forecasts/tests/test_scoped_skill_recalc.py:181-218`).
+
+The dashboard does not need a PP-036 code change. It fetches persisted skill metrics from `/skill-metric/` in `get_forecast_stats()` (`apps/forecast_dashboard/src/db.py:420-444`) and all-station skill metrics in `get_forecast_stats_all()` (`apps/forecast_dashboard/src/db.py:447-489`). `get_data()` merges those persisted values into forecasts on `["code", horizon_in_year, "model_short"]` at `apps/forecast_dashboard/src/db.py:633-675`. The all-station skill table also uses the same API-backed cache path (`apps/forecast_dashboard/dashboard/data_manager.py:148-156`, `apps/forecast_dashboard/dashboard/plot_manager.py:415-434`). Once recalculation writes correct `n_pairs` and metric values, the dashboard will read them.
+
+Related dashboard plans touch neighboring display bugs, not this recalc root cause. `high_prio_gi_draft_dashboard_skill_metrics_model_long_mismatch.md` proposes removing `model_long` from merge keys (`doc/plans/issues/high_prio_gi_draft_dashboard_skill_metrics_model_long_mismatch.md:68-84`), which current code already reflects at `apps/forecast_dashboard/src/db.py:658-675`. `high_prio_gi_draft_dashboard_duplicate_forecasts_skill_merge.md` proposes keeping the latest skill metric per key (`doc/plans/issues/high_prio_gi_draft_dashboard_duplicate_forecasts_skill_merge.md:58-91`), which current code reflects at `apps/forecast_dashboard/src/db.py:441-443` and `apps/forecast_dashboard/src/db.py:486-488`. `high_prio_gi_draft_dashboard_daily_ml_forecast_limit_truncation.md` concerns raw DAY forecast display truncation (`doc/plans/issues/high_prio_gi_draft_dashboard_daily_ml_forecast_limit_truncation.md:13-31`) and is independent of skill-metric recalculation.
+
+Long-term month/quarter/season skill metrics are not affected by PP-036. The bimonthly long-term wrapper only runs `MONTHLY`, `QUARTERLY`, and `SEASONAL` (`bin/bimonthly_long_term_skill_metrics_recalculation.sh:100-108`). In `recalculate_skill_metrics.py`, those modes call `read_monthly_forecasts()`, `read_quarterly_forecasts()`, and `read_seasonal_forecasts()` at `apps/postprocessing_forecasts/recalculate_skill_metrics.py:238-346`; those readers use `_read_long_forecasts_api()` and the `long_forecasts` endpoint/table (`apps/postprocessing_forecasts/src/data_reader.py:994-1090`, `apps/postprocessing_forecasts/src/data_reader.py:2528-2647`), not `_read_ml_forecasts_pp_api()`.
+
+## Desired Behaviour
+
+For `horizon_type in {"pentad", "decad"}`, `_read_ml_forecasts_pp_api(model, horizon_type, codes, start_year, end_year)` must:
+
+1. Query both archives for the same model, station scope, and date range: `horizon="day"` and `horizon="pentad"` or `horizon="decade"`.
+2. Preserve pagination and station scoping for both archives.
+3. Compute `first_day_date` from raw DAY rows after `_clean_code_column()`, per `(code, model_type)` pair. This is structurally feasible because `_clean_code_column()` is a local helper (`apps/postprocessing_forecasts/src/data_reader.py:1394-1398`) and `_normalize_ml_forecasts()` is called only after `_read_ml_forecasts_pp_api()` returns (`apps/postprocessing_forecasts/src/data_reader.py:2149-2152`).
+4. Log a WARNING if any `(code, model_type)` has DAY rows older than its earliest period-archive row. That should not happen and signals upstream data inconsistency, but it must not abort recalculation.
+5. Keep all DAY rows from each pair's `first_day_date` forward.
+6. Append PENTAD/DECADE rows only for issue dates older than that pair's `first_day_date`.
+7. If a station/model has no DAY rows at all, return the PENTAD/DECADE rows exactly as the current fallback does.
+8. If a station/model has only DAY rows and the period-archive query is empty, return DAY rows and continue normally.
+9. If a station/model has DAY rows but a missing DAY issue date inside the DAY era, do not fill that gap from the PENTAD/DECADE archive.
+10. Preserve the daily target fan in raw DAY rows so `_normalize_ml_forecasts()` can average the in-period targets correctly.
+11. Do not raw-deduplicate on `(code, date, model_type)`, because DAY rows intentionally contain multiple targets for the same issue date. The smaller safe implementation is to filter the period archive by DAY-era cutover before normalization, keeping `_normalize_ml_forecasts()` archive-agnostic. Computing the cutover after normalization would force `_normalize_ml_forecasts()` to understand archive provenance, breaking its current contract as a pure raw-API normalizer.
+12. Ensure the normalized downstream forecast output has at most one row per `(code, date, model_short)`; DAY wins any overlap and no period is double-counted.
+
+## Edge Cases Requiring Tests
+
+- Station `19999` has only PENTAD/DECADE history and no DAY rows: return period rows and normalize to period forecasts.
+- Station `19999` has only DAY history and no PENTAD/DECADE rows: function returns the DAY-derived normalized rows unchanged and does not crash when the period-archive query returns empty.
+- Station `19999` has DAY and PENTAD/DECADE rows on the same issue date: normalized output uses DAY-derived values and has no duplicate `(code, date, model_short)`.
+- Station `19999` has DAY rows, then a DAY-era outage date where period rows exist: do not use period rows for that in-era gap.
+- Station `19999` has no ML history in either archive: preserve current `None`/empty behavior.
+- Recalc input straddles the DAY cutover: older PENTAD/DECADE rows plus newer DAY rows both contribute.
+- Full-history synthetic recalc produces `n_pairs >= 15` for at least one `(code, model_short, horizon_in_year)` after the fix; the same test should fail on `maxat_sapphire_2` because the early return leaves only the DAY-era pairs.
+
+## Phase P1 - Tests First
+
+**Goal:** Add failing tests that lock the archive-union contract before implementation.
+
+**Files allowed:**
+
+- `apps/postprocessing_forecasts/tests/test_data_reader.py`
+- `apps/postprocessing_forecasts/tests/test_ml_horizon_archive_split.py` (new, preferred if the existing file is too large)
+- `apps/postprocessing_forecasts/tests/test_data_reader_ml_aggregation.py` only if an existing normalization assertion needs extension
+
+**Forbidden:** code changes under `apps/postprocessing_forecasts/src/` and all changes under `sapphire/services/`.
+
+**Depends on:** none.
+
+**Agents:** 1 Sonnet 4.6 general-purpose agent, `isolation: "worktree"`.
+
+**Agent instructions:**
+
+- Add unit tests around `_read_ml_forecasts_pp_api()` using a fake `SapphirePostprocessingClient`.
+- Use station code `19999` only.
+- Do not call `date.today()` or `datetime.now()` in tests; use fixed dates and explicit `start_year`/`end_year`.
+- Cover the seven edge cases above, including the DAY-only branch where the period archive is empty.
+- Update or replace the current assertions at `apps/postprocessing_forecasts/tests/test_data_reader.py:2659-2725` that encode "return DAY when present" as the desired behavior.
+- Assert the sequence of API calls includes both `horizon="day"` and the period horizon for pentad and decad.
+- Include pagination coverage for both archives if the fake client can do so without brittle mock ordering.
+- Do NOT change any existing function signatures, data flow logic, or control flow.
+
+**Acceptance criteria:**
+
+- New tests fail against the current code because PENTAD/DECADE is never read when DAY is non-empty.
+- Existing normalization tests still pass.
+- No test uses a real station code, operational discharge value, external API, service DB, or wall-clock date.
+
+## Phase P2 - Reader Implementation
+
+**Goal:** Fix the archive read/merge behavior with the smallest safe change.
+
+**Files allowed:**
+
+- `apps/postprocessing_forecasts/src/data_reader.py`
+
+**Forbidden:** all files under `sapphire/services/`; public API helper signature changes; changes to `calculate_skill_metrics()`; changes to long-term readers.
+
+**Depends on:** P1.
+
+**Agents:** 1 Sonnet 4.6 general-purpose agent, `isolation: "worktree"`.
+
+**Agent instructions:**
+
+- Do NOT change any existing function signatures, data flow logic, or control flow outside the specific behavior described here.
+- Keep `_read_ml_forecasts_pp_api(model, horizon_type, codes=None, start_year=None, end_year=None)` signature unchanged.
+- Extract the existing per-horizon paginated fetch loop into a private helper in the same file, or otherwise remove duplication without changing callers.
+- Query `day` and `api_horizon` unconditionally when the API is available and ready.
+- Add a helper that merges raw archives by DAY-era cutover:
+  - Clean `code` with `_clean_code_column()` and parse `date` before computing cutovers.
+  - Compute `first_day_date` from raw DAY rows per `(code, model_type)` pair.
+  - Log a WARNING, but do not abort, if a pair has DAY rows older than its earliest period-archive row.
+  - For each `(code, model_type)` pair found in DAY rows, keep period rows with `date < first_day_date`.
+  - For pairs with no DAY rows, keep all period rows.
+  - Concatenate all DAY rows with retained period rows.
+  - Do not raw-deduplicate DAY rows on `(code, date, model_type)`.
+  - Drop any temporary columns before returning.
+- Log separate row counts for DAY, period, retained period, and final rows.
+- Preserve current behavior for API unavailable, API disabled, readiness failure, and both archives empty.
+
+**Acceptance criteria:**
+
+- P1 tests pass.
+- `_read_ml_forecasts_pp_api()` makes both API requests when DAY rows exist.
+- The function returns `None` when both archives are empty, matching current contract.
+- No `date.today()` or `datetime.now()` is added.
+- `read_individual_model_forecasts()` at `apps/postprocessing_forecasts/src/data_reader.py:2090-2173` does not need a signature change.
+
+## Phase P3 - Recalc Integration Test
+
+**Goal:** Prove the full short-term recalc path sees the longer ML history and produces realistic `n_pairs`.
+
+**Files allowed:**
+
+- `apps/postprocessing_forecasts/tests/test_ml_horizon_archive_split.py`
+- `apps/postprocessing_forecasts/tests/test_wiring_integration.py` only if that suite already has the right entry-point fixtures
+- `apps/postprocessing_forecasts/tests/test_recalc_workflow.py` only for narrow entry-point assertions
+
+**Forbidden:** real API/DB writes; all changes under `sapphire/services/`.
+
+**Depends on:** P2.
+
+**Agents:** 1 Sonnet 4.6 general-purpose agent, `isolation: "worktree"`.
+
+**Agent instructions:**
+
+- Build an in-memory fake for observed runoff and ML forecast API responses.
+- Do NOT change any existing function signatures, data flow logic, or control flow.
+- Use fixed years and set `SAPPHIRE_SKILL_METRICS_START_YEAR` explicitly so the test is independent of the machine date.
+- Exercise the pipeline through `read_observed_and_modelled_data()` plus `calculate_skill_metrics()`, or through `_run_short_term_recalc()` with `file_writer.save_skill_metrics()` monkeypatched to capture the DataFrame.
+- Construct data so the current early return would yield only one or two DAY-era pairs for a period group, while the fixed reader yields at least fifteen pairs.
+- Assert `n_pairs >= 15` for station `19999` and at least one ML model on both pentad and decad paths if runtime is acceptable; otherwise make decad a separate unit-level regression and pentad the full integration case.
+- Construct a mixed-coverage Neural Ensemble fixture where TFT and TiDE have full PENTAD/DECADE history but TSMixer has only DAY-era rows. The existing `calculate_neural_ensemble_forecast()` and decad variant build NE from whatever target-model rows are available per date by grouping and averaging (`apps/iEasyHydroForecast/setup_library.py:3822-3877`, `apps/iEasyHydroForecast/setup_library.py:3892-3940`), so assert NE exists on historical dates as a partial average of TFT/TiDE and is not silently NaN-filled or absent. Also assert DAY-era NE includes TSMixer once TSMixer rows exist.
+
+**Acceptance criteria:**
+
+- Test fails on the current early-return implementation and passes after P2.
+- No test writes to PostgreSQL, SQLite service tables, local production CSVs, or `sapphire/services/`.
+- `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh postprocessing_forecasts` passes with zero unexpected skips.
+
+## Phase P4 - Operational Verification
+
+**Goal:** Verify the fix on staging before Tajik deployment cutover.
+
+**Files allowed:** none; operator commands only.
+
+**Depends on:** P3.
+
+**Agents:** 0; operator runs commands, orchestrator reviews results.
+
+**Operator commands:**
+
+```bash
+BASE_URL="http://localhost:8000/api/postprocessing"
+
+# Confirm the archive split for a placeholder station code. Substitute the
+# real station code only in the operator shell; do not commit it to docs.
+for H in day pentad decade; do
+  curl -s "${BASE_URL}/forecast/?horizon=${H}&code=19999&model=TFT&start_date=2000-01-01&end_date=2026-12-31&limit=100000" \
+    | jq -r --arg h "$H" '[.[].date] | {horizon:$h, rows:length, first:(min // null), last:(max // null)}'
+done
+```
+
+Run one staging recalculation after deployment. If running locally inside the postprocessing app environment:
+
+```bash
+cd apps/postprocessing_forecasts
+SAPPHIRE_PREDICTION_MODE=BOTH \
+SAPPHIRE_RECALC_STATION_CODE=19999 \
+SAPPHIRE_SKILL_METRICS_START_YEAR=2009 \
+SAPPHIRE_SKILL_METRICS_YEAR=2026 \
+uv run python recalculate_skill_metrics.py
+```
+
+If running the deployed Docker job, use the existing annual or initialization path and verify the same station after completion.
+
+API-level assertion. The `date` filter below is intentional: `_write_skill_metrics_to_api()` maps each `horizon_in_year` to a target-year period date from `SAPPHIRE_SKILL_METRICS_YEAR`/`skill_metrics_year`, not to the recalc runtime (`apps/postprocessing_forecasts/src/api_writer.py:438-440`, `apps/postprocessing_forecasts/src/api_writer.py:543-555`).
+
+```bash
+for H in pentad decade; do
+  curl -s "${BASE_URL}/skill-metric/?horizon=${H}&code=19999&start_date=2026-01-01&end_date=2026-12-31&limit=10000" \
+    | jq -r '
+      group_by(.model_type)[] |
+      {model: .[0].model_type,
+       rows: length,
+       min_n_pairs: ([.[].n_pairs] | min),
+       max_n_pairs: ([.[].n_pairs] | max),
+       avg_n_pairs: (([.[].n_pairs] | add) / length)}'
+done
+```
+
+Optional SQL assertion inside the postprocessing DB:
+
+```sql
+SELECT horizon_type,
+       code,
+       model_type,
+       COUNT(*) AS rows,
+       MIN(n_pairs) AS min_n_pairs,
+       ROUND(AVG(n_pairs)::numeric, 2) AS avg_n_pairs,
+       MAX(n_pairs) AS max_n_pairs
+FROM skill_metrics
+WHERE code = '19999'
+  AND horizon_type IN ('PENTAD', 'DECADE')
+  AND date >= DATE '2026-01-01'
+  AND date <= DATE '2026-12-31'
+GROUP BY horizon_type, code, model_type
+ORDER BY horizon_type, model_type;
+```
+
+**Acceptance criteria:**
+
+- Archive probe shows DAY and period archives are both queryable for the chosen station/model, or documents that a given model has only period rows.
+- After one recalc, at least one `(code, model_type)` pair per short-term horizon has `n_pairs >= 15`.
+- No model regresses to duplicate skill rows per `(code, horizon_in_year, model_type)` in the latest recalculation year.
+- Dashboard skill tables and plots consume updated API values without dashboard code changes.
+
+## Risks And Mitigations
+
+- **Tests writing to DB:** avoid service clients and monkeypatch all writers. Use in-memory fakes and captured DataFrames.
+- **PostgreSQL-only upsert behavior vs SQLite tests:** PP-036 should not test upsert semantics. If any integration test uses SQLite, keep it read-only or capture writes before they reach the service layer.
+- **Long-term regression:** `_read_long_forecasts_api()`, `read_monthly_forecasts()`, `read_quarterly_forecasts()`, and `read_seasonal_forecasts()` are separate (`apps/postprocessing_forecasts/src/data_reader.py:994-1090`, `apps/postprocessing_forecasts/src/data_reader.py:2528-2647`). P2 must not touch them; run existing monthly/quarterly/seasonal tests as a guard if the agent edits shared helpers.
+- **LR path regression:** LR pentad/decad reads go through `_read_lr_forecasts_pp_api()`, which P2 must not modify. The structural isolation is enforced by the P2 file allow-list (only `apps/postprocessing_forecasts/src/data_reader.py`) and the literal "no signature/data-flow/control-flow change" constraint. Orchestrator deliberation after P2 must explicitly confirm `_read_lr_forecasts_pp_api()` and its callers are unchanged in the diff; this replaces an earlier draft requirement for a byte-identical LR skill baseline fixture, which would have added significant fixture/capture complexity for a contract the file allow-list already enforces.
+- **Raw dedupe collapsing DAY fan:** do not raw-deduplicate on `(code, date, model_type)`. Use DAY-era period filtering before normalization, or normalize separately and deduplicate normalized rows.
+- **Silent fill of DAY-era outages:** period rows after first DAY issue date must be discarded for that station/model, even if DAY has a missing issue date.
+- **Existing NE partial-average behavior:** Neural Ensemble is currently computed from whatever base ML models are available for each date, so historical dates where TSMixer is absent can still get NE from TFT/TiDE. PP-036 preserves this behavior; changing it to require all three base models is a separate modelling decision.
+- **Unverified DAY cutoff:** repository evidence does not prove the running deployment's first DAY dates. P4 includes operator archive probes before and after recalculation.
+- **Runtime and API volume:** reading both archives increases API calls. Preserve pagination, station scoping, and date bounds; log separate row counts for observability.
+
+## Whole-Fix Acceptance Criteria
+
+- `_read_ml_forecasts_pp_api()` reads both DAY and PENTAD/DECADE archives for ML models and returns a non-double-counted union according to the DAY-era cutover rule.
+- Existing public function signatures remain unchanged unless an implementer documents why a private helper cannot preserve them.
+- New tests fail on `maxat_sapphire_2` without the fix and pass with the fix.
+- `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh postprocessing_forecasts` passes with zero unexpected skips.
+- On staging, after one recalculation, `n_pairs >= 15` for at least one `(code, model_type)` pair per short-term horizon using the API/SQL checks above.
+- No code under `sapphire/services/` is modified.
+- No dashboard code change is required for PP-036.
+- No regression in long-term month/quarter/season skill metrics or forecast readers.
+
+## Assumptions For Operator Confirmation
+
+- The running Kyrgyz deployment's DAY archive starts around April 2024 for TFT/TiDE and later for TSMixer.
+- The PENTAD/DECADE archive contains the migrated long history needed for each Tajik station before the first recalc.
+- The placeholder station code `19999` in examples will be replaced only in operator shells, not committed to repo docs.
+- API enum query parameters continue accepting lowercase `day`, `pentad`, and `decade` even though the PostgreSQL enum stores uppercase names.
+
+## Open Questions
+
+- Should `calculate_skill_metrics()` receive an explicit forecast/reference date in a follow-up to remove the current `dt.date.today().year - 20` default?
+- Should `bin/utils/run_skill_metrics_recalc.sh` pass through `SAPPHIRE_RECALC_STATION_CODE` for easier staging verification, or should scoped recalc remain a local/dashboard-only path?
+
+## Dependency Graph
+
+```json
+{
+  "phases": {
+    "P1": { "depends_on": [], "parallel_agents": 1 },
+    "P2": { "depends_on": ["P1"], "parallel_agents": 1 },
+    "P3": { "depends_on": ["P2"], "parallel_agents": 1 },
+    "P4": { "depends_on": ["P3"], "parallel_agents": 0 }
+  }
+}
+```
+
+## Red-Phase Verification Log
+
+**2026-05-28** — Verified the P1 and P3 test commits genuinely guard the P2
+fix. Procedure: created an isolated worktree at HEAD (`a32a11f` P1 +
+`c228122` P2 + `755addf` P3), reverted only `c228122` with
+`git revert --no-commit`, and ran the postprocessing_forecasts test suite.
+
+Revert scope was clean: only `apps/postprocessing_forecasts/src/data_reader.py`
+changed (210 lines, +63/-147), no test files touched.
+
+**Result:** 1320 passed / 10 failed / 0 skipped. All 10 failures came from
+`postprocessing_forecasts/tests/test_ml_horizon_archive_split.py`:
+
+- 8 P1 unit failures in `TestMlHorizonArchiveSplit` covering DAY-only
+  history preservation, DAY/PERIOD dedup on same issue date, DAY-era outage
+  guard, cutover merge, API call sequencing for both pentad and decad
+  parametrizations, and paginated union.
+- 2 P3 integration failures in `TestMlHorizonArchiveSplitIntegration`
+  (pentad and decad) — both reproduced the PP-036 starvation end-to-end:
+  `tft_skill["n_pairs"].max() == 1`, expected `>= 15`.
+
+No PP-036 test passed without the fix (no Type-II errors), and no
+non-PP-036 test failed (revert did not bleed scope). Worktree removed
+afterwards. The fix is verified.

--- a/doc/plans/issues/low_prio_gi_draft_infra_playwright_sandbox_browser_launch.md
+++ b/doc/plans/issues/low_prio_gi_draft_infra_playwright_sandbox_browser_launch.md
@@ -1,0 +1,68 @@
+# Playwright integration tests fail at browser launch under macOS sandbox
+
+| Field | Value |
+|---|---|
+| Module | dev infra / test harness |
+| Priority | Low |
+| Status | Draft |
+| Labels | `dev-infra`, `tests`, `playwright`, `macos` |
+
+## Summary
+
+The Playwright-based integration tests in
+`apps/forecast_dashboard/tests/test_integration*.py` fail at browser launch with
+macOS sandbox permission errors when run inside a constrained shell sandbox
+(observed during PP-036 and PP-DASHBOARD-LONG-HORIZON red-phase verification,
+2026-05-28 and 2026-05-31). The errors are infrastructure-level (browser
+process cannot launch), not test assertions, so they surface as `errors`
+rather than `failures` in the pytest summary.
+
+## Symptoms
+
+- ~6 errors in `apps/forecast_dashboard/tests/test_integration*.py` during
+  `SAPPHIRE_TEST_ENV=True bash run_tests.sh forecast_dashboard` runs from
+  certain shell environments.
+- Failure mode: Playwright unable to launch a Chromium/Firefox process; macOS
+  raises sandbox-permission errors before any test code runs.
+- The same tests run cleanly from an unrestricted terminal session.
+
+## Why it matters
+
+Two effects:
+
+1. **Verification noise.** Anyone running the test suite from a sandboxed
+   shell (e.g., during red-phase reproductions performed by an LLM agent) sees
+   ~6 spurious errors and has to mentally exclude them when assessing
+   whether the suite actually passed.
+2. **Coverage gap.** If the Playwright tests are silently failing in CI or in
+   any automated environment, the dashboard integration coverage they provide
+   is not actually running. Verify this hasn't crept into a CI configuration.
+
+## Suggested investigation
+
+1. Confirm whether the failures occur only in shell-sandboxed sessions or also
+   in `bash`/`zsh` directly. Document the threshold.
+2. Decide whether Playwright tests should be gated on an environment variable
+   (e.g., `SAPPHIRE_RUN_PLAYWRIGHT=1`) so they are explicitly opt-in for
+   contexts that can launch a browser. The dashboard test suite already
+   skips Playwright when the package is unavailable
+   (`apps/forecast_dashboard/tests/conftest.py` — verify) but does not gate
+   on launch capability.
+3. If gating, update `bin/run_daily_maintenance.sh` and any CI workflow to
+   set the gate explicitly where appropriate.
+
+## Workaround
+
+For now: ignore Playwright `errors` in red-phase verification runs as long as
+they are clearly browser-launch failures, not assertion failures. Distinguish
+in any verification report.
+
+## Out of scope
+
+- Fixing the underlying macOS sandbox permission model.
+- Replacing Playwright with a non-browser test harness.
+
+## Related
+
+- PP-036 red-phase verification log (`doc/plans/issues/archive/high_prio_gi_draft_pp_ml_skill_horizon_archive_split.md`) noted the issue but did not file it.
+- Dashboard long-horizon skill summary red-phase verification (2026-05-31) hit the same errors and prompted this issue.

--- a/doc/plans/module_issues.md
+++ b/doc/plans/module_issues.md
@@ -98,6 +98,7 @@ These are blocking decisions — work downstream cannot advance until they are r
 | ~~**INFRA-016**~~ | ~~Switch default branch from `main` to `maxat_sapphire_2` (v2 cut)~~ | ~~infra~~ | | Complete | [`archive/high_prio_gi_draft_infra_default_branch_switch.md`](issues/archive/high_prio_gi_draft_infra_default_branch_switch.md) | — |
 | **FD-002b** | Synthetic integration tests with fake data | fd | **Medium** | Open | — (plan file never created) | — |
 | **INFRA-017** | Document DB initialization for fresh deployments (`SAPPHIRE_SYNC_MODE=initial`) | infra | **Medium** | Draft | [`mid_prio_gi_draft_infra_initial_sync_docs.md`](issues/mid_prio_gi_draft_infra_initial_sync_docs.md) | — |
+| **INFRA-018** | Playwright integration tests fail at browser launch under macOS sandbox (verification noise + potential CI coverage gap) | infra | **Low** | Draft | [`low_prio_gi_draft_infra_playwright_sandbox_browser_launch.md`](issues/low_prio_gi_draft_infra_playwright_sandbox_browser_launch.md) | — |
 | ~~**P-006**~~ | ~~Move long-term schedule query into Luigi pipeline~~ | ~~pipeline~~ | | Complete | [`review_gi_draft_pipeline_lt_schedule_into_luigi.md`](issues/review_gi_draft_pipeline_lt_schedule_into_luigi.md) | — |
 
 ---
@@ -200,6 +201,7 @@ These are blocking decisions — work downstream cannot advance until they are r
 | **FD-011** | Horizon selector widget passes translated strings as API enum values | **High** | Draft | [`high_prio_gi_draft_fd_horizon_selector_i18n.md`](issues/high_prio_gi_draft_fd_horizon_selector_i18n.md) | — |
 | ~~**FD-013**~~ | ~~Monthly skill metrics not loaded from API — all columns show "-"~~ | ~~**Mid**~~ | Complete | [`archive/mid_prio_gi_draft_fd_monthly_skill_metrics.md`](issues/archive/mid_prio_gi_draft_fd_monthly_skill_metrics.md) | — |
 | **FD-014** | Snow visualization — configurable year start, units & labels | **Medium** | In Progress | [`mid_prio_gi_draft_dashboard_snow_visualization_enhancements.md`](issues/mid_prio_gi_draft_dashboard_snow_visualization_enhancements.md) | Phase 2 blocked on colleague (services) |
+| ~~**FD-015**~~ | ~~Quarter/season skill metrics not rendered in summary table (data layer returns empty `forecast_stats`); reservoir quarterly card on month tab also affected~~ | | Complete | [`archive/high_prio_gi_draft_dashboard_long_horizon_skill_summary.md`](issues/archive/high_prio_gi_draft_dashboard_long_horizon_skill_summary.md) | Red-phase verified 2026-05-31 across P1-P4; tajik-deployment visible-impact target |
 
 ### iEasyHydro HF Migration
 

--- a/doc/plans/module_issues.md
+++ b/doc/plans/module_issues.md
@@ -140,7 +140,7 @@ These are blocking decisions — work downstream cannot advance until they are r
 | ~~**LTF-001**~~ | ~~`--today` flag in `run_forecast.py` runs zero models~~ | | Complete | [`archive/review_gi_draft_lt_today_flag_runs_no_models.md`](issues/archive/review_gi_draft_lt_today_flag_runs_no_models.md) | — |
 | ~~**LTF-002**~~ | ~~SQL org-scoping for long-term forecasting queries~~ | | Complete | [`archive/review_gi_draft_ltf_sql_org_scoping.md`](issues/archive/review_gi_draft_ltf_sql_org_scoping.md) | — |
 | ~~**LTF-003**~~ | ~~run_forecast.py sets flag=0 on null forecasts — marks failures as valid~~ (Fixed by @sandrohuni: NaN-aware flag=2 + dependency propagation) | | Complete | [`archive/high_prio_gi_draft_ltf_flag_zero_on_null.md`](issues/archive/high_prio_gi_draft_ltf_flag_zero_on_null.md) | — |
-| **LTF-004** | Seasonal/quarterly hindcasts have `q=None` for LR models — blocks skill computation (root cause: upstream `calibrate_model_and_hindcast` skips NaN rows) | **High** | Draft | [`high_prio_gi_draft_ltf_seasonal_quarterly_q_null.md`](issues/high_prio_gi_draft_ltf_seasonal_quarterly_q_null.md) | Fix A: @sandrohuni (upstream library); Fix B: @mabesa (fallback guard) |
+| ~~**LTF-004**~~ | ~~Seasonal/quarterly hindcasts have `q=None` for LR models — blocks skill computation~~ | | Complete | [`archive/high_prio_gi_draft_ltf_seasonal_quarterly_q_null.md`](issues/archive/high_prio_gi_draft_ltf_seasonal_quarterly_q_null.md) | Resolved 2026-05-29: `q` is now populated; `q50` null is harmless via `q`-first fallback at `skill_metrics.py:1090` |
 | **LTF-005** | Add climatological quantile bounds (Q25/Q75) for GBT forecasts | **Medium** | Review | [`review_gi_draft_lt_gbt_quantile_bounds.md`](issues/review_gi_draft_lt_gbt_quantile_bounds.md) | — |
 
 ### Postprocessing Forecasts (`pp`)
@@ -181,6 +181,7 @@ These are blocking decisions — work downstream cannot advance until they are r
 | ~~**PP-034**~~ | ~~`read_daily_forecasts()` passes wrong keyword `horizon_type` to API client — daily skill metrics never computed~~ | | Complete | [`archive/high_prio_gi_draft_pp_daily_forecast_read_horizon_type.md`](issues/archive/high_prio_gi_draft_pp_daily_forecast_read_horizon_type.md) | — |
 | **PP-035** | Deduplicate skill metrics before API write to fix monthly/quarterly/seasonal bulk upsert | **Medium** | Review | [`review_gi_draft_pp_skill_metric_dedup.md`](issues/review_gi_draft_pp_skill_metric_dedup.md) | — |
 | **PP-028b** | Skill metrics crash/silent failure — missing `q50` column across all horizons | **High** | Review | [`review_gi_draft_pp_monthly_skill_q50_regression.md`](issues/review_gi_draft_pp_monthly_skill_q50_regression.md) | — |
+| ~~**PP-036**~~ | ~~ML pentad/decadal skill metrics starved by `horizon='day'` short-circuit in API reader~~ | | Complete | [`archive/high_prio_gi_draft_pp_ml_skill_horizon_archive_split.md`](issues/archive/high_prio_gi_draft_pp_ml_skill_horizon_archive_split.md) | — |
 
 ### Forecast Dashboard (`fd`)
 


### PR DESCRIPTION
## Summary

- **PP-036** — Fix ML pentad/decade skill metrics starved by DAY-horizon short-circuit in `_read_ml_forecasts_pp_api`. The reader now queries both DAY and PENTAD/DECADE archives and merges by a per-`(code, model_type)` `first_day_date` cutover, restoring `n_pairs` to realistic values (~15–18 vs. the previous 1–2). Plan archived. Tajik deployment blocker.
- **LTF-004** — Confirmed no longer reproducing on the live kghm stack (`q` is populated; `q50` null is harmless because `skill_metrics.py:1090` resolves point forecasts as `q` first). Archived with resolution note; no code change required.
- **FD-015** — Render quarter and season skill metrics in the dashboard summary table and the **reservoir quarterly card on the month tab**. Closes the data-layer gap where `_get_data_quarter`, `_get_data_season`, and `_get_data_monthly`'s `long_forecasts_quarter` returned empty `forecast_stats`. The reservoir quarter-on-month-tab gap was caught during post-implementation review and addressed as P4.
- **Dashboard UI improvements** (pre-existing on branch): quarterly forecast card on month horizon for reservoirs; target-period bulletin naming for month/season/quarter; active horizon/period in dashboard header; skill-metrics table hidden on long-term horizons; tab/widget refinements.
- **Integration test coverage** (pre-existing on branch): month and season horizon coverage in the `test_local` Playwright suite; pentad/decade flow regression guards; ML forecast horizon archive-split tests.
- **api-gateway fix** — 204 response Content-Length mismatch (`sapphire/services/api-gateway/app/main.py`).
- **INFRA-018 filed** — Playwright integration tests fail at browser launch under macOS sandbox during local red-phase verification. Low-priority draft; not a regression from this PR's changes.

## Test plan

- [x] Full module test suite passes: `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh` for `postprocessing_forecasts` (1330 passed) and `forecast_dashboard` (288 passed), zero unexpected skips.
- [x] PP-036 red-phase verified (2026-05-28): reverting only the implementation commit `c228122` produces 10 expected failures across P1 + P3 assertions, no Type-II errors, no non-PP-036 test failures.
- [x] FD-015 P1–P3 red-phase verified (2026-05-31): reverting only `0f96d1e` produces 18 expected failures across all P1/P3 assertions, no Type-II errors, no P1–P3 regressions.
- [x] FD-015 P4 red-phase verified (2026-05-31): reverting only `65e9662` produces 3 expected P4a failures (`KeyError: 'delta'` on `long_forecasts_quarter`), no Type-II errors, no P1–P3 regressions.
- [ ] **Operator (PP-036)** — On staging, run skill-metric recalc and confirm `n_pairs >= 15` for at least one `(code, model_type)` per short-term horizon. Query: `GET /api/postprocessing/skill-metric/?horizon={pentad|decade}&model_type=TFT&limit=20`.
- [ ] **Operator (FD-015 season)** — Navigate to the season tab for a station with seasonal LR_Base/LR_SM skill data; confirm populated `accuracy`/`delta`/`sdivsigma`/`mae` columns in the summary table. Discover a station via `GET /api/postprocessing/skill-metric/?horizon=season&model_type=LR_Base&limit=5`.
- [ ] **Operator (FD-015 reservoir quarter)** — Navigate to the month tab for a reservoir station with quarter LR_Base skill data; confirm populated metric columns on the quarterly card. Discover a station via `GET /api/postprocessing/skill-metric/?horizon=quarter&model_type=LR_Base&limit=5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)