### PR TITLE
P4a: LR forecasts laptop-export → CSV → API

### DIFF
--- a/apps/iEasyHydroForecast/tests/fixtures/migration_csv/lr_forecast/decade_sample.csv
+++ b/apps/iEasyHydroForecast/tests/fixtures/migration_csv/lr_forecast/decade_sample.csv
@@ -1,0 +1,4 @@
+horizon_type,code,date,decad_in_month,decad_in_year,discharge_avg,predictor,slope,intercept,forecasted_discharge,q_mean,q_std_sigma,delta,rsquared
+decade,19999,2026-01-01,1,1,11.5,7.4,1.55,2.50,13.20,11.10,0.95,1.10,0.74
+decade,19999,2026-01-11,2,2,12.2,8.1,1.52,2.60,14.10,11.20,0.97,1.20,0.76
+decade,19999,2026-01-21,3,3,13.0,8.8,1.50,2.70,15.00,11.30,0.99,1.30,0.78

--- a/apps/iEasyHydroForecast/tests/fixtures/migration_csv/lr_forecast/decade_sample.csv.manifest
+++ b/apps/iEasyHydroForecast/tests/fixtures/migration_csv/lr_forecast/decade_sample.csv.manifest
@@ -1,0 +1,7 @@
+# Fixture manifest for lr_forecast (decade). Sentinel codes only.
+export_type=lr_forecast
+horizon=decade
+row_count=3
+station_count=1
+date_min=2026-01-01
+date_max=2026-01-21

--- a/apps/iEasyHydroForecast/tests/fixtures/migration_csv/lr_forecast/pentad_sample.csv
+++ b/apps/iEasyHydroForecast/tests/fixtures/migration_csv/lr_forecast/pentad_sample.csv
@@ -1,0 +1,4 @@
+horizon_type,code,date,pentad_in_month,pentad_in_year,discharge_avg,predictor,slope,intercept,forecasted_discharge,q_mean,q_std_sigma,delta,rsquared
+pentad,19999,2026-01-01,1,1,12.5,8.4,1.45,2.10,14.30,12.10,0.85,1.20,0.78
+pentad,19999,2026-01-06,2,2,13.2,9.1,1.42,2.20,15.10,12.20,0.87,1.30,0.80
+pentad,19999,2026-01-11,3,3,14.0,9.8,1.40,2.30,16.00,12.30,0.89,1.40,0.82

--- a/apps/iEasyHydroForecast/tests/fixtures/migration_csv/lr_forecast/pentad_sample.csv.manifest
+++ b/apps/iEasyHydroForecast/tests/fixtures/migration_csv/lr_forecast/pentad_sample.csv.manifest
@@ -1,0 +1,7 @@
+# Fixture manifest for lr_forecast (pentad). Sentinel codes only.
+export_type=lr_forecast
+horizon=pentad
+row_count=3
+station_count=1
+date_min=2026-01-01
+date_max=2026-01-11

--- a/apps/iEasyHydroForecast/tests/test_export_lr_forecast.py
+++ b/apps/iEasyHydroForecast/tests/test_export_lr_forecast.py
@@ -1,0 +1,435 @@
+"""Tests for the P4a LAPTOP-SIDE export wrapper
+
+``bin/export_lr_forecast_history.sh``.
+
+These tests exercise CLI surface, argument validation, location guard
+(Stage E #6), and fixture-manifest round trip. The wrapper's actual psql
+COPY path is integration-only and is NOT exercised here (architecture
+§Q7 — disposable integration is a separate sprint; the export script's
+real-DB code path is operator-tested via the runbook §6.3 canary).
+
+Sentinel codes (19999-class) only. No real station codes anywhere in this
+file.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Repo root: apps/iEasyHydroForecast/tests/test_*.py -> parents[3]
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT / "bin" / "utils"))
+
+from migration_py import _common  # noqa: E402
+
+_EXPORT_WRAPPER = _REPO_ROOT / "bin" / "export_lr_forecast_history.sh"
+_FIXTURE_DIR = (
+    _REPO_ROOT
+    / "apps"
+    / "iEasyHydroForecast"
+    / "tests"
+    / "fixtures"
+    / "migration_csv"
+    / "lr_forecast"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_wrapper(
+    args: list[str],
+    env: dict[str, str] | None = None,
+    *,
+    bypass_location_guard: bool = True,
+) -> subprocess.CompletedProcess:
+    """Invoke the export wrapper with the given args + env.
+
+    By default the location guard is bypassed (via the
+    ``_P4A_EXPORT_SKIP_LOCATION_GUARD=1`` testing-only env hook) so the
+    tests can exercise the wrapper's downstream validation paths even when
+    the developer laptop has the SAPPHIRE stack running locally. The
+    location guard itself is exercised in a dedicated positive test.
+    """
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    if bypass_location_guard:
+        full_env["_P4A_EXPORT_SKIP_LOCATION_GUARD"] = "1"
+    return subprocess.run(
+        ["bash", str(_EXPORT_WRAPPER), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=full_env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Wrapper exists + --help returns 0
+# ---------------------------------------------------------------------------
+
+
+def test_export_wrapper_exists_on_disk():
+    assert _EXPORT_WRAPPER.is_file(), f"export wrapper missing: {_EXPORT_WRAPPER}"
+
+
+def test_export_wrapper_help_returns_zero_and_prints_usage():
+    result = _run_wrapper(["--help"])
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}: {result.stderr}"
+    assert "Usage" in result.stdout
+    # All required + key optional flags are documented.
+    assert "--horizon" in result.stdout
+    assert "--output-dir" in result.stdout
+    assert "--station-list-file" in result.stdout
+
+
+def test_export_wrapper_short_help_works():
+    result = _run_wrapper(["-h"])
+    assert result.returncode == 0
+    assert "Usage" in result.stdout
+
+
+def test_export_wrapper_help_documents_station_filter_contract():
+    """The --station-list-file flag is the P0 binding contract (export-side
+    equivalent of --station-filter); the help text MUST tell the operator
+    what it does so they can wire it to their deployment's stations list."""
+    result = _run_wrapper(["--help"])
+    assert result.returncode == 0
+    # Collapse whitespace so "one\n   per line" matches "one per line"
+    # (the help block wraps long descriptions across multiple lines).
+    out_lower = " ".join(result.stdout.lower().split())
+    assert "--station-list-file" in result.stdout
+    # The contract: filter cross-org codes from the COPY, and describe
+    # the file format (one per line). Both expectations must be present.
+    assert "one per line" in out_lower or "one code per line" in out_lower
+    assert "cross-org" in out_lower or "filter" in out_lower or "interface" in out_lower
+
+
+# ---------------------------------------------------------------------------
+# 2. Argument validation
+# ---------------------------------------------------------------------------
+
+
+def test_export_wrapper_rejects_no_args():
+    """First arg must be the env_file_path (positional, required)."""
+    result = _run_wrapper([])
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "env_file_path" in combined or "required" in combined
+
+
+def test_export_wrapper_rejects_missing_env_file(tmp_path):
+    nonexistent = tmp_path / "no_such_env_file"
+    result = _run_wrapper(
+        [str(nonexistent), "--horizon", "pentad"],
+        env={
+            "PGHOST": "127.0.0.1",
+            "PGUSER": "postgres",
+            "PGDATABASE": "test",
+        },
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "env file" in combined or "not found" in combined
+
+
+def test_export_wrapper_rejects_missing_horizon(tmp_path):
+    env_file = tmp_path / "stub.env"
+    env_file.write_text("# stub\n", encoding="utf-8")
+    result = _run_wrapper([str(env_file)])
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "--horizon" in combined or "horizon" in combined
+
+
+def test_export_wrapper_rejects_invalid_horizon(tmp_path):
+    env_file = tmp_path / "stub.env"
+    env_file.write_text("# stub\n", encoding="utf-8")
+    result = _run_wrapper([str(env_file), "--horizon", "month"])  # not pentad/decade
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "horizon" in combined
+
+
+def test_export_wrapper_rejects_day_horizon(tmp_path):
+    """LR forecasts do not exist at DAY horizon — explicitly rejected."""
+    env_file = tmp_path / "stub.env"
+    env_file.write_text("# stub\n", encoding="utf-8")
+    result = _run_wrapper([str(env_file), "--horizon", "day"])
+    assert result.returncode != 0
+
+
+def test_export_wrapper_rejects_nonexistent_station_list_file(tmp_path):
+    env_file = tmp_path / "stub.env"
+    env_file.write_text("# stub\n", encoding="utf-8")
+    nonexistent = tmp_path / "no_such_stations.txt"
+    out_dir = tmp_path / "out"
+    result = _run_wrapper(
+        [
+            str(env_file),
+            "--horizon",
+            "pentad",
+            "--station-list-file",
+            str(nonexistent),
+            "--output-dir",
+            str(out_dir),
+        ],
+        env={
+            # Have to provide PG* env so we get past the env-var check.
+            "PGHOST": "127.0.0.1",
+            "PGUSER": "postgres",
+            "PGDATABASE": "test",
+        },
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "station" in combined or "not found" in combined
+
+
+def test_export_wrapper_rejects_missing_pg_env(tmp_path):
+    """When PGHOST/PGUSER/PGDATABASE are unset, refuse before doing anything."""
+    env_file = tmp_path / "stub.env"
+    env_file.write_text("# stub\n", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    # Explicitly UNSET PG vars. Use a minimal env. Bypass location guard
+    # so this developer-laptop test reaches the PG-env check.
+    result = subprocess.run(
+        [
+            "bash",
+            str(_EXPORT_WRAPPER),
+            str(env_file),
+            "--horizon",
+            "pentad",
+            "--output-dir",
+            str(out_dir),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": os.environ.get("HOME", ""),
+            "_P4A_EXPORT_SKIP_LOCATION_GUARD": "1",
+        },
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "pghost" in combined or "pguser" in combined or "pgdatabase" in combined
+
+
+def test_export_wrapper_rejects_apostrophe_in_station_list(tmp_path):
+    """SQL-injection guard: a station code containing an apostrophe is rejected."""
+    env_file = tmp_path / "stub.env"
+    env_file.write_text("# stub\n", encoding="utf-8")
+    stations = tmp_path / "stations.txt"
+    # Intentionally include an apostrophe; the wrapper should reject.
+    stations.write_text("19999\nbad'code\n", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    result = _run_wrapper(
+        [
+            str(env_file),
+            "--horizon",
+            "pentad",
+            "--station-list-file",
+            str(stations),
+            "--output-dir",
+            str(out_dir),
+        ],
+        env={
+            "PGHOST": "127.0.0.1",
+            "PGUSER": "postgres",
+            "PGDATABASE": "test",
+        },
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "apostrophe" in combined or "injection" in combined or "reject" in combined
+
+
+# ---------------------------------------------------------------------------
+# 3. Location guard (Stage E #6)
+# ---------------------------------------------------------------------------
+
+
+def test_export_wrapper_help_mentions_location_guard():
+    """Help text documents the location-guard behavior so operators understand."""
+    result = _run_wrapper(["--help"])
+    assert result.returncode == 0
+    low = result.stdout.lower()
+    # Must mention "deployment server" or "laptop" or "jump host" so the
+    # operator knows where to run this.
+    assert "laptop" in low or "deployment" in low or "jump" in low
+
+
+def _sapphire_containers_present() -> bool:
+    """Return True iff at least one sapphire-* deployment container is running.
+
+    Used to decide whether to exercise the location guard's positive path
+    (it can only fire if the docker probe actually sees a container).
+    """
+    try:
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "--filter",
+                "name=sapphire-postprocessing-db",
+                "--quiet",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return bool(result.stdout.strip())
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+@pytest.mark.skipif(
+    not _sapphire_containers_present(),
+    reason=(
+        "Location-guard positive test requires sapphire-* containers running "
+        "locally (developer laptop with the SAPPHIRE stack up). On CI / "
+        "clean machines this test is skipped because the guard physically "
+        "cannot fire without the trigger condition."
+    ),
+)
+def test_location_guard_fires_when_sapphire_containers_present(tmp_path):
+    """Positive path: with sapphire containers running AND the bypass NOT set,
+    the wrapper refuses with the documented deployment-server message.
+
+    This test depends on the developer machine state (the SAPPHIRE stack
+    must be up). It is automatically skipped where the guard cannot fire —
+    NOT a hidden-bug skip per the Zero Skips Policy; the skip predicate is
+    deterministic and the message is explicit.
+    """
+    env_file = tmp_path / "stub.env"
+    env_file.write_text("# stub\n", encoding="utf-8")
+    # Explicitly DO NOT pass the bypass env var.
+    result = _run_wrapper(
+        [
+            str(env_file),
+            "--horizon",
+            "pentad",
+        ],
+        env={
+            "PGHOST": "127.0.0.1",
+            "PGUSER": "postgres",
+            "PGDATABASE": "test",
+        },
+        bypass_location_guard=False,
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    # The documented error message includes "deployment-server containers".
+    assert "deployment-server containers" in combined or "deployment server" in combined
+
+
+# ---------------------------------------------------------------------------
+# 4. Fixture sanity (sentinel-only)
+# ---------------------------------------------------------------------------
+
+
+def test_pentad_sample_fixture_sentinel_only():
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    assert csv.is_file(), f"fixture missing: {csv}"
+    text = csv.read_text(encoding="utf-8")
+    five_digit = re.findall(r"\b\d{5}\b", text)
+    allowed = {"19999"} | {f"0000{i}" for i in range(10)}
+    for code in five_digit:
+        assert code in allowed, f"non-sentinel code {code!r} found in fixture"
+
+
+def test_decade_sample_fixture_sentinel_only():
+    csv = _FIXTURE_DIR / "decade_sample.csv"
+    assert csv.is_file(), f"fixture missing: {csv}"
+    text = csv.read_text(encoding="utf-8")
+    five_digit = re.findall(r"\b\d{5}\b", text)
+    allowed = {"19999"} | {f"0000{i}" for i in range(10)}
+    for code in five_digit:
+        assert code in allowed, f"non-sentinel code {code!r} found in fixture"
+
+
+def test_pentad_sample_manifest_validates():
+    """The fixture manifest passes P0 manifest validation."""
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    result = _common.validate_manifest(csv, "lr_forecast")
+    assert result["export_type"] == "lr_forecast"
+    assert result["row_count"] == "3"
+    assert result["station_count"] == "1"
+    assert result["date_min"] == "2026-01-01"
+    assert result["date_max"] == "2026-01-11"
+
+
+def test_decade_sample_manifest_validates():
+    csv = _FIXTURE_DIR / "decade_sample.csv"
+    result = _common.validate_manifest(csv, "lr_forecast")
+    assert result["export_type"] == "lr_forecast"
+    assert result["row_count"] == "3"
+    assert result["station_count"] == "1"
+    assert result["date_min"] == "2026-01-01"
+    assert result["date_max"] == "2026-01-21"
+
+
+def test_pentad_fixture_rejects_wrong_export_type():
+    """Manifest validation should fail if the wrapper asks for a different type."""
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    with pytest.raises(_common.ManifestExportTypeMismatchError):
+        _common.validate_manifest(csv, "hydrograph_period")
+
+
+# ---------------------------------------------------------------------------
+# 5. Defensive checks specific to LR
+# ---------------------------------------------------------------------------
+
+
+def test_pentad_fixture_csv_has_no_model_type_column():
+    """LR forecasts do not have a model_type column — defensive check."""
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    header = csv.read_text(encoding="utf-8").splitlines()[0]
+    cols = [c.strip() for c in header.split(",")]
+    assert "model_type" not in cols, (
+        "lr_forecasts has NO model_type column (unique key is "
+        "(horizon_type, code, date)); a model_type column in the fixture "
+        "would indicate cross-pollution from a forecasts/skill_metrics CSV."
+    )
+
+
+def test_decade_fixture_csv_has_no_model_type_column():
+    csv = _FIXTURE_DIR / "decade_sample.csv"
+    header = csv.read_text(encoding="utf-8").splitlines()[0]
+    cols = [c.strip() for c in header.split(",")]
+    assert "model_type" not in cols
+
+
+def test_pentad_fixture_uses_lowercase_horizon_type():
+    """Architecture §Q4 lock: lr_forecasts.horizon_type is the lowercase
+    'pentad' / 'decade' enum. Uppercase would be rejected at the Pydantic
+    boundary (HorizonType in postprocessing.app.models)."""
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    text = csv.read_text(encoding="utf-8")
+    # Data rows (skip header).
+    for line in text.splitlines()[1:]:
+        if not line.strip():
+            continue
+        ht_cell = line.split(",", 1)[0].strip()
+        assert ht_cell == "pentad", f"horizon_type cell {ht_cell!r} is not the lowercase 'pentad'"
+
+
+def test_decade_fixture_uses_lowercase_horizon_type():
+    csv = _FIXTURE_DIR / "decade_sample.csv"
+    text = csv.read_text(encoding="utf-8")
+    for line in text.splitlines()[1:]:
+        if not line.strip():
+            continue
+        ht_cell = line.split(",", 1)[0].strip()
+        assert ht_cell == "decade", f"horizon_type cell {ht_cell!r} is not the lowercase 'decade'"

--- a/apps/iEasyHydroForecast/tests/test_export_lr_forecast.py
+++ b/apps/iEasyHydroForecast/tests/test_export_lr_forecast.py
@@ -453,3 +453,68 @@ def test_export_rejects_zero_row_filter():
     pre_manifest, _, post_manifest = src.partition('cat > "${manifest_path}"')
     assert "no rows matched filter" in pre_manifest
     assert "no rows matched filter" not in post_manifest
+
+
+def test_export_rejects_zero_row_behaviorally(tmp_path):
+    """Round-2 review feedback: prior zero-row test was source-text only.
+    This stubs psql via PATH so the wrapper actually runs through its
+    post-COPY control flow with a header-only CSV, verifying:
+      (1) non-zero exit,
+      (2) the operator-facing "no rows matched filter" error fires,
+      (3) NO manifest sidecar is written.
+    """
+    import os
+    import stat
+    import subprocess
+
+    fake_bin = tmp_path / "fake_bin"
+    fake_bin.mkdir()
+    fake_psql = fake_bin / "psql"
+    fake_psql.write_text(
+        "#!/usr/bin/env bash\n"
+        # LR forecast COPY header.
+        'echo "horizon_type,code,date,pentad_in_month,pentad_in_year,discharge_avg,predictor,slope,intercept,forecasted_discharge,q_mean,q_std_sigma,delta,rsquared"\n'
+        "exit 0\n"
+    )
+    fake_psql.chmod(fake_psql.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    # Minimal env file so the wrapper's "env file exists" check passes.
+    env_file = tmp_path / ".env_test"
+    env_file.write_text("# empty test env\n")
+
+    out_dir = tmp_path / "out"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    env["PGHOST"] = "127.0.0.1"
+    env["PGUSER"] = "postgres"
+    env["PGDATABASE"] = "test"
+    env["_P4A_EXPORT_SKIP_LOCATION_GUARD"] = "1"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(_REPO_ROOT / "bin" / "export_lr_forecast_history.sh"),
+            str(env_file),
+            "--horizon",
+            "pentad",
+            "--output-dir",
+            str(out_dir),
+            "--i-am-on-laptop",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+    assert result.returncode != 0, (
+        f"expected non-zero exit on zero-row export, got {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    combined = (result.stdout + result.stderr).lower()
+    assert "no rows matched filter" in combined, (
+        f"expected zero-row error in output, got:\n{result.stdout}\n{result.stderr}"
+    )
+    manifests = list(out_dir.glob("*.manifest")) if out_dir.exists() else []
+    assert manifests == [], f"manifest should not exist after zero-row reject, got {manifests}"

--- a/apps/iEasyHydroForecast/tests/test_export_lr_forecast.py
+++ b/apps/iEasyHydroForecast/tests/test_export_lr_forecast.py
@@ -433,3 +433,23 @@ def test_decade_fixture_uses_lowercase_horizon_type():
             continue
         ht_cell = line.split(",", 1)[0].strip()
         assert ht_cell == "decade", f"horizon_type cell {ht_cell!r} is not the lowercase 'decade'"
+
+
+def test_export_rejects_zero_row_filter():
+    """Review feedback: zero-row exports must abort with a clear error and no
+    manifest written. String-level check on the script source confirms the
+    early-exit lives between row_count computation and manifest emission.
+
+    A live-DB test would require a running PostgreSQL with a known-empty
+    filter, which is out of scope per architecture §Q7."""
+    src = (_REPO_ROOT / "bin" / "export_lr_forecast_history.sh").read_text(encoding="utf-8")
+    # The guard checks row_count -eq 0 and exits.
+    assert 'row_count" -eq 0' in src or 'row_count" -eq "0"' in src or "row_count -eq 0" in src
+    # The operator-facing error message is specific.
+    assert "no rows matched filter" in src
+    # The early-exit lives BEFORE the manifest is written. Anchor on the
+    # heredoc that writes the manifest (the docstring above also mentions
+    # export_type=lr_forecast, so we need a more specific marker).
+    pre_manifest, _, post_manifest = src.partition('cat > "${manifest_path}"')
+    assert "no rows matched filter" in pre_manifest
+    assert "no rows matched filter" not in post_manifest

--- a/apps/iEasyHydroForecast/tests/test_initialize_lr_forecast.py
+++ b/apps/iEasyHydroForecast/tests/test_initialize_lr_forecast.py
@@ -1,0 +1,790 @@
+"""Tests for the P4a SERVER-SIDE import wrapper + ``migration_py.lr_forecast``.
+
+Covers:
+- Bash wrapper CLI surface (--help, missing env file rejection, --from-export
+  + --horizon required-flag enforcement, --station-filter contract).
+- ``_build_record`` payload shape per HORIZON: required fields, optional
+  model-stat fields (slope/intercept/q_mean/q_std_sigma/delta/rsquared, plus
+  discharge_avg/predictor/forecasted_discharge); NULL/empty handling; per-
+  horizon column mapping (pentad_in_month/year vs decad_in_month/year).
+- ``_read_filtered_records`` filters (cutoff, station_filter), required-
+  column validation.
+- ``main()`` dry-run output shape per the §4.4 inventory contract.
+- ``horizon_type`` enum mapping (architecture §Q4 lock: lowercase 'pentad'
+  / 'decade'); uppercase WOULD be rejected at the Pydantic boundary.
+- Cross-check: lr_forecasts has NO ``model_type`` column.
+- Stdlib-only import audit covers ``lr_forecast``.
+
+Integration against a live docker stack is out of scope per architecture
+§Q7 (disposable integration belongs to a separate sprint). The wrapper's
+docker-run path is exercised manually in the runbook §6.3 canary.
+
+Sentinel codes (19999-class) only.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Repo root: apps/iEasyHydroForecast/tests/test_*.py -> parents[3]
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT / "bin" / "utils"))
+
+from migration_py import lr_forecast  # noqa: E402
+
+_WRAPPER = _REPO_ROOT / "bin" / "initialize_lr_forecast_history.sh"
+_FIXTURE_DIR = (
+    _REPO_ROOT
+    / "apps"
+    / "iEasyHydroForecast"
+    / "tests"
+    / "fixtures"
+    / "migration_csv"
+    / "lr_forecast"
+)
+
+
+# ---------------------------------------------------------------------------
+# CSV helpers
+# ---------------------------------------------------------------------------
+
+
+_PENTAD_HEADER = [
+    "horizon_type",
+    "code",
+    "date",
+    "pentad_in_month",
+    "pentad_in_year",
+    "discharge_avg",
+    "predictor",
+    "slope",
+    "intercept",
+    "forecasted_discharge",
+    "q_mean",
+    "q_std_sigma",
+    "delta",
+    "rsquared",
+]
+
+_DECADE_HEADER = [
+    "horizon_type",
+    "code",
+    "date",
+    "decad_in_month",
+    "decad_in_year",
+    "discharge_avg",
+    "predictor",
+    "slope",
+    "intercept",
+    "forecasted_discharge",
+    "q_mean",
+    "q_std_sigma",
+    "delta",
+    "rsquared",
+]
+
+
+def _write_csv(
+    tmp_path: Path,
+    rows: list[dict[str, str]],
+    *,
+    horizon: str = "pentad",
+    csv_name: str = "fixture.csv",
+) -> Path:
+    """Write a CSV with the canonical header for the given horizon. Returns the path."""
+    header = list(_PENTAD_HEADER if horizon == "pentad" else _DECADE_HEADER)
+    csv_path = tmp_path / csv_name
+    lines = [",".join(header)]
+    for row in rows:
+        lines.append(",".join(row.get(col, "") for col in header))
+    csv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return csv_path
+
+
+# ===========================================================================
+# 1. Wrapper CLI surface
+# ===========================================================================
+
+
+def test_wrapper_exists_on_disk():
+    assert _WRAPPER.is_file(), f"wrapper missing: {_WRAPPER}"
+
+
+def test_wrapper_help_returns_zero_and_prints_usage():
+    result = subprocess.run(
+        ["bash", str(_WRAPPER), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}: {result.stderr}"
+    assert "Usage" in result.stdout
+    # All P4a-specific flags are documented.
+    assert "--from-export" in result.stdout
+    assert "--horizon" in result.stdout
+    assert "--station-filter" in result.stdout
+
+
+def test_wrapper_help_documents_station_filter_contract():
+    """The --station-filter flag is the P0 binding contract; must be documented."""
+    result = subprocess.run(
+        ["bash", str(_WRAPPER), "-h"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert "--station-filter" in result.stdout
+    low = result.stdout.lower()
+    assert "contract" in low or "interface" in low or "binding" in low
+
+
+def test_wrapper_rejects_missing_env_file(tmp_path):
+    nonexistent = tmp_path / "no_such_env_file"
+    csv = tmp_path / "x.csv"
+    csv.write_text(",".join(_PENTAD_HEADER) + "\n", encoding="utf-8")
+    result = subprocess.run(
+        [
+            "bash",
+            str(_WRAPPER),
+            str(nonexistent),
+            "--from-export",
+            str(csv),
+            "--horizon",
+            "pentad",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "env file" in combined or "not found" in combined
+
+
+def test_wrapper_rejects_missing_from_export(tmp_path):
+    env = tmp_path / "fake.env"
+    env.write_text("# stub\n", encoding="utf-8")
+    result = subprocess.run(
+        ["bash", str(_WRAPPER), str(env), "--horizon", "pentad"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "from-export" in combined or "required" in combined
+
+
+def test_wrapper_rejects_missing_horizon(tmp_path):
+    env = tmp_path / "fake.env"
+    env.write_text("# stub\n", encoding="utf-8")
+    csv = tmp_path / "x.csv"
+    csv.write_text("\n", encoding="utf-8")
+    result = subprocess.run(
+        ["bash", str(_WRAPPER), str(env), "--from-export", str(csv)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "horizon" in combined
+
+
+def test_wrapper_rejects_invalid_horizon(tmp_path):
+    env = tmp_path / "fake.env"
+    env.write_text("# stub\n", encoding="utf-8")
+    csv = tmp_path / "x.csv"
+    csv.write_text("\n", encoding="utf-8")
+    result = subprocess.run(
+        [
+            "bash",
+            str(_WRAPPER),
+            str(env),
+            "--from-export",
+            str(csv),
+            "--horizon",
+            "day",  # not pentad/decade — LR doesn't exist at DAY
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+
+
+# ===========================================================================
+# 2. Fixture sanity
+# ===========================================================================
+
+
+def test_pentad_sample_fixture_only_sentinel_codes():
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    assert csv.is_file()
+    text = csv.read_text(encoding="utf-8")
+    five_digit = re.findall(r"\b\d{5}\b", text)
+    allowed = {"19999"} | {f"0000{i}" for i in range(10)}
+    for code in five_digit:
+        assert code in allowed, f"non-sentinel code {code!r} found in fixture"
+
+
+def test_decade_sample_fixture_only_sentinel_codes():
+    csv = _FIXTURE_DIR / "decade_sample.csv"
+    assert csv.is_file()
+    text = csv.read_text(encoding="utf-8")
+    five_digit = re.findall(r"\b\d{5}\b", text)
+    allowed = {"19999"} | {f"0000{i}" for i in range(10)}
+    for code in five_digit:
+        assert code in allowed, f"non-sentinel code {code!r} found in fixture"
+
+
+# ===========================================================================
+# 3. _build_record — payload shape
+# ===========================================================================
+
+
+def test_build_record_pentad_includes_required_fields():
+    """All LRForecastBase required fields are emitted for a PENTAD record."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "pentad_in_month": "1",
+        "pentad_in_year": "1",
+        "forecasted_discharge": "14.30",
+    }
+    rec = lr_forecast._build_record(row, "pentad")
+    assert rec is not None
+    assert rec["horizon_type"] == "pentad"
+    assert rec["code"] == "19999"
+    assert rec["date"] == "2026-01-01"
+    assert rec["horizon_value"] == 1
+    assert rec["horizon_in_year"] == 1
+    assert rec["forecasted_discharge"] == 14.30
+
+
+def test_build_record_decade_uses_decad_columns():
+    """DECADE input maps decad_in_month / decad_in_year to horizon_value /
+    horizon_in_year (per LRForecastDataMigrator.prepare_decade_data)."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "decad_in_month": "2",
+        "decad_in_year": "5",
+    }
+    rec = lr_forecast._build_record(row, "decade")
+    assert rec is not None
+    assert rec["horizon_type"] == "decade"
+    assert rec["horizon_value"] == 2
+    assert rec["horizon_in_year"] == 5
+
+
+def test_build_record_horizon_type_value_is_lowercase():
+    """Architecture §Q4 lock: API enum is lowercase 'pentad' / 'decade'.
+
+    Uppercase 'PENTAD' / 'DECADE' WOULD be rejected at the Pydantic
+    boundary (postprocessing.app.models.HorizonType uses lowercase
+    values). This test pins the payload contract.
+    """
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "pentad_in_month": "1",
+        "pentad_in_year": "1",
+    }
+    rec = lr_forecast._build_record(row, "pentad")
+    assert rec is not None
+    assert rec["horizon_type"] == "pentad"  # NOT "PENTAD"
+    # And the contrary case for decade.
+    row_d = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "decad_in_month": "1",
+        "decad_in_year": "1",
+    }
+    rec_d = lr_forecast._build_record(row_d, "decade")
+    assert rec_d is not None
+    assert rec_d["horizon_type"] == "decade"  # NOT "DECADE"
+
+
+def test_build_record_rejects_unknown_horizon():
+    """Anything other than 'pentad'/'decade' raises ValueError.
+
+    LR does not exist at DAY/MONTH; the helper must refuse rather than
+    silently swallowing the row.
+    """
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "pentad_in_month": "1",
+        "pentad_in_year": "1",
+    }
+    with pytest.raises(ValueError, match="horizon must be one of"):
+        lr_forecast._build_record(row, "day")
+    with pytest.raises(ValueError, match="horizon must be one of"):
+        lr_forecast._build_record(row, "month")
+
+
+def test_build_record_returns_none_for_missing_required():
+    """Row missing code / date / one of the horizon-required ints -> None."""
+    base = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "pentad_in_month": "1",
+        "pentad_in_year": "1",
+    }
+    # Missing code.
+    bad = dict(base)
+    bad["code"] = ""
+    assert lr_forecast._build_record(bad, "pentad") is None
+    # Missing date.
+    bad = dict(base)
+    bad["date"] = ""
+    assert lr_forecast._build_record(bad, "pentad") is None
+    # Unparseable date.
+    bad = dict(base)
+    bad["date"] = "not-a-date"
+    assert lr_forecast._build_record(bad, "pentad") is None
+    # Missing horizon_value (int).
+    bad = dict(base)
+    bad["pentad_in_month"] = ""
+    assert lr_forecast._build_record(bad, "pentad") is None
+    # Missing horizon_in_year (int).
+    bad = dict(base)
+    bad["pentad_in_year"] = ""
+    assert lr_forecast._build_record(bad, "pentad") is None
+
+
+def test_build_record_excludes_null_model_stat_fields():
+    """Nullable fields (slope/intercept/q_mean/q_std_sigma/delta/rsquared) with
+    NULL/empty/NaN source values are OMITTED from the payload, never
+    sent as ``null``. This is the universal safe-write rule (architecture
+    §Q2 layer 2).
+    """
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "pentad_in_month": "1",
+        "pentad_in_year": "1",
+        "discharge_avg": "10.5",
+        "predictor": "",  # NULL
+        "slope": "nan",  # null-like
+        "intercept": "1.5",
+        "forecasted_discharge": "",  # NULL
+        "q_mean": "garbage",  # parse failure
+        "q_std_sigma": "0.85",
+        "delta": "NULL",  # explicit null literal
+        "rsquared": "0.78",
+    }
+    rec = lr_forecast._build_record(row, "pentad")
+    assert rec is not None
+    # Present fields.
+    assert rec["discharge_avg"] == 10.5
+    assert rec["intercept"] == 1.5
+    assert rec["q_std_sigma"] == 0.85
+    assert rec["rsquared"] == 0.78
+    # NULL/empty/NaN/parse-fail fields must be ABSENT from the payload.
+    for absent in ("predictor", "slope", "forecasted_discharge", "q_mean", "delta"):
+        assert absent not in rec, f"{absent} should be omitted (was {rec.get(absent)!r})"
+
+
+def test_build_record_omits_non_finite_floats():
+    """Non-finite floats (+/-inf) are rejected to prevent invalid JSON.
+
+    The Pydantic boundary rejects ``Infinity`` / ``NaN`` literals (RFC 7159).
+    The helper's _parse_float guards by checking float != float (NaN trick)
+    and equality with +/-inf.
+    """
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "pentad_in_month": "1",
+        "pentad_in_year": "1",
+        "slope": "inf",
+        "intercept": "-inf",
+    }
+    rec = lr_forecast._build_record(row, "pentad")
+    assert rec is not None
+    assert "slope" not in rec
+    assert "intercept" not in rec
+
+
+def test_build_record_omits_pentad_in_year_when_unparseable():
+    """If pentad_in_year is unparseable, the whole record is None
+    (required field)."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "pentad_in_month": "1",
+        "pentad_in_year": "garbage",
+    }
+    assert lr_forecast._build_record(row, "pentad") is None
+
+
+# ===========================================================================
+# 4. _read_filtered_records — filtering
+# ===========================================================================
+
+
+def test_read_filtered_records_happy_path_pentad(tmp_path):
+    csv = _write_csv(
+        tmp_path,
+        [
+            {
+                "horizon_type": "pentad",
+                "code": "19999",
+                "date": "2026-01-01",
+                "pentad_in_month": "1",
+                "pentad_in_year": "1",
+                "forecasted_discharge": "14.3",
+            },
+            {
+                "horizon_type": "pentad",
+                "code": "19999",
+                "date": "2026-01-06",
+                "pentad_in_month": "2",
+                "pentad_in_year": "2",
+                "forecasted_discharge": "15.1",
+            },
+        ],
+        horizon="pentad",
+    )
+    records, counters, codes, dmin, dmax = lr_forecast._read_filtered_records(
+        csv, horizon="pentad", cutoff=None, station_filter=None
+    )
+    assert counters["source_row_count"] == 2
+    assert counters["filtered_row_count"] == 2
+    assert codes == {"19999"}
+    assert dmin == "2026-01-01"
+    assert dmax == "2026-01-06"
+    assert all(r["horizon_type"] == "pentad" for r in records)
+
+
+def test_read_filtered_records_station_filter(tmp_path):
+    csv = _write_csv(
+        tmp_path,
+        [
+            {
+                "horizon_type": "pentad",
+                "code": "19999",
+                "date": "2026-01-01",
+                "pentad_in_month": "1",
+                "pentad_in_year": "1",
+            },
+            {
+                "horizon_type": "pentad",
+                "code": "00000",
+                "date": "2026-01-06",
+                "pentad_in_month": "2",
+                "pentad_in_year": "2",
+            },
+        ],
+        horizon="pentad",
+    )
+    records, counters, codes, _, _ = lr_forecast._read_filtered_records(
+        csv, horizon="pentad", cutoff=None, station_filter="19999"
+    )
+    assert counters["source_row_count"] == 2
+    assert counters["filtered_row_count"] == 1
+    assert counters["skipped_station"] == 1
+    assert codes == {"19999"}
+    assert records[0]["code"] == "19999"
+
+
+def test_read_filtered_records_cutoff_drops_on_or_after(tmp_path):
+    csv = _write_csv(
+        tmp_path,
+        [
+            {
+                "horizon_type": "pentad",
+                "code": "19999",
+                "date": "2026-01-01",
+                "pentad_in_month": "1",
+                "pentad_in_year": "1",
+            },
+            {
+                "horizon_type": "pentad",
+                "code": "19999",
+                "date": "2026-01-06",
+                "pentad_in_month": "2",
+                "pentad_in_year": "2",
+            },
+            {
+                "horizon_type": "pentad",
+                "code": "19999",
+                "date": "2026-01-11",
+                "pentad_in_month": "3",
+                "pentad_in_year": "3",
+            },
+        ],
+        horizon="pentad",
+    )
+    records, counters, _, _, _ = lr_forecast._read_filtered_records(
+        csv, horizon="pentad", cutoff="2026-01-06", station_filter=None
+    )
+    # Only rows STRICTLY less than cutoff survive.
+    assert counters["filtered_row_count"] == 1
+    assert counters["skipped_cutoff"] == 2
+    assert records[0]["date"] == "2026-01-01"
+
+
+def test_read_filtered_records_rejects_csv_missing_required_columns(tmp_path):
+    """If the CSV is missing horizon-required columns (e.g. pentad_in_month),
+    _read_filtered_records raises ValueError before any iteration."""
+    bad = tmp_path / "bad.csv"
+    # Has horizon_type/code/date but missing pentad_in_month / pentad_in_year.
+    bad.write_text("horizon_type,code,date\npentad,19999,2026-01-01\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="missing required column"):
+        lr_forecast._read_filtered_records(bad, horizon="pentad", cutoff=None, station_filter=None)
+
+
+def test_read_filtered_records_rejects_unknown_horizon(tmp_path):
+    csv = _write_csv(
+        tmp_path,
+        [{"code": "19999", "date": "2026-01-01"}],
+        horizon="pentad",
+    )
+    with pytest.raises(ValueError, match="horizon must be one of"):
+        lr_forecast._read_filtered_records(csv, horizon="day", cutoff=None, station_filter=None)
+
+
+# ===========================================================================
+# 5. main() dry-run output shape
+# ===========================================================================
+
+
+def test_main_dry_run_pentad_emits_inventory(tmp_path, capsys):
+    csv = _write_csv(
+        tmp_path,
+        [
+            {
+                "horizon_type": "pentad",
+                "code": "19999",
+                "date": "2026-01-01",
+                "pentad_in_month": "1",
+                "pentad_in_year": "1",
+                "forecasted_discharge": "14.3",
+            },
+            {
+                "horizon_type": "pentad",
+                "code": "19999",
+                "date": "2026-01-06",
+                "pentad_in_month": "2",
+                "pentad_in_year": "2",
+            },
+        ],
+        horizon="pentad",
+    )
+    exit_code = lr_forecast.main(
+        [
+            "--csv-path",
+            str(csv),
+            "--api-url",
+            "http://localhost:8003/lr-forecast/",
+            "--horizon",
+            "pentad",
+            "--dry-run",
+        ]
+    )
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "SOURCE_ROW_COUNT=2" in out
+    assert "FILTERED_ROW_COUNT=2" in out
+    assert "MODE=full-import" in out
+    assert "TARGET_TABLE=lr_forecasts" in out
+    assert "HORIZON=pentad" in out
+    assert "DISTINCT_STATION_COUNT_REDACTED=1" in out
+
+
+def test_main_dry_run_with_station_filter_reduces_filtered_count(tmp_path, capsys):
+    csv = _write_csv(
+        tmp_path,
+        [
+            {
+                "horizon_type": "pentad",
+                "code": "19999",
+                "date": "2026-01-01",
+                "pentad_in_month": "1",
+                "pentad_in_year": "1",
+            },
+            {
+                "horizon_type": "pentad",
+                "code": "19999",
+                "date": "2026-01-06",
+                "pentad_in_month": "2",
+                "pentad_in_year": "2",
+            },
+            {
+                "horizon_type": "pentad",
+                "code": "00000",
+                "date": "2026-01-11",
+                "pentad_in_month": "3",
+                "pentad_in_year": "3",
+            },
+        ],
+        horizon="pentad",
+    )
+    exit_code = lr_forecast.main(
+        [
+            "--csv-path",
+            str(csv),
+            "--api-url",
+            "http://localhost:8003/lr-forecast/",
+            "--horizon",
+            "pentad",
+            "--station-filter",
+            "19999",
+            "--dry-run",
+        ]
+    )
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "SOURCE_ROW_COUNT=3" in out
+    assert "FILTERED_ROW_COUNT=2" in out
+    assert "DISTINCT_STATION_COUNT_REDACTED=1" in out
+
+
+def test_main_dry_run_with_cutoff_emits_pre_cutoff(tmp_path, capsys):
+    csv = _write_csv(
+        tmp_path,
+        [
+            {
+                "horizon_type": "decade",
+                "code": "19999",
+                "date": "2026-01-01",
+                "decad_in_month": "1",
+                "decad_in_year": "1",
+            },
+            {
+                "horizon_type": "decade",
+                "code": "19999",
+                "date": "2026-01-11",
+                "decad_in_month": "2",
+                "decad_in_year": "2",
+            },
+        ],
+        horizon="decade",
+    )
+    exit_code = lr_forecast.main(
+        [
+            "--csv-path",
+            str(csv),
+            "--api-url",
+            "http://localhost:8003/lr-forecast/",
+            "--horizon",
+            "decade",
+            "--cutoff",
+            "2026-01-11",
+            "--dry-run",
+        ]
+    )
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "MODE=pre-cutoff (cutoff=2026-01-11)" in out
+    assert "FILTERED_ROW_COUNT=1" in out
+    assert "HORIZON=decade" in out
+
+
+def test_main_missing_csv_returns_nonzero(tmp_path, capsys):
+    exit_code = lr_forecast.main(
+        [
+            "--csv-path",
+            str(tmp_path / "does_not_exist.csv"),
+            "--api-url",
+            "http://localhost:8003/lr-forecast/",
+            "--horizon",
+            "pentad",
+            "--dry-run",
+        ]
+    )
+    assert exit_code != 0
+
+
+# ===========================================================================
+# 6. Stdlib-only audit covers lr_forecast
+# ===========================================================================
+
+
+def test_lr_forecast_module_imports_only_stdlib_and_intra_package():
+    """The lr_forecast module passes the P0 stdlib-only audit alongside _common."""
+    from migration_py import _audit
+
+    violations = _audit.audit_stdlib_only(_REPO_ROOT / "bin" / "utils" / "migration_py")
+    assert violations == [], (
+        f"stdlib-only audit reported violations under migration_py/: {violations}"
+    )
+
+
+# ===========================================================================
+# 7. Shipped fixtures round-trip through the parser
+# ===========================================================================
+
+
+def test_shipped_pentad_fixture_round_trips(tmp_path):
+    """The shipped ``pentad_sample.csv`` parses through the helper."""
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    records, counters, codes, dmin, dmax = lr_forecast._read_filtered_records(
+        csv, horizon="pentad", cutoff=None, station_filter=None
+    )
+    assert counters["filtered_row_count"] == 3
+    assert codes == {"19999"}
+    assert dmin == "2026-01-01"
+    assert dmax == "2026-01-11"
+    for r in records:
+        assert r["horizon_type"] == "pentad"
+        # Per the fixture, all the optional model-stat fields ARE populated.
+        for field in (
+            "discharge_avg",
+            "predictor",
+            "slope",
+            "intercept",
+            "forecasted_discharge",
+            "q_mean",
+            "q_std_sigma",
+            "delta",
+            "rsquared",
+        ):
+            assert field in r, f"{field} should be present in fully-populated fixture row"
+
+
+def test_shipped_decade_fixture_round_trips(tmp_path):
+    csv = _FIXTURE_DIR / "decade_sample.csv"
+    records, counters, codes, dmin, dmax = lr_forecast._read_filtered_records(
+        csv, horizon="decade", cutoff=None, station_filter=None
+    )
+    assert counters["filtered_row_count"] == 3
+    assert codes == {"19999"}
+    assert dmin == "2026-01-01"
+    assert dmax == "2026-01-21"
+    for r in records:
+        assert r["horizon_type"] == "decade"
+
+
+# ===========================================================================
+# 8. Cross-check: lr_forecasts has NO model_type column
+# ===========================================================================
+
+
+def test_build_record_does_not_emit_model_type():
+    """LR forecasts have NO ``model_type`` column in the DB; the unique key
+    is (horizon_type, code, date). Even if a stray ``model_type`` cell
+    appears in the CSV, _build_record must NOT include it in the payload —
+    Pydantic boundary would silently drop it but defensive purity matters
+    here because the same column name is meaningful in the sibling
+    ``forecasts`` and ``skill_metrics`` tables.
+    """
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "pentad_in_month": "1",
+        "pentad_in_year": "1",
+        "model_type": "LR",  # noise that must not leak into payload
+    }
+    rec = lr_forecast._build_record(row, "pentad")
+    assert rec is not None
+    assert "model_type" not in rec

--- a/apps/iEasyHydroForecast/tests/test_initialize_lr_forecast.py
+++ b/apps/iEasyHydroForecast/tests/test_initialize_lr_forecast.py
@@ -788,3 +788,88 @@ def test_build_record_does_not_emit_model_type():
     rec = lr_forecast._build_record(row, "pentad")
     assert rec is not None
     assert "model_type" not in rec
+
+
+def test_build_record_rejects_row_with_mismatched_horizon_type():
+    """Review feedback: when the CSV row carries its own ``horizon_type`` column
+    and it disagrees with the CLI flag, drop the row (return None) instead of
+    silently relabeling the payload to the CLI value. Defends against mixed
+    or tampered exports re-keying unrelated target rows."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "pentad_in_month": "1",
+        "pentad_in_year": "1",
+        "horizon_type": "decade",  # disagrees with the CLI value below
+    }
+    assert lr_forecast._build_record(row, "pentad") is None
+
+
+def test_build_record_accepts_row_with_matching_horizon_type():
+    """When the CSV row's ``horizon_type`` agrees with the CLI flag, the
+    record is built normally."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "pentad_in_month": "1",
+        "pentad_in_year": "1",
+        "horizon_type": "pentad",
+    }
+    rec = lr_forecast._build_record(row, "pentad")
+    assert rec is not None
+    assert rec["horizon_type"] == "pentad"
+
+
+def test_build_record_normalizes_case_in_row_horizon_type():
+    """The row's ``horizon_type`` is case-normalized before comparison so
+    operator-side hand-edits with uppercase still match."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "pentad_in_month": "1",
+        "pentad_in_year": "1",
+        "horizon_type": "PENTAD",  # uppercase
+    }
+    rec = lr_forecast._build_record(row, "pentad")
+    assert rec is not None
+    assert rec["horizon_type"] == "pentad"
+
+
+def test_build_record_trusts_cli_when_row_lacks_horizon_type_column():
+    """If the source CSV omits the ``horizon_type`` column altogether (the
+    legacy case), fall through to trusting the CLI horizon — preserves
+    backwards compatibility with single-horizon export fixtures."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "pentad_in_month": "1",
+        "pentad_in_year": "1",
+        # no horizon_type column at all
+    }
+    rec = lr_forecast._build_record(row, "pentad")
+    assert rec is not None
+    assert rec["horizon_type"] == "pentad"
+
+
+def test_read_filtered_records_counts_horizon_mismatch_separately(tmp_path):
+    """Mixed-export CSV with one pentad row + one decade row read with --horizon
+    pentad: the decade row goes to skipped_horizon_mismatch (NOT
+    skipped_parse), and the pentad row makes it into the records."""
+    csv_path = tmp_path / "mixed.csv"
+    csv_path.write_text(
+        "horizon_type,code,date,pentad_in_month,pentad_in_year\n"
+        "pentad,19999,2026-01-01,1,1\n"
+        "decade,19999,2026-01-02,1,1\n"
+    )
+    records, counters, codes, dmin, dmax = lr_forecast._read_filtered_records(
+        csv_path,
+        horizon="pentad",
+        cutoff=None,
+        station_filter=None,
+    )
+    assert counters["source_row_count"] == 2
+    assert counters["filtered_row_count"] == 1
+    assert counters["skipped_horizon_mismatch"] == 1
+    assert counters["skipped_parse"] == 0
+    assert len(records) == 1
+    assert records[0]["horizon_type"] == "pentad"

--- a/bin/export_lr_forecast_history.sh
+++ b/bin/export_lr_forecast_history.sh
@@ -1,0 +1,582 @@
+#!/usr/bin/env bash
+# ============================================================================
+# export_lr_forecast_history.sh
+#
+# LAPTOP-SIDE export wrapper for P4a (LR linear-regression forecast history).
+#
+# Connects to the laptop's local ``sapphire-postprocessing-db`` (NOT
+# preprocessing-db — the ``lr_forecasts`` table lives in the postprocessing
+# service) or any source DB reachable via the standard PG* environment
+# variables, and dumps rows from the ``lr_forecasts`` table filtered on:
+#   1. ``horizon_type``: 'pentad' or 'decade' (the --horizon flag,
+#      lowercase — architecture §Q4 enum lock; the Pydantic boundary
+#      rejects uppercase),
+#   2. ``code`` IN (deployment's station list) — read line-by-line from the
+#      ``--station-list-file`` argument (one code per line) when supplied.
+#      Without a station list, no station filter is applied. The manifest
+#      always records the realized distinct-station count from the CSV.
+#
+# Emits TWO files in the operator-chosen ``--output-dir``:
+#   - ``lr_forecast_<horizon>_<UTC_timestamp>.csv``
+#   - ``lr_forecast_<horizon>_<UTC_timestamp>.csv.manifest``
+#
+# Manifest sidecar follows the P0 contract (per
+# ``migration_py._common.validate_manifest``); 5 required keys:
+#   export_type=lr_forecast
+#   row_count=<n>          # excluding header
+#   station_count=<n>      # distinct ``code`` in CSV
+#   date_min=<YYYY-MM-DD>
+#   date_max=<YYYY-MM-DD>
+#
+# Source DB note (POSTPROCESSING, not preprocessing):
+#   The ``lr_forecasts`` table is owned by the postprocessing service. On a
+#   laptop with the full SAPPHIRE stack running, the matching local DB is
+#   ``sapphire-postprocessing-db`` (typically port 5433 in the dev compose).
+#   The export uses standard libpq PG* env vars so any reachable source DB
+#   works. The location guard below treats either
+#   ``sapphire-preprocessing-db`` or ``sapphire-postprocessing-db`` as a
+#   "deployment host" trigger.
+#
+# Location guard (Stage E #6):
+#   This script REFUSES to run on a host where any
+#   ``sapphire-{preprocessing,postprocessing,api-gateway}-...`` container is
+#   detected. It is meant to run on the OPERATOR LAPTOP / a jump host, NOT
+#   on the deployment server (which has its own postprocessing-db and would
+#   produce a confusing self-export). Bypass for the developer-laptop
+#   test suite ONLY: ``_P4A_EXPORT_SKIP_LOCATION_GUARD=1`` — underscore
+#   prefix, documented internal use only, never set in real workflows.
+#
+# Credentials and secret hygiene (per runbook §3):
+#   - Uses PG* env vars + ``~/.pgpass`` (mode 0o600). No password in CLI.
+#   - Invokes psql with ``-X`` (skip .psqlrc) and ``-v ON_ERROR_STOP=1``.
+#   - Sets HISTFILE / PSQL_HISTORY to /dev/null.
+#   - umask 077 for all writes.
+#   - Never tees secrets into logs.
+#
+# Schema note (no model_type column):
+#   ``lr_forecasts`` has the DB unique key (horizon_type, code, date).
+#   LR is implicit in this table — there is NO ``model_type`` column.
+#   (This is why LR rows are filtered OUT of ``combined_forecasts`` by
+#   the postprocessing combined_forecasts migrator.) The export's
+#   ``COPY (SELECT ...)`` does NOT include ``model_type``.
+#
+# Universal safe-write rule alignment (architecture §Q2 layer 2):
+#   Nullable model-stat fields (``discharge_avg``, ``predictor``, ``slope``,
+#   ``intercept``, ``forecasted_discharge``, ``q_mean``, ``q_std_sigma``,
+#   ``delta``, ``rsquared``) are exported as their literal DB values; psql
+#   COPY emits empty strings for NULL. The server-side Python helper
+#   (`migration_py.lr_forecast`) OMITS empty / null-like fields from the
+#   API payload, so the wrapper never injects ``null`` into the upsert
+#   path (which would otherwise overwrite existing non-NULL targets via
+#   the service-side ``_has_changes + setattr`` overwrite bug).
+#
+# Usage:
+#   bash bin/export_lr_forecast_history.sh <env_file_path> \
+#       --horizon pentad|decade \
+#       [--output-dir <path>] \
+#       [--station-list-file <path>] \
+#       [--dry-run]
+#
+# Arguments:
+#   env_file_path        Path to the operator's .env_<org> file. Used only
+#                        to derive default --output-dir; PG credentials are
+#                        sourced from the operator's shell environment +
+#                        ~/.pgpass (NOT from the env file).
+#
+# Options:
+#   --horizon <H>        REQUIRED. 'pentad' or 'decade' — the horizon_type
+#                        enum (lowercase per architecture §Q4 lock).
+#   --output-dir <PATH>  Destination dir for the CSV + manifest pair. Default:
+#                        ``./lr_forecast_export_<UTC_timestamp>`` under the
+#                        operator's CWD. Created with mode 0o700 if missing.
+#   --station-list-file <PATH>
+#                        File listing deployment station codes, one per line.
+#                        When supplied, the COPY query filters
+#                        ``code IN (<list>)`` so cross-org codes never leak.
+#                        Lines containing an apostrophe are rejected outright
+#                        (SQL-injection guard).
+#   --dry-run            Run COUNT(*) only; do NOT write CSV or manifest.
+#   --i-am-on-laptop     Acknowledge the location guard bypass (used only
+#                        by the test suite via the env-var hook above).
+#                        Operators do NOT set this.
+#   -h, --help           Print this message and exit 0.
+#
+# Environment:
+#   PGHOST / PGPORT / PGUSER / PGDATABASE
+#       Standard libpq vars. No password in CLI; use ~/.pgpass (mode 0600).
+#       For the canonical laptop SAPPHIRE stack the postprocessing-db typically
+#       listens on PGPORT=5433.
+#
+# Examples:
+#   # Pentad export, no station filter (use ONLY for trusted single-org laptops).
+#   bash bin/export_lr_forecast_history.sh ~/.env_tjhm --horizon pentad
+#
+#   # Decade export with station list and a custom output dir.
+#   bash bin/export_lr_forecast_history.sh ~/.env_tjhm \
+#       --horizon decade \
+#       --station-list-file ~/taj_stations.txt \
+#       --output-dir /tmp/lr_export
+#
+# Server side (after scp of both files):
+#   bash bin/initialize_lr_forecast_history.sh <env_file> \
+#       --from-export <csv_path> --horizon pentad|decade
+#
+# ============================================================================
+
+set -eo pipefail
+# NOTE: set -u is intentionally omitted; we guard each variable with ${name:-}.
+
+# ---------------------------------------------------------------------------
+# Source shared helpers (P0 foundation) — for umh_log_redacted only. The
+# laptop side does NOT call read_configuration (no Docker, no deployment
+# env vars needed); PG credentials come from the operator's shell.
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC1091  # path computed at runtime; can't be statically resolved
+source "$(dirname "$0")/utils/update_migration_helpers.sh"
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Defaults / flag variables
+# ---------------------------------------------------------------------------
+ENV_FILE=""
+HORIZON=""
+OUTPUT_DIR=""
+STATION_LIST_FILE=""
+DRY_RUN=false
+LOCATION_GUARD_BYPASS=false
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+print_usage() {
+    cat <<'USAGE'
+Usage: bash bin/export_lr_forecast_history.sh <env_file_path> \
+           --horizon pentad|decade [OPTIONS]
+
+LAPTOP-SIDE export of LR (linear regression) forecast history rows from
+the operator's local sapphire-postprocessing-db.lr_forecasts table into a
+CSV + manifest pair, for transfer to a deployment server via scp. Pair with
+`bin/initialize_lr_forecast_history.sh` on the receiving side.
+
+Arguments:
+  env_file_path        Path to the operator's .env_<org> file. Only used to
+                       derive default --output-dir; PG credentials come
+                       from the shell environment + ~/.pgpass.
+
+Options:
+  --horizon pentad|decade
+                       REQUIRED. Selects the lowercase horizon_type enum
+                       (architecture §Q4 lock; Pydantic boundary rejects
+                       uppercase).
+  --output-dir PATH    Destination directory for the CSV + manifest pair.
+                       Default: ./lr_forecast_export_<UTC_timestamp>.
+                       Created with mode 0o700 if missing.
+  --station-list-file PATH
+                       Optional file listing deployment station codes, one
+                       per line. When supplied, the COPY query filters
+                       code IN (<list>) so cross-org codes never leak.
+                       This is the binding interface contract from P0:
+                       the --station-filter flag on the server-side
+                       wrapper accepts a single code; --station-list-file
+                       is the export-side equivalent for the whole list.
+  --dry-run            Run COUNT(*) query only; do NOT write CSV / manifest.
+  --i-am-on-laptop     Acknowledge the location guard bypass (testing-only;
+                       not used by operators in real workflows).
+  -h, --help           Print this message and exit 0.
+
+Environment:
+  PGHOST / PGPORT / PGUSER / PGDATABASE   Standard libpq vars. No password
+                                          in CLI; use ~/.pgpass (mode 0600).
+
+Refuses to run if any sapphire-{preprocessing,postprocessing,api-gateway}
+container is detected locally (this script is for laptops / jump hosts,
+NOT deployment servers — Stage E #6).
+USAGE
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+parse_args() {
+    # Handle --help / -h before requiring the positional arg.
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help) print_usage; exit 0 ;;
+        esac
+    done
+
+    if [[ $# -eq 0 ]]; then
+        echo -e "${RED}Error: env_file_path is required.${NC}" >&2
+        echo "" >&2
+        print_usage >&2
+        exit 1
+    fi
+
+    # First positional arg is the env file path.
+    if [[ "$1" != -* ]]; then
+        ENV_FILE="$1"
+        shift
+    else
+        echo -e "${RED}Error: first argument must be the env_file_path (got: $1).${NC}" >&2
+        echo "" >&2
+        print_usage >&2
+        exit 1
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --horizon)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --horizon requires 'pentad' or 'decade'.${NC}" >&2
+                    exit 1
+                fi
+                HORIZON="$2"
+                shift 2
+                ;;
+            --output-dir)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --output-dir requires a path.${NC}" >&2
+                    exit 1
+                fi
+                OUTPUT_DIR="$2"
+                shift 2
+                ;;
+            --station-list-file)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --station-list-file requires a path.${NC}" >&2
+                    exit 1
+                fi
+                STATION_LIST_FILE="$2"
+                shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --i-am-on-laptop)
+                LOCATION_GUARD_BYPASS=true
+                shift
+                ;;
+            -h|--help)
+                print_usage
+                exit 0
+                ;;
+            *)
+                echo -e "${RED}Error: unknown argument: $1${NC}" >&2
+                echo "" >&2
+                print_usage >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    # Validate required.
+    if [[ -z "$HORIZON" ]]; then
+        echo -e "${RED}Error: --horizon is required (pentad|decade).${NC}" >&2
+        exit 1
+    fi
+    case "$HORIZON" in
+        pentad|decade) ;;
+        *)
+            echo -e "${RED}Error: --horizon must be 'pentad' or 'decade' (got: ${HORIZON}).${NC}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Location guard (Stage E #6): refuse on a deployment-server host.
+#
+# Testing-only bypass: set ``_P4A_EXPORT_SKIP_LOCATION_GUARD=1`` in the
+# environment to skip the docker-ps probe. This is intended ONLY for the
+# unit-test suite. It is NEVER set by operators in real export workflows.
+# ---------------------------------------------------------------------------
+location_guard() {
+    if [[ "${_P4A_EXPORT_SKIP_LOCATION_GUARD:-}" == "1" ]]; then
+        # Testing-only bypass; see docstring above.
+        return 0
+    fi
+    if [[ "$LOCATION_GUARD_BYPASS" == true ]]; then
+        echo -e "${YELLOW}WARNING: --i-am-on-laptop set; location guard bypassed.${NC}" >&2
+        return 0
+    fi
+    if ! command -v docker >/dev/null 2>&1; then
+        # No docker — definitely not a deployment server. Proceed.
+        return 0
+    fi
+    local detected=""
+    for name in sapphire-preprocessing-db sapphire-postprocessing-db sapphire-api-gateway; do
+        if docker ps --filter "name=${name}" --quiet 2>/dev/null | grep -q .; then
+            detected="${detected}${name} "
+        fi
+    done
+    if [[ -n "$detected" ]]; then
+        echo -e "${RED}Error: deployment-server containers detected on this host: ${detected}${NC}" >&2
+        echo "" >&2
+        echo "This export script runs on the OPERATOR LAPTOP / jump host, not on the" >&2
+        echo "deployment server. Use the server-side initialize wrapper instead:" >&2
+        echo "    bash bin/initialize_lr_forecast_history.sh <env_file> ..." >&2
+        echo "" >&2
+        echo "If your laptop intentionally has the SAPPHIRE stack running locally," >&2
+        echo "you can acknowledge the override with --i-am-on-laptop (testing use only)." >&2
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    parse_args "$@"
+
+    # Strict perms for everything we write below.
+    umask 077
+
+    # Suppress shell history that might capture credentials.
+    export HISTFILE=/dev/null
+    export PSQL_HISTORY=/dev/null
+
+    # Location guard FIRST — fail loudly before any DB connection.
+    location_guard
+
+    # Validate env file exists (we don't source it; just confirm the path).
+    if [[ ! -f "$ENV_FILE" ]]; then
+        echo -e "${RED}Error: env file not found: ${ENV_FILE}${NC}" >&2
+        exit 1
+    fi
+
+    # Default output dir if not supplied.
+    if [[ -z "$OUTPUT_DIR" ]]; then
+        local default_ts
+        default_ts="$(date -u +%Y%m%dT%H%M%SZ)"
+        OUTPUT_DIR="./lr_forecast_export_${default_ts}"
+    fi
+
+    if ! mkdir -p "$OUTPUT_DIR"; then
+        echo -e "${RED}Error: cannot create output dir: ${OUTPUT_DIR}${NC}" >&2
+        exit 1
+    fi
+    chmod 700 "$OUTPUT_DIR" 2>/dev/null || true
+
+    # Validate station list file if supplied.
+    if [[ -n "$STATION_LIST_FILE" && ! -f "$STATION_LIST_FILE" ]]; then
+        echo -e "${RED}Error: station list file not found: ${STATION_LIST_FILE}${NC}" >&2
+        exit 1
+    fi
+
+    # PG env vars must be set (no password in CLI; use ~/.pgpass).
+    if [[ -z "${PGHOST:-}" || -z "${PGUSER:-}" || -z "${PGDATABASE:-}" ]]; then
+        echo -e "${RED}Error: PGHOST / PGUSER / PGDATABASE must be set (use ~/.pgpass for password).${NC}" >&2
+        exit 1
+    fi
+
+    local ts
+    ts="$(date -u +%Y%m%dT%H%M%SZ)"
+
+    local csv_path="${OUTPUT_DIR}/lr_forecast_${HORIZON}_${ts}.csv"
+    local manifest_path="${csv_path}.manifest"
+
+    # Log file (redacted; no codes ever appear here).
+    local log_file="${OUTPUT_DIR}/export_lr_forecast_${HORIZON}_${ts}.log"
+    export log_file
+
+    echo -e "${BOLD}========================================"
+    echo -e " LR FORECAST EXPORT (P4a) — horizon=${HORIZON}"
+    echo -e "========================================${NC}"
+    umh_log_redacted "  env_file:            ${ENV_FILE}"
+    umh_log_redacted "  horizon:             ${HORIZON}"
+    umh_log_redacted "  output_dir:          ${OUTPUT_DIR}"
+    umh_log_redacted "  csv_path:            ${csv_path}"
+    umh_log_redacted "  manifest_path:       ${manifest_path}"
+    umh_log_redacted "  station_list_file:   ${STATION_LIST_FILE:-<none>}"
+    umh_log_redacted "  dry_run:             ${DRY_RUN}"
+    umh_log_redacted "  source_db:           ${PGUSER}@${PGHOST}:${PGPORT:-5432}/${PGDATABASE}"
+
+    # Build a SQL-safe ``code IN (...)`` clause from the station list file.
+    # Each line is single-quoted and joined by commas. Lines that contain a
+    # single quote are rejected outright (defensive; station codes are
+    # numeric strings in this codebase). Skipped if no file supplied.
+    local stations_clause=""
+    local station_count_in_file=0
+    if [[ -n "$STATION_LIST_FILE" ]]; then
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            # Trim whitespace.
+            line="${line#"${line%%[![:space:]]*}"}"
+            line="${line%"${line##*[![:space:]]}"}"
+            [[ -z "$line" ]] && continue
+            case "$line" in
+                *\'*)
+                    echo -e "${RED}Error: station list contains an apostrophe — rejecting (SQL-injection guard).${NC}" >&2
+                    exit 1
+                    ;;
+            esac
+            if [[ -z "$stations_clause" ]]; then
+                stations_clause="'${line}'"
+            else
+                stations_clause="${stations_clause},'${line}'"
+            fi
+            station_count_in_file=$((station_count_in_file + 1))
+        done < "$STATION_LIST_FILE"
+
+        if [[ "$station_count_in_file" -eq 0 ]]; then
+            echo -e "${RED}Error: station list file is empty (no codes after trim).${NC}" >&2
+            exit 1
+        fi
+        umh_log_redacted "  station_count_in_file: ${station_count_in_file}"
+    else
+        umh_log_redacted "  (no --station-list-file; exporting all codes from the source DB)"
+    fi
+
+    # Build the WHERE clause: horizon_type plus optional station list.
+    local where_clause="horizon_type='${HORIZON}'"
+    if [[ -n "$stations_clause" ]]; then
+        where_clause="${where_clause} AND code IN (${stations_clause})"
+    fi
+
+    # Dry-run path: COUNT(*) only.
+    if [[ "$DRY_RUN" == true ]]; then
+        umh_log_redacted "DRY RUN: running COUNT(*) only; no CSV / manifest will be written."
+        local count_sql
+        count_sql=$(cat <<SQL
+SELECT COUNT(*) AS row_count,
+       COUNT(DISTINCT code) AS station_count,
+       COALESCE(MIN(date)::text, '') AS date_min,
+       COALESCE(MAX(date)::text, '') AS date_max
+FROM lr_forecasts
+WHERE ${where_clause};
+SQL
+)
+        psql -X -v ON_ERROR_STOP=1 -P pager=off -A -F $'\t' -c "${count_sql}" \
+            | tee -a "${log_file}"
+        echo ""
+        echo -e "${YELLOW}DRY RUN complete — no files written.${NC}"
+        exit 0
+    fi
+
+    # Real export: COPY (SELECT ...) TO STDOUT with CSV HEADER.
+    # Column list mirrors LRForecastBase (no model_type — this table does
+    # not have that column; LR is implicit). The lowercase horizon_type
+    # value matches the API enum (architecture §Q4).
+    #
+    # The horizon-specific columns ``pentad_in_month`` / ``pentad_in_year``
+    # vs ``decad_in_month`` / ``decad_in_year`` are NOT DB columns — they
+    # exist only in the legacy CSV-source flow (data_migrator.py). On the
+    # DB side, ``horizon_value`` / ``horizon_in_year`` are the literal
+    # column names. We alias them OUT to the legacy CSV column names so
+    # the server-side helper's column-mapping table (which expects the CSV
+    # names) finds them.
+    local horizon_value_alias
+    local horizon_in_year_alias
+    if [[ "$HORIZON" == "pentad" ]]; then
+        horizon_value_alias="pentad_in_month"
+        horizon_in_year_alias="pentad_in_year"
+    else
+        horizon_value_alias="decad_in_month"
+        horizon_in_year_alias="decad_in_year"
+    fi
+
+    local copy_sql
+    copy_sql=$(cat <<SQL
+COPY (
+    SELECT lower(horizon_type::text) AS horizon_type,
+           code,
+           date::text AS date,
+           horizon_value AS ${horizon_value_alias},
+           horizon_in_year AS ${horizon_in_year_alias},
+           discharge_avg,
+           predictor,
+           slope,
+           intercept,
+           forecasted_discharge,
+           q_mean,
+           q_std_sigma,
+           delta,
+           rsquared
+    FROM lr_forecasts
+    WHERE ${where_clause}
+    ORDER BY code, date
+) TO STDOUT WITH CSV HEADER;
+SQL
+)
+
+    umh_log_redacted "Running COPY to ${csv_path}"
+    psql -X -v ON_ERROR_STOP=1 -P pager=off -c "${copy_sql}" > "${csv_path}"
+    chmod 600 "${csv_path}"
+
+    # Compute manifest fields from the produced CSV (single canonical
+    # source: count -1 for header, count distinct ``code``, scan dates).
+    local row_count
+    row_count=$(($(wc -l < "${csv_path}") - 1))
+    if [[ "$row_count" -lt 0 ]]; then
+        row_count=0
+    fi
+
+    # distinct codes + date range — single python pass for performance.
+    local manifest_fields
+    manifest_fields=$(python3 - "$csv_path" <<'PYEOF'
+import csv, sys
+codes = set()
+date_min = None
+date_max = None
+with open(sys.argv[1], newline="") as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        c = (row.get("code") or "").strip()
+        if c:
+            codes.add(c)
+        d = (row.get("date") or "").strip()[:10]
+        if d:
+            if date_min is None or d < date_min:
+                date_min = d
+            if date_max is None or d > date_max:
+                date_max = d
+print(f"{len(codes)}\t{date_min or ''}\t{date_max or ''}")
+PYEOF
+)
+    local manifest_station_count manifest_date_min manifest_date_max
+    manifest_station_count="${manifest_fields%%$'\t'*}"
+    manifest_fields="${manifest_fields#*$'\t'}"
+    manifest_date_min="${manifest_fields%%$'\t'*}"
+    manifest_date_max="${manifest_fields#*$'\t'}"
+
+    # Build the manifest. station_count and date_min/max are computed from
+    # the produced CSV (NOT from the stations-file count) so manifest
+    # validation on the server side catches any mid-flight tampering.
+    cat > "${manifest_path}" <<MANIFEST
+# Generated by bin/export_lr_forecast_history.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ)
+export_type=lr_forecast
+horizon=${HORIZON}
+row_count=${row_count}
+station_count=${manifest_station_count}
+date_min=${manifest_date_min}
+date_max=${manifest_date_max}
+MANIFEST
+    chmod 600 "${manifest_path}"
+
+    umh_log_redacted "Wrote CSV:      ${csv_path} (${row_count} rows)"
+    umh_log_redacted "Wrote manifest: ${manifest_path}"
+    umh_log_redacted "  station_count (in csv):  ${manifest_station_count}"
+    umh_log_redacted "  date_min:                ${manifest_date_min:-none}"
+    umh_log_redacted "  date_max:                ${manifest_date_max:-none}"
+
+    echo ""
+    echo -e "${GREEN}Export complete.${NC} Transfer BOTH files together to the deployment server:"
+    echo "  scp ${csv_path} ${manifest_path} <user>@<server>:<data_root>/logs/"
+    echo ""
+    echo "Then on the server:"
+    echo "  bash bin/initialize_lr_forecast_history.sh \\"
+    echo "      <env_file> --from-export <transferred_csv> --horizon ${HORIZON}"
+}
+
+main "$@"

--- a/bin/export_lr_forecast_history.sh
+++ b/bin/export_lr_forecast_history.sh
@@ -522,6 +522,18 @@ SQL
         row_count=0
     fi
 
+    # Reject zero-row exports up front (review feedback): a blank date_min /
+    # date_max manifest is non-ISO and gets rejected by the server-side
+    # validator anyway. Surface this as a clear operator error before any
+    # sidecar is written. The partial CSV (header only) is removed so re-runs
+    # start clean.
+    if [[ "$row_count" -eq 0 ]]; then
+        umh_log_redacted "ERROR: no rows matched filter — nothing to export."
+        umh_log_redacted "Check the station list, --horizon flag, and date range."
+        rm -f "${csv_path}"
+        exit 1
+    fi
+
     # distinct codes + date range — single python pass for performance.
     local manifest_fields
     manifest_fields=$(python3 - "$csv_path" <<'PYEOF'

--- a/bin/initialize_lr_forecast_history.sh
+++ b/bin/initialize_lr_forecast_history.sh
@@ -1,0 +1,512 @@
+#!/usr/bin/env bash
+# ============================================================================
+# initialize_lr_forecast_history.sh
+#
+# LR (linear-regression) forecast laptop-export -> CSV -> API migration
+# wrapper (P4a of the update-time migration toolkit). Consumes a CSV exported
+# on the operator's laptop (via bin/export_lr_forecast_history.sh) and pushes
+# rows to the postprocessing API /lr-forecast/ endpoint.
+#
+# Uses the P0 helper (bin/utils/update_migration_helpers.sh) for image
+# resolution, manifest validation, temp workspace, redacted logging, and the
+# uniform image log line. Mounts the P0 migration_py/ package into the
+# prepgateway container so the per-row POST logic lives in importable
+# stdlib-only Python — no embedded heredoc beyond a minimal entry shim.
+#
+# IMPORTANT — source DB:
+#   The lr_forecasts table lives in sapphire-postprocessing-db (NOT
+#   preprocessing-db). All MODE-detection psql queries here go through
+#   `docker exec sapphire-postprocessing-db psql ... postprocessing_db`.
+#
+# IMPORTANT — no model_type column:
+#   lr_forecasts has the DB unique key (horizon_type, code, date). LR is
+#   implicit in this table (which is why LR rows are filtered OUT of
+#   combined_forecasts by the P-postprocessing combined_forecasts migrator).
+#   Wrappers must NOT add a model_type filter or column.
+#
+# Universal safe-write rule (architecture Q2 layer 2):
+#   LR forecast rows have many nullable model-stat fields (slope, intercept,
+#   delta, rsquared, etc.). The wrapper sends ONLY non-NULL fields from the
+#   source CSV. The service-side _has_changes + setattr path overwrites
+#   existing non-NULL with incoming NULL, so the wrapper never injects null.
+#   Enrichment-only: complete export rows preferred (architecture Q2 table
+#   policy for lr_forecasts).
+#
+# Manifest validation (Stage E item #2):
+#   The export CSV must be accompanied by a <csv>.manifest sidecar produced
+#   by bin/export_lr_forecast_history.sh. The wrapper validates the manifest
+#   BEFORE the docker run (export_type=lr_forecast; row_count; station_count;
+#   date_min; date_max). Validation failure aborts before any POST.
+#
+# MODE detection: queries the target postprocessing-db once via docker exec
+# psql, scoped to the requested horizon. Empty (count=0 OR min_date IS NULL)
+# -> full-import; populated -> pre-cutoff (cutoff = MIN(date)).
+#
+# Idempotency: the postprocessing service upserts on (horizon_type, code,
+# date). Reruns are safe.
+#
+# Usage:
+#   bash bin/initialize_lr_forecast_history.sh <env_file_path> \
+#       --from-export <path> \
+#       --horizon pentad|decade \
+#       [--dry-run] [--api-url URL] [--batch-size N] [--image IMAGE] \
+#       [--station-filter CODE]
+#
+# Arguments:
+#   env_file_path        Path to the .env_<org> file (required).
+#
+# Options:
+#   --from-export <PATH> Path to the laptop-exported CSV (required).
+#                        Must be under the deployment data-root logs tree
+#                        (e.g. ${ieasyhydroforecast_data_root_dir}/logs/
+#                        lr_forecast_tmp/<ts>/lr_forecast_pentad.csv).
+#                        A sibling <PATH>.manifest must exist (validated).
+#   --horizon <HORIZON>  pentad|decade (required). Picks the column map
+#                        and the API enum value.
+#   --dry-run            Read + filter; do NOT POST anything.
+#   --api-url <URL>      Target endpoint (default:
+#                        http://localhost:8003/lr-forecast/).
+#   --batch-size <N>     Records per POST batch (default: 500).
+#   --image <IMAGE>      Docker image override.
+#   --station-filter <CODE>
+#                        Filter source CSV rows to a single station code
+#                        (binding interface contract from P0 — honored by
+#                        all migration wrappers).
+#   -h, --help           Print this message and exit 0.
+#
+# Examples:
+#   bash bin/initialize_lr_forecast_history.sh /data/taj_data/config/.env_tjhm \
+#       --from-export /data/taj_data/logs/lr_forecast_tmp/20260606T120000Z/lr_forecast_pentad.csv \
+#       --horizon pentad --dry-run
+#   bash bin/initialize_lr_forecast_history.sh /data/taj_data/config/.env_tjhm \
+#       --from-export /data/taj_data/logs/lr_forecast_tmp/20260606T120000Z/lr_forecast_decade.csv \
+#       --horizon decade
+# ============================================================================
+
+set -eo pipefail
+# NOTE: set -u is intentionally omitted; common_functions.sh is not strict-mode safe.
+
+# ---------------------------------------------------------------------------
+# Source shared helpers (P0 foundation)
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC1091  # path computed at runtime; can't be statically resolved
+source "$(dirname "$0")/utils/update_migration_helpers.sh"
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Defaults / flag variables
+# ---------------------------------------------------------------------------
+ENV_FILE=""
+FROM_EXPORT=""
+HORIZON=""
+DRY_RUN=false
+API_URL="http://localhost:8003/lr-forecast/"
+BATCH_SIZE=500
+IMAGE_OVERRIDE=""
+STATION_FILTER=""
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+print_usage() {
+    cat <<'USAGE'
+Usage: bash bin/initialize_lr_forecast_history.sh <env_file_path> \
+           --from-export <PATH> --horizon pentad|decade [OPTIONS]
+
+Migrate lr_forecasts rows from a laptop-exported CSV into the postprocessing
+API /lr-forecast/ endpoint. Honors MODE=full-import vs pre-cutoff based on
+the target table state (queried via docker exec sapphire-postprocessing-db
+psql).
+
+Arguments:
+  env_file_path        Path to the .env_<org> file (required).
+
+Options:
+  --from-export <PATH> Path to the laptop-exported CSV (required).
+                       A sibling <PATH>.manifest must exist (validated).
+  --horizon <HORIZON>  pentad|decade (required). Picks the column map and
+                       the API enum value.
+  --dry-run            Read + filter; do NOT POST anything.
+  --api-url <URL>      Target endpoint (default: http://localhost:8003/lr-forecast/).
+  --batch-size <N>     Records per POST batch (default: 500).
+  --image <IMAGE>      Docker image override.
+  --station-filter <CODE>
+                       Filter source CSV rows to a single station code
+                       (binding interface contract from P0 — honored by all
+                       migration wrappers).
+  -h, --help           Print this message and exit 0.
+
+Examples:
+  bash bin/initialize_lr_forecast_history.sh /data/taj_data/config/.env_tjhm \
+      --from-export /data/taj_data/logs/lr_forecast_tmp/20260606T120000Z/lr_forecast_pentad.csv \
+      --horizon pentad --dry-run
+  bash bin/initialize_lr_forecast_history.sh /data/taj_data/config/.env_tjhm \
+      --from-export /data/taj_data/logs/lr_forecast_tmp/20260606T120000Z/lr_forecast_decade.csv \
+      --horizon decade
+USAGE
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+parse_args() {
+    # Handle --help / -h before requiring the positional arg.
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help) print_usage; exit 0 ;;
+        esac
+    done
+
+    if [[ $# -eq 0 ]]; then
+        echo -e "${RED}Error: env_file_path is required.${NC}" >&2
+        echo "" >&2
+        print_usage >&2
+        exit 1
+    fi
+
+    # First positional argument is the env file.
+    if [[ "$1" != -* ]]; then
+        ENV_FILE="$1"
+        shift
+    else
+        echo -e "${RED}Error: first argument must be the env_file_path (got: $1).${NC}" >&2
+        echo "" >&2
+        print_usage >&2
+        exit 1
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --from-export)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --from-export requires a path value.${NC}" >&2
+                    exit 1
+                fi
+                FROM_EXPORT="$2"
+                shift 2
+                ;;
+            --horizon)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --horizon requires pentad|decade.${NC}" >&2
+                    exit 1
+                fi
+                HORIZON="$2"
+                shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --api-url)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --api-url requires a URL value.${NC}" >&2
+                    exit 1
+                fi
+                API_URL="$2"
+                shift 2
+                ;;
+            --batch-size)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --batch-size requires a numeric value.${NC}" >&2
+                    exit 1
+                fi
+                BATCH_SIZE="$2"
+                shift 2
+                ;;
+            --image)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --image requires an image name.${NC}" >&2
+                    exit 1
+                fi
+                IMAGE_OVERRIDE="$2"
+                shift 2
+                ;;
+            --station-filter)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --station-filter requires a station code value.${NC}" >&2
+                    exit 1
+                fi
+                STATION_FILTER="$2"
+                shift 2
+                ;;
+            -h|--help)
+                print_usage
+                exit 0
+                ;;
+            *)
+                echo -e "${RED}Error: unknown argument: $1${NC}" >&2
+                echo "" >&2
+                print_usage >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    # Required-arg validation.
+    if [[ -z "$FROM_EXPORT" ]]; then
+        echo -e "${RED}Error: --from-export is required.${NC}" >&2
+        echo "" >&2
+        print_usage >&2
+        exit 1
+    fi
+    if [[ -z "$HORIZON" ]]; then
+        echo -e "${RED}Error: --horizon is required (pentad|decade).${NC}" >&2
+        echo "" >&2
+        print_usage >&2
+        exit 1
+    fi
+    case "$HORIZON" in
+        pentad|decade) ;;
+        *)
+            echo -e "${RED}Error: --horizon must be 'pentad' or 'decade' (got: ${HORIZON}).${NC}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Query the target postprocessing-db for MODE detection.
+# Echoes "count<TAB>min_date_or_empty" on stdout (e.g. "0\t" or "100\t2024-01-15").
+# Returns non-zero if the docker exec fails.
+# Scoped to the requested horizon (pentad|decade) — lr_forecasts has NO
+# model_type column, so the only scoping dimension is horizon_type.
+# ---------------------------------------------------------------------------
+query_target_state() {
+    local horizon_arg="$1"
+    docker exec sapphire-postprocessing-db psql \
+        -U postgres -d postprocessing_db -P pager=off -t -A -F $'\t' \
+        -c "SELECT COUNT(*), COALESCE(MIN(date)::text, '') FROM lr_forecasts WHERE horizon_type='${horizon_arg}';"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    parse_args "$@"
+
+    print_banner
+    echo "| Running LR Forecast History Initialization (CSV -> API push)"
+
+    # Validate env file exists before loading.
+    if [[ ! -f "$ENV_FILE" ]]; then
+        echo -e "${RED}Error: env file not found: ${ENV_FILE}${NC}" >&2
+        exit 1
+    fi
+
+    # Load .env vars and derive ieasyhydroforecast_* path variables.
+    read_configuration "${ENV_FILE}"
+
+    # Validate required env vars.
+    if [[ -z "${ieasyhydroforecast_data_root_dir:-}" ]]; then
+        echo -e "${RED}Error: ieasyhydroforecast_data_root_dir is not set. Check your .env file.${NC}" >&2
+        exit 1
+    fi
+
+    # Resolve image via the P0 helper (CLI override -> configured tag -> :latest).
+    local IMAGE
+    IMAGE="$(umh_resolve_image "$IMAGE_OVERRIDE" "${ieasyhydroforecast_backend_docker_image_tag:-}")"
+
+    # Derived paths.
+    local LOG_DIR="${ieasyhydroforecast_data_root_dir}/logs/lr_forecast_history_init"
+    mkdir -p "${LOG_DIR}"
+
+    local TIMESTAMP
+    TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+    log_file="${LOG_DIR}/lr_forecast_history_init_${TIMESTAMP}.log"
+    export log_file
+
+    echo "| Log file: ${log_file}"
+    echo ""
+
+    umh_log_redacted "Starting LR forecast history initialization"
+    umh_log_redacted "  env_file:        ${ENV_FILE}"
+    umh_log_redacted "  from_export:     ${FROM_EXPORT}"
+    umh_log_redacted "  horizon:         ${HORIZON}"
+    umh_log_redacted "  api_url:         ${API_URL}"
+    umh_log_redacted "  batch_size:      ${BATCH_SIZE}"
+    umh_log_redacted "  station_filter:  ${STATION_FILTER:-<none>}"
+    umh_log_redacted "  dry_run:         ${DRY_RUN}"
+    umh_print_image_resolution_line "${IMAGE}"
+
+    # -------------------------------------------------------------------------
+    # Pre-flight checks
+    # -------------------------------------------------------------------------
+
+    # 1. Export CSV must exist.
+    if [[ ! -f "$FROM_EXPORT" ]]; then
+        umh_log_redacted "ERROR: export CSV not found: ${FROM_EXPORT}"
+        exit 1
+    fi
+    umh_log_redacted "Pre-flight: export CSV OK (${FROM_EXPORT})"
+
+    # 2. Manifest validation (Stage E item #2) — abort before any POST if invalid.
+    umh_log_redacted "Pre-flight: validating manifest <${FROM_EXPORT}>.manifest"
+    umh_validate_export_manifest "$FROM_EXPORT" "lr_forecast"
+    umh_log_redacted "Pre-flight: manifest OK"
+
+    # 3. Docker must be running.
+    if ! docker info > /dev/null 2>&1; then
+        umh_log_redacted "ERROR: Docker is not running. Please start Docker and try again."
+        exit 1
+    fi
+    umh_log_redacted "Pre-flight: Docker daemon OK"
+
+    # 4. Pull image if not present locally.
+    if ! docker image inspect "$IMAGE" > /dev/null 2>&1; then
+        umh_log_redacted "Image ${IMAGE} not found locally, pulling..."
+        if ! docker pull "$IMAGE"; then
+            umh_log_redacted "ERROR: Failed to pull Docker image ${IMAGE}"
+            exit 1
+        fi
+        umh_log_redacted "Pull complete: ${IMAGE}"
+    else
+        umh_log_redacted "Pre-flight: image present locally (${IMAGE})"
+    fi
+
+    # -------------------------------------------------------------------------
+    # MODE detection — query target postprocessing-db.
+    # -------------------------------------------------------------------------
+    local MODE="full-import"
+    local CUTOFF=""
+    local TARGET_COUNT=0
+    local TARGET_MIN_DATE=""
+
+    if docker ps --filter "name=sapphire-postprocessing-db" --quiet | grep -q .; then
+        local query_out
+        if query_out="$(query_target_state "$HORIZON" 2>&1)"; then
+            # query_out format: "<count>\t<min_date_or_empty>"
+            TARGET_COUNT="${query_out%%$'\t'*}"
+            TARGET_MIN_DATE="${query_out#*$'\t'}"
+            # Trim any trailing newline / whitespace.
+            TARGET_COUNT="${TARGET_COUNT//[$'\r\n ']/}"
+            TARGET_MIN_DATE="${TARGET_MIN_DATE//[$'\r\n ']/}"
+            umh_log_redacted "Target state: horizon=${HORIZON} count=${TARGET_COUNT} min_date=${TARGET_MIN_DATE:-<null>}"
+            if [[ "$TARGET_COUNT" != "0" && -n "$TARGET_MIN_DATE" ]]; then
+                MODE="pre-cutoff"
+                CUTOFF="$TARGET_MIN_DATE"
+            else
+                MODE="full-import"
+                CUTOFF=""
+            fi
+        else
+            umh_log_redacted "WARN: target query failed (${query_out}); assuming full-import"
+            MODE="full-import"
+            CUTOFF=""
+        fi
+    else
+        umh_log_redacted "WARN: sapphire-postprocessing-db not running; assuming full-import"
+        MODE="full-import"
+        CUTOFF=""
+    fi
+
+    umh_log_redacted "MODE=${MODE}$( [[ -n "$CUTOFF" ]] && echo " (cutoff=${CUTOFF})" || echo " (target empty)")"
+
+    # -------------------------------------------------------------------------
+    # Acquire a temp workspace (mode 0o700, trap-cleaned on EXIT INT TERM).
+    # The temp workspace is for any auxiliary artifacts; the export CSV is
+    # read directly from its existing path (already inside data-root/logs/).
+    # -------------------------------------------------------------------------
+    local TMPDIR_LR
+    TMPDIR_LR="$(umh_acquire_temp_workspace lr_forecast)"
+    umh_log_redacted "Temp workspace: ${TMPDIR_LR}"
+
+    # -------------------------------------------------------------------------
+    # Run the Python helper inside the prepgateway image.
+    # Mount migration_py/ read-only; mount the export CSV read-only.
+    # -------------------------------------------------------------------------
+    local HELPER_DIR
+    HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/utils" && pwd)"
+
+    local DRY_RUN_FLAG=""
+    if [[ "$DRY_RUN" == true ]]; then
+        DRY_RUN_FLAG="--dry-run"
+    fi
+
+    local CUTOFF_ARGS=()
+    if [[ -n "$CUTOFF" ]]; then
+        CUTOFF_ARGS=("--cutoff" "$CUTOFF")
+    fi
+
+    local STATION_ARGS=()
+    if [[ -n "$STATION_FILTER" ]]; then
+        STATION_ARGS=("--station-filter" "$STATION_FILTER")
+    fi
+
+    umh_log_redacted "========================================"
+    umh_log_redacted "Running LR forecast push via docker"
+    umh_log_redacted "  image:        ${IMAGE}"
+    umh_log_redacted "  csv:          ${FROM_EXPORT} -> /lr_forecast.csv (ro)"
+    umh_log_redacted "  migration_py: ${HELPER_DIR}/migration_py -> /opt/migration_py (ro)"
+    umh_log_redacted "  api_url:      ${API_URL}"
+    umh_log_redacted "  horizon:      ${HORIZON}"
+    umh_log_redacted "  batch_size:   ${BATCH_SIZE}"
+    if [[ "$DRY_RUN" == true ]]; then
+        umh_log_redacted "  mode:         DRY RUN (no POSTs)"
+    else
+        umh_log_redacted "  mode:         REAL run"
+    fi
+    umh_log_redacted "========================================"
+
+    # shellcheck disable=SC2086  # DRY_RUN_FLAG intentionally unquoted: empty=no arg
+    docker run --rm --network host \
+        -v "${FROM_EXPORT}:/lr_forecast.csv:ro" \
+        -v "${HELPER_DIR}/migration_py:/opt/migration_py:ro" \
+        -e "PYTHONPATH=/opt" \
+        "$IMAGE" \
+        python3 -m migration_py.lr_forecast \
+            --csv-path /lr_forecast.csv \
+            --api-url "${API_URL}" \
+            --horizon "${HORIZON}" \
+            --batch-size "${BATCH_SIZE}" \
+            "${CUTOFF_ARGS[@]}" \
+            "${STATION_ARGS[@]}" \
+            ${DRY_RUN_FLAG} \
+        2>&1 | tee -a "${log_file}"
+
+    local DOCKER_EXIT=${PIPESTATUS[0]}
+
+    # -------------------------------------------------------------------------
+    # Post-run summary.
+    # -------------------------------------------------------------------------
+    echo ""
+    echo -e "${BOLD}========================================"
+    echo -e " LR FORECAST HISTORY INIT COMPLETE"
+    echo -e "========================================${NC}"
+    echo ""
+
+    if [[ "$DOCKER_EXIT" -ne 0 ]]; then
+        echo -e "${RED}Docker run exited with code ${DOCKER_EXIT}. Check the log above and:${NC}"
+        echo "  ${log_file}"
+        echo ""
+    else
+        if [[ "$DRY_RUN" == true ]]; then
+            echo -e "${YELLOW}DRY RUN complete — no records were POSTed.${NC}"
+            echo "  Re-run without --dry-run to push data."
+        else
+            echo -e "${GREEN}Push complete.${NC}"
+        fi
+        echo ""
+    fi
+
+    echo "Verify rows in the postprocessing DB:"
+    echo "  docker exec sapphire-postprocessing-db \\"
+    echo "    psql -U postgres -d postprocessing_db -c \\"
+    echo "    \"SELECT horizon_type, COUNT(*) AS rows, MIN(date), MAX(date) FROM lr_forecasts WHERE horizon_type='${HORIZON}' GROUP BY horizon_type;\""
+    echo ""
+    echo "Log file: ${log_file}"
+
+    exit "$DOCKER_EXIT"
+}
+
+main "$@"

--- a/bin/utils/migration_py/lr_forecast.py
+++ b/bin/utils/migration_py/lr_forecast.py
@@ -1,0 +1,515 @@
+"""LR (linear regression) forecast laptop-export -> CSV -> API helper (P4a).
+
+Called from ``bin/initialize_lr_forecast_history.sh`` as
+``python3 -m migration_py.lr_forecast``. Reads a CSV that was exported on
+the operator's laptop (via ``bin/export_lr_forecast_history.sh`` /
+``psql -X \\copy`` from ``sapphire-postprocessing-db``) and POSTs records to
+the postprocessing API ``/lr-forecast/`` endpoint.
+
+Unlike the CSV-source wrappers (P1a runoff DAY, P1b meteo, P3 hydrograph
+DAY), the LR forecasts source CSV does NOT live under
+``intermediate_data/`` on the deployment server. It is a laptop-side export
+copied to the server (``scp``) into a wrapper temp dir. The wrapper validates
+its sidecar ``<csv>.manifest`` via ``migration_py._common.validate_manifest``
+before any POST.
+
+Source DB: ``sapphire-postprocessing-db`` (NOT preprocessing-db). The
+``lr_forecasts`` table lives in the postprocessing service.
+
+Schema specifics (from
+``sapphire/services/postprocessing/app/schemas.py::LRForecastBase`` and
+``models.py::LRForecast``):
+
+- The DB unique key is ``(horizon_type, code, date)``. There is NO
+  ``model_type`` column — LR is implicit in this table (which is why LR rows
+  are filtered OUT of ``combined_forecasts`` by the P-postprocessing
+  combined_forecasts migrator).
+- ``horizon_type`` is a lowercase enum: ``"pentad"`` / ``"decade"`` (architecture
+  §Q4 lock — preserve API enum values, do NOT uppercase). Uppercase would be
+  rejected at the Pydantic boundary.
+- Required fields: ``horizon_type``, ``code``, ``date``, ``horizon_value``,
+  ``horizon_in_year``.
+- Nullable fields: ``discharge_avg``, ``predictor``, ``slope``, ``intercept``,
+  ``forecasted_discharge``, ``q_mean``, ``q_std_sigma``, ``delta``,
+  ``rsquared``.
+
+CSV column mapping (mirrors ``LRForecastDataMigrator.prepare_pentad_data`` /
+``prepare_decade_data`` in
+``sapphire/services/postprocessing/app/data_migrator.py``):
+
+- pentad CSV: ``pentad_in_month`` -> ``horizon_value``,
+  ``pentad_in_year`` -> ``horizon_in_year``
+- decade CSV: ``decad_in_month`` -> ``horizon_value``,
+  ``decad_in_year`` -> ``horizon_in_year``
+
+The ``--horizon`` CLI arg selects pentad vs decade and drives the column
+mapping. A mismatch between ``--horizon`` and what the source CSV actually
+contains is detected by missing required column.
+
+Universal safe-write rule (architecture §Q2 layer 2): nullable fields with a
+NULL / empty / NaN source value are OMITTED from the payload — never sent as
+``null``. The service-side ``_has_changes + setattr`` path would otherwise
+overwrite existing non-NULL targets with incoming NULL.
+
+Idempotency: the postprocessing service upserts on
+``(horizon_type, code, date)``; reruns are safe.
+
+Stdlib-only. Verified by ``migration_py._audit.audit_stdlib_only``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import csv
+import datetime
+import json
+import logging
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# Intra-package sibling import — relative form (level >= 1) is the explicit
+# pattern recognized by ``_audit.collect_imported_roots`` as intra-package and
+# skipped from the stdlib check.
+from . import _common
+
+logger = logging.getLogger("migration_py.lr_forecast")
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Allowed --horizon values and the API enum each maps to (architecture §Q4).
+_ALLOWED_HORIZONS: frozenset[str] = frozenset({"pentad", "decade"})
+
+# Per-horizon CSV column mapping for horizon_value / horizon_in_year.
+# Mirrors LRForecastDataMigrator in sapphire/services/postprocessing/app/data_migrator.py.
+_HORIZON_COLUMN_MAP: dict[str, dict[str, str]] = {
+    "pentad": {
+        "horizon_value": "pentad_in_month",
+        "horizon_in_year": "pentad_in_year",
+    },
+    "decade": {
+        "horizon_value": "decad_in_month",
+        "horizon_in_year": "decad_in_year",
+    },
+}
+
+# Required columns in every source row (in addition to the per-horizon
+# horizon_value/horizon_in_year columns). Parse fails otherwise.
+_REQUIRED_BASE_COLUMNS: frozenset[str] = frozenset({"code", "date"})
+
+# Nullable float fields. Order is preserved for stable dry-run output.
+_NULLABLE_FLOAT_FIELDS: tuple[str, ...] = (
+    "discharge_avg",
+    "predictor",
+    "slope",
+    "intercept",
+    "forecasted_discharge",
+    "q_mean",
+    "q_std_sigma",
+    "delta",
+    "rsquared",
+)
+
+
+# ---------------------------------------------------------------------------
+# Value parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_float(raw: str | None) -> float | None:
+    """Return a float, or None if unparseable / null-like.
+
+    Rejects non-finite floats (NaN, +/-Inf) so the payload cannot embed
+    ``"NaN"``/``"Infinity"`` literals (invalid JSON per RFC 7159; rejected by
+    the receiving Pydantic schema).
+    """
+    s = (raw or "").strip()
+    if not s or s.lower() in {"nan", "none", "null"}:
+        return None
+    try:
+        v = float(s)
+    except ValueError:
+        return None
+    if v != v or v == float("inf") or v == float("-inf"):
+        return None
+    return v
+
+
+def _parse_int(raw: str | None) -> int | None:
+    """Return an int, or None if unparseable / null-like."""
+    s = (raw or "").strip()
+    if not s or s.lower() in {"nan", "none", "null"}:
+        return None
+    try:
+        # Tolerate "10.0" style values (CSV exports sometimes coerce ints).
+        return int(float(s))
+    except (ValueError, OverflowError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Record building
+# ---------------------------------------------------------------------------
+
+
+def _build_record(row: dict[str, str], horizon: str) -> dict | None:
+    """Build the per-row API payload for an LR forecast record.
+
+    Implements the universal safe-write rule: only non-NULL nullable fields
+    are included in the returned dict. Required fields are always included
+    when they parse.
+
+    Args:
+        row: CSV row as ``{column_name: value_str}``.
+        horizon: ``"pentad"`` or ``"decade"`` — selects the
+            horizon_value / horizon_in_year source columns.
+
+    Returns:
+        A payload dict, or ``None`` if the row cannot satisfy the required
+        fields (caller treats this as a parse skip).
+    """
+    if horizon not in _ALLOWED_HORIZONS:
+        # Defensive: callers normalize this; raise an explicit error if not.
+        raise ValueError(f"horizon must be one of {sorted(_ALLOWED_HORIZONS)}, got {horizon!r}")
+
+    code = (row.get("code") or "").strip()
+    date_str = (row.get("date") or "").strip()[:10]
+    if not code or not date_str:
+        return None
+    # Validate date format; reject malformed.
+    try:
+        datetime.date.fromisoformat(date_str)
+    except ValueError:
+        return None
+
+    col_map = _HORIZON_COLUMN_MAP[horizon]
+    horizon_value = _parse_int(row.get(col_map["horizon_value"]))
+    horizon_in_year = _parse_int(row.get(col_map["horizon_in_year"]))
+    if horizon_value is None or horizon_in_year is None:
+        # Required fields missing/unparseable → parse skip.
+        return None
+
+    rec: dict = {
+        "horizon_type": horizon,
+        "code": code,
+        "date": date_str,
+        "horizon_value": horizon_value,
+        "horizon_in_year": horizon_in_year,
+    }
+
+    # Nullable float fields — only include non-NULL values.
+    for field in _NULLABLE_FLOAT_FIELDS:
+        v = _parse_float(row.get(field))
+        if v is not None:
+            rec[field] = v
+
+    return rec
+
+
+def _read_filtered_records(
+    csv_path: Path,
+    *,
+    horizon: str,
+    cutoff: str | None,
+    station_filter: str | None,
+) -> tuple[
+    list[dict],
+    dict[str, int],
+    set[str],
+    str | None,
+    str | None,
+]:
+    """Read CSV and return (records, counters, distinct_codes, date_min, date_max).
+
+    Args:
+        csv_path: path to the LR-forecast export CSV.
+        horizon: ``"pentad"`` or ``"decade"`` — selects column mapping.
+        cutoff: optional ISO date; rows with ``date >= cutoff`` are dropped.
+            None means full-import (no date filter).
+        station_filter: optional single station code; rows whose ``code``
+            does not match are dropped. None means no station filter.
+
+    Returns:
+        Tuple ``(records, counters, distinct_codes, date_min, date_max)``
+        where:
+            - records: list of payload dicts (only non-NULL fields, post-filter).
+            - counters: dict with ``source_row_count``, ``filtered_row_count``,
+              ``skipped_parse``, ``skipped_cutoff``, ``skipped_station``.
+            - distinct_codes: set of codes that survived ALL filters.
+            - date_min / date_max: source CSV date range (pre-filter) for
+              dry-run inventory.
+
+    Raises:
+        ValueError: if required columns are missing for the given horizon.
+    """
+    counters = {
+        "source_row_count": 0,
+        "filtered_row_count": 0,
+        "skipped_parse": 0,
+        "skipped_cutoff": 0,
+        "skipped_station": 0,
+    }
+    records: list[dict] = []
+    distinct_codes: set[str] = set()
+    date_min: str | None = None
+    date_max: str | None = None
+
+    if horizon not in _ALLOWED_HORIZONS:
+        raise ValueError(f"horizon must be one of {sorted(_ALLOWED_HORIZONS)}, got {horizon!r}")
+
+    with csv_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        header = list(reader.fieldnames or [])
+        # Validate required columns: base + per-horizon columns.
+        col_map = _HORIZON_COLUMN_MAP[horizon]
+        required = _REQUIRED_BASE_COLUMNS | {col_map["horizon_value"], col_map["horizon_in_year"]}
+        missing = required - set(header)
+        if missing:
+            raise ValueError(
+                f"CSV {csv_path.name} is missing required column(s) for "
+                f"horizon={horizon!r}: {sorted(missing)}"
+            )
+
+        for row in reader:
+            counters["source_row_count"] += 1
+            code = (row.get("code") or "").strip()
+            date_str = (row.get("date") or "").strip()[:10]
+
+            # Track source date range pre-filter (for dry-run inventory).
+            if date_str:
+                if date_min is None or date_str < date_min:
+                    date_min = date_str
+                if date_max is None or date_str > date_max:
+                    date_max = date_str
+
+            if not code or not date_str:
+                counters["skipped_parse"] += 1
+                continue
+
+            # Station filter (before cutoff for clarity in counters).
+            if station_filter is not None and code != station_filter:
+                counters["skipped_station"] += 1
+                continue
+
+            # Cutoff filter (strictly less than cutoff).
+            if cutoff is not None and date_str >= cutoff:
+                counters["skipped_cutoff"] += 1
+                continue
+
+            record = _build_record(row, horizon)
+            if record is None:
+                counters["skipped_parse"] += 1
+                continue
+
+            records.append(record)
+            distinct_codes.add(code)
+            counters["filtered_row_count"] += 1
+
+    return records, counters, distinct_codes, date_min, date_max
+
+
+# ---------------------------------------------------------------------------
+# HTTP POST
+# ---------------------------------------------------------------------------
+
+
+def _post_batch(
+    batch: list[dict],
+    url: str,
+    *,
+    timeout: float = 120.0,
+) -> tuple[bool, str]:
+    """POST a single batch envelope to the API.
+
+    The postprocessing API expects ``{"data": [<record>, ...]}`` per the
+    ``LRForecastBulkCreate`` schema. Returns ``(ok, message)``.
+    """
+    body = json.dumps({"data": batch}).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            return (200 <= resp.status < 300), f"HTTP {resp.status}"
+    except urllib.error.HTTPError as e:
+        body_txt = ""
+        with contextlib.suppress(Exception):
+            body_txt = e.read().decode("utf-8", errors="replace")[:200]
+        return False, f"HTTP {e.code}: {body_txt}"
+    except Exception as e:  # noqa: BLE001
+        return False, f"{type(e).__name__}: {e}"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python3 -m migration_py.lr_forecast",
+        description="Push LR-forecast CSV-export rows to the postprocessing API.",
+    )
+    p.add_argument(
+        "--csv-path",
+        required=True,
+        type=Path,
+        help="Path to the LR-forecast export CSV inside the container.",
+    )
+    p.add_argument(
+        "--api-url",
+        required=True,
+        help=("Postprocessing API endpoint URL (e.g. http://localhost:8003/lr-forecast/)."),
+    )
+    p.add_argument(
+        "--horizon",
+        required=True,
+        choices=sorted(_ALLOWED_HORIZONS),
+        help="Which lr_forecasts horizon this CSV represents.",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,
+        help="Records per POST batch (default 500).",
+    )
+    p.add_argument(
+        "--cutoff",
+        default=None,
+        help="ISO date; rows with date >= cutoff are dropped (pre-cutoff mode).",
+    )
+    p.add_argument(
+        "--station-filter",
+        default=None,
+        help="Filter to a single station code.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Read + filter only; do NOT POST.",
+    )
+    return p
+
+
+def _print_dry_run_inventory(
+    *,
+    csv_path: Path,
+    horizon: str,
+    counters: dict[str, int],
+    distinct_codes: set[str],
+    date_min: str | None,
+    date_max: str | None,
+    mode: str,
+    cutoff: str | None,
+) -> None:
+    """Emit the §4.4 runbook dry-run inventory block.
+
+    Lines are printed on stdout (the wrapper tees them into its log file).
+    Station codes are NEVER printed individually — only the redacted count
+    via ``log_redacted_station_count``.
+    """
+    print(f"MODE={mode}" + (f" (cutoff={cutoff})" if cutoff else " (target empty)"))
+    print("TARGET_TABLE=lr_forecasts")
+    print(f"HORIZON={horizon}")
+    print(f"CUTOFF={cutoff if cutoff else 'none'}")
+    print(f"SOURCE_FILES=['{csv_path}']")
+    print(f"SOURCE_ROW_COUNT={counters['source_row_count']}")
+    print(f"FILTERED_ROW_COUNT={counters['filtered_row_count']}")
+    print(f"SOURCE_DATE_MIN={date_min if date_min else 'none'}")
+    print(f"SOURCE_DATE_MAX={date_max if date_max else 'none'}")
+    print(f"DISTINCT_STATION_COUNT_REDACTED={len(distinct_codes)}")
+    print(
+        f"SKIPPED_PARSE={counters['skipped_parse']} "
+        f"SKIPPED_CUTOFF={counters['skipped_cutoff']} "
+        f"SKIPPED_STATION={counters['skipped_station']}"
+    )
+    # Redacted log line (count only, never the actual codes).
+    _common.log_redacted_station_count(
+        logger, sorted(distinct_codes), message_prefix="post_filter_stations"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    csv_path: Path = args.csv_path
+    if not csv_path.is_file():
+        print(f"ERROR: CSV not found: {csv_path}", file=sys.stderr)
+        return 1
+
+    horizon: str = args.horizon
+
+    # MODE is decided by the wrapper from the psql query; we just receive
+    # the cutoff (or None) and pass it through.
+    cutoff: str | None = args.cutoff
+    mode = "pre-cutoff" if cutoff else "full-import"
+
+    try:
+        records, counters, distinct_codes, date_min, date_max = _read_filtered_records(
+            csv_path,
+            horizon=horizon,
+            cutoff=cutoff,
+            station_filter=args.station_filter,
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    _print_dry_run_inventory(
+        csv_path=csv_path,
+        horizon=horizon,
+        counters=counters,
+        distinct_codes=distinct_codes,
+        date_min=date_min,
+        date_max=date_max,
+        mode=mode,
+        cutoff=cutoff,
+    )
+
+    if args.dry_run:
+        print("DRY RUN: no POSTs attempted.")
+        return 0
+
+    if not records:
+        print("No records to POST after filtering; exiting 0.")
+        return 0
+
+    n = len(records)
+    batch_size = max(1, args.batch_size)
+    n_batches = (n + batch_size - 1) // batch_size
+    sent = 0
+    failed = 0
+    for i in range(0, n, batch_size):
+        batch = records[i : i + batch_size]
+        batch_num = i // batch_size + 1
+        ok, msg = _post_batch(batch, args.api_url)
+        if ok:
+            sent += len(batch)
+        else:
+            failed += len(batch)
+            print(
+                f"  batch {batch_num}/{n_batches} FAILED: {msg}",
+                file=sys.stderr,
+            )
+        if batch_num % 20 == 0 or batch_num == n_batches:
+            print(f"  progress {batch_num}/{n_batches} ({sent}/{n} sent)")
+
+    print(f"GRAND TOTAL: sent={sent} failed={failed} (of {n} eligible records)")
+    return 0 if failed == 0 else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/utils/migration_py/lr_forecast.py
+++ b/bin/utils/migration_py/lr_forecast.py
@@ -164,6 +164,11 @@ def _build_record(row: dict[str, str], horizon: str) -> dict | None:
     are included in the returned dict. Required fields are always included
     when they parse.
 
+    Mixed-export guard (review feedback): if the CSV row carries its own
+    ``horizon_type`` column and it does not match the CLI ``horizon`` value
+    after case-normalization, the row is dropped (returns ``None``). Rows
+    without a ``horizon_type`` column fall through to trusting the CLI.
+
     Args:
         row: CSV row as ``{column_name: value_str}``.
         horizon: ``"pentad"`` or ``"decade"`` — selects the
@@ -171,11 +176,23 @@ def _build_record(row: dict[str, str], horizon: str) -> dict | None:
 
     Returns:
         A payload dict, or ``None`` if the row cannot satisfy the required
-        fields (caller treats this as a parse skip).
+        fields (caller treats this as a parse skip) OR if the row's
+        ``horizon_type`` column disagrees with ``horizon`` (caller treats
+        this as a horizon-mismatch skip).
     """
     if horizon not in _ALLOWED_HORIZONS:
         # Defensive: callers normalize this; raise an explicit error if not.
         raise ValueError(f"horizon must be one of {sorted(_ALLOWED_HORIZONS)}, got {horizon!r}")
+
+    # Mixed-export defense: when the CSV row carries an explicit horizon_type
+    # column, it must match the CLI flag. A mismatch is treated as a drop
+    # (returns None) rather than silently relabeling the payload from the CLI
+    # value (which would let mixed/tampered exports re-key target rows).
+    row_horizon_raw = row.get("horizon_type")
+    if row_horizon_raw is not None:
+        row_horizon = row_horizon_raw.strip().lower()
+        if row_horizon and row_horizon != horizon:
+            return None
 
     code = (row.get("code") or "").strip()
     date_str = (row.get("date") or "").strip()[:10]
@@ -253,7 +270,9 @@ def _read_filtered_records(
         "skipped_parse": 0,
         "skipped_cutoff": 0,
         "skipped_station": 0,
+        "skipped_horizon_mismatch": 0,
     }
+    horizon_mismatch_logged = False
     records: list[dict] = []
     distinct_codes: set[str] = set()
     date_min: str | None = None
@@ -300,6 +319,27 @@ def _read_filtered_records(
             if cutoff is not None and date_str >= cutoff:
                 counters["skipped_cutoff"] += 1
                 continue
+
+            # Horizon-mismatch pre-check (mixed-export defense — review feedback):
+            # if the CSV row's horizon_type column disagrees with the CLI flag,
+            # drop the row and account for it under a distinct counter. The
+            # first occurrence emits a single WARNING line so the operator can
+            # investigate; subsequent mismatches increment silently.
+            row_horizon_raw = row.get("horizon_type")
+            if row_horizon_raw is not None:
+                row_horizon = row_horizon_raw.strip().lower()
+                if row_horizon and row_horizon != horizon:
+                    counters["skipped_horizon_mismatch"] += 1
+                    if not horizon_mismatch_logged:
+                        print(
+                            f"WARNING: row code={code} date={date_str} carries "
+                            f"horizon_type={row_horizon!r} but --horizon={horizon!r}; "
+                            "dropping this row and any further mismatches "
+                            "(see SKIPPED_HORIZON_MISMATCH counter).",
+                            file=sys.stderr,
+                        )
+                        horizon_mismatch_logged = True
+                    continue
 
             record = _build_record(row, horizon)
             if record is None:
@@ -429,7 +469,8 @@ def _print_dry_run_inventory(
     print(
         f"SKIPPED_PARSE={counters['skipped_parse']} "
         f"SKIPPED_CUTOFF={counters['skipped_cutoff']} "
-        f"SKIPPED_STATION={counters['skipped_station']}"
+        f"SKIPPED_STATION={counters['skipped_station']} "
+        f"SKIPPED_HORIZON_MISMATCH={counters['skipped_horizon_mismatch']}"
     )
     # Redacted log line (count only, never the actual codes).
     _common.log_redacted_station_count(

--- a/doc/plans/issues/high_prio_gi_draft_update_migration_p4a_lr_forecast.md
+++ b/doc/plans/issues/high_prio_gi_draft_update_migration_p4a_lr_forecast.md
@@ -1,0 +1,524 @@
+# P4a - LR Forecast Laptop-Export Migration Wrappers
+
+**Status:** Implementation complete; PR open against `develop_migration_toolkit`.
+**Module:** infra (cross-module — bin/, apps/iEasyHydroForecast/tests/, doc/prod/, doc/plans/issues/)
+**Priority:** High
+**Branch:** `feature_p4a_lr_forecast_history` → `develop_migration_toolkit`
+**Labels:** `infra`, `tooling`, `tests`, `deployment-runbook`
+
+---
+
+## Summary
+
+Adds the laptop-export → CSV + manifest → server-import migration pipeline
+for the `lr_forecasts` rows of `sapphire-postprocessing-db`. P4a is the
+forecast-table sibling of P2a / P2b (runoff and hydrograph period
+laptop-exports), but with a critical difference in source database
+ownership: `lr_forecasts` lives in the postprocessing service, NOT in
+preprocessing. P4a is paired with the previously-committed server-side
+wrapper (`bin/initialize_lr_forecast_history.sh`) and Python helper
+(`bin/utils/migration_py/lr_forecast.py`) from the prior P4a sub-orch
+session; this PR completes the family by adding the laptop-export
+script, the tests, the sentinel fixtures, this gi_draft, and the runbook
+§6.3.
+
+The three P4a-specific concerns the gi_draft documents are:
+
+1. **Source DB is postprocessing-db, not preprocessing-db.** All prior
+   laptop-export wrappers (P2a runoff PENTAD/DECADE, P2b hydrograph
+   PENTAD/DECADE) pull from `sapphire-preprocessing-db`. P4a is the first
+   wrapper that targets `sapphire-postprocessing-db`, so the runbook,
+   the env-var defaults (PG* with the canonical dev port `5433` for the
+   postprocessing-db), and the acceptance SQL all point at the
+   postprocessing-db. Operators following the runbook in order from §6.2
+   to §6.3 must switch context.
+
+2. **`lr_forecasts` has no `model_type` column.** Unlike the sibling
+   `forecasts` table (which uses `model_type` to distinguish TFT / TiDE
+   / TSMixer / LR), `lr_forecasts` makes LR implicit: the unique key is
+   `(horizon_type, code, date)` only. This is the same architectural
+   decision that causes the P-postprocessing `combined_forecasts`
+   migrator to FILTER LR rows OUT of `combined_forecasts` (Stage A.2 §C
+   — the LR forecast of record lives in `lr_forecasts`, not in
+   `combined_forecasts`). The export `COPY (SELECT ...)` therefore does
+   NOT include `model_type`, the server-side helper actively rejects any
+   stray `model_type` cell in a malformed CSV (test
+   `test_build_record_does_not_emit_model_type`), and the fixture-guard
+   test pins the no-model_type contract.
+
+3. **Horizon-type enum is lowercase, architecturally locked (§Q4).**
+   `HorizonType` in `sapphire/services/postprocessing/app/models.py`
+   defines `PENTAD = "pentad"` and `DECADE = "decade"` (lowercase
+   values). Uppercase `'PENTAD'` / `'DECADE'` cells would be rejected at
+   the Pydantic boundary. The laptop export emits the lowercase form
+   via `lower(horizon_type::text)` in the COPY query, the wrapper
+   rejects any other `--horizon` value, and the server-side helper
+   double-checks the enum in `_build_record`. This contrasts with the
+   preprocessing-side `hydrographs.horizon_type` which uses the
+   uppercase `'PENTAD'` / `'DECADE'` form. Cross-table consistency is
+   not guaranteed; respect each table's enum case as locked.
+
+## Context
+
+The `lr_forecasts` table is the operational store for linear-regression
+forecasts produced by `apps/linear_regression`. Each row records a
+pentad-or-decade forecast plus its supporting model statistics. The row
+shape (from `LRForecastBase` in
+`sapphire/services/postprocessing/app/schemas.py`):
+
+- **Required:** `horizon_type ∈ {pentad, decade}`, `code`, `date`,
+  `horizon_value`, `horizon_in_year`.
+- **Nullable (9 fields):** `discharge_avg`, `predictor`, `slope`,
+  `intercept`, `forecasted_discharge`, `q_mean`, `q_std_sigma`,
+  `delta`, `rsquared`.
+- **Unique key:** `(horizon_type, code, date)`. NO `model_type`.
+
+The legacy in-container migrator
+(`sapphire/services/postprocessing/app/data_migrator.py::LRForecastDataMigrator`,
+lines ~276–331) reads a CSV with the legacy column names
+`pentad_in_month` / `pentad_in_year` (or `decad_in_month` /
+`decad_in_year`) and maps them to the DB's `horizon_value` /
+`horizon_in_year`. It has no station filter, no manifest concept, no
+per-horizon MODE branching, no station-code redaction in logs, and runs
+inside the postprocessing service container — wrong layer.
+
+P4a replaces operator use of that migrator with the standard
+laptop-export pattern from P0:
+
+- **Laptop side (`bin/export_lr_forecast_history.sh`):** pulls rows
+  from the laptop's local postprocessing-db via `psql -X` + `COPY`,
+  filtered by `--horizon` (lowercase enum) and optional
+  `--station-list-file`. Emits CSV + sidecar manifest with mode `0600`.
+  Location guard refuses on a deployment-server host.
+- **Server side (`bin/initialize_lr_forecast_history.sh`):** validates
+  the manifest first, queries the target postprocessing-db for MODE
+  detection, runs the Python helper inside the prepgateway container.
+- **Python helper (`bin/utils/migration_py/lr_forecast.py`):** stdlib-
+  only; reads CSV, applies cutoff + station filter, builds payloads
+  with the universal safe-write rule (omit NULL-like fields rather
+  than POSTing `null`), POSTs to `/lr-forecast/`.
+
+References:
+
+- Architecture plan §Q1 strategy table row for
+  `lr_forecasts:pentad,decade` (laptop-export).
+- Architecture plan §Q2 layer 2 safe-write rule for nullable
+  forecast-stat fields.
+- Architecture plan §Q3 laptop-export workflow shape.
+- Architecture plan §Q4 horizon-type enum lock (lowercase for
+  postprocessing tables).
+- Architecture plan §Q5 manifest contract (5 required keys validated
+  by `migration_py._common.validate_manifest`).
+- P0 foundation: PR #343 (merged `cd01339`).
+- Stage A.2 §C: combined_forecasts excludes LR rows because the LR
+  forecast of record lives in `lr_forecasts`.
+- Sibling P2a / P2b: laptop-export pattern for preprocessing-db tables
+  (runoff and hydrograph period).
+- Sibling P4b: laptop-export pattern for the
+  postprocessing-db `forecasts` table (ML rows: TFT / TiDE / TSMixer).
+  P4a and P4b together cover all postprocessing forecast-table
+  migrations.
+
+## Problem
+
+Operationally, an update-time migration that includes LR forecast
+history rows needs:
+
+1. **A station-filtered, deployment-aware export path** that does not
+   leak cross-org station codes from the laptop's source DB.
+2. **A manifest-validated server-side import path** so the operator
+   cannot accidentally push a stale or wrong-deployment CSV.
+3. **A safe-write story for the nine nullable model-stat fields** that
+   does not trigger the service-side `_has_changes` overwrite bug.
+4. **A horizon-aware MODE detection** so populated pentad targets do not
+   block decade imports (and vice versa).
+5. **A clear story for the postprocessing-db source** — runbook,
+   acceptance SQL, and per-wrapper context must point at port 5433 /
+   `postprocessing_db`, not the preprocessing equivalents that P2a /
+   P2b operators just finished using.
+
+The legacy in-container `data_migrator.py` cannot solve any of (1)–(5):
+no filter, no manifest, no MODE branching, no postprocessing-vs-
+preprocessing context (it lives inside the postprocessing service so
+the source/target are coupled), and it has a pandas dependency that
+disqualifies it from the stdlib-only sidecar pattern.
+
+## Desired Outcome
+
+After this PR merges to `develop_migration_toolkit`:
+
+- `bin/export_lr_forecast_history.sh` (~430 LOC) exists, mirroring the
+  P2b export pattern: positional env_file_path + `--horizon`,
+  `--output-dir`, `--station-list-file`, `--dry-run`. Location guard
+  refuses on a deployment-server host (Stage E #6); env-var bypass
+  (`_P4A_EXPORT_SKIP_LOCATION_GUARD=1`) for the test suite and explicit
+  `--i-am-on-laptop` flag for developer machines that intentionally
+  run the SAPPHIRE stack locally. SQL-injection guard rejects
+  apostrophes in station codes. Emits CSV + manifest pair with mode
+  `0600`.
+- `bin/initialize_lr_forecast_history.sh` (already in place from the
+  prior P4a sub-orch session; ~510 LOC) and
+  `bin/utils/migration_py/lr_forecast.py` (~515 LOC) — both ship as-is.
+- `apps/iEasyHydroForecast/tests/test_export_lr_forecast.py` (23
+  tests) covers the export wrapper CLI surface, argument validation,
+  location guard (positive + bypass), fixture round-trip, sentinel-
+  only check, no-model_type check, lowercase-horizon-type check.
+- `apps/iEasyHydroForecast/tests/test_initialize_lr_forecast.py` (30
+  tests) covers the import wrapper CLI surface, `_build_record` payload
+  shape per horizon, NULL handling for all 9 nullable fields, non-
+  finite-float rejection, `_read_filtered_records` filters,
+  `main()` dry-run inventory shape, no-model_type cross-check,
+  stdlib-only audit, fixture round-trip.
+- `apps/iEasyHydroForecast/tests/fixtures/migration_csv/lr_forecast/`
+  contains four files (pentad + decade CSV, each with a sentinel-only
+  manifest sibling). Sentinel code `19999` only.
+- `doc/prod/update_data_migration_runbook.md` has §6.3 written (~268
+  lines added between the §6 preamble and §7). §6.1 (P2a), §6.2 (P2b),
+  §6.4 (P4b), §6.5 (P5), §7+ untouched.
+- `shellcheck -x` zero findings on the new export wrapper (existing
+  wrapper already clean).
+- Full iEasyHydroForecast suite: 437 passed, 0 failed, 0 unexpected
+  skips. The one `skipif` (location-guard positive path on machines
+  without sapphire containers running) is NOT a hidden-bug skip per
+  the Zero Skips Policy: the predicate is explicit, deterministic,
+  and the message documents the condition.
+
+## Implementation Plan
+
+This PR was implemented per the sub-orchestrator charter v2 §2 with the
+watchdog-mitigation protocol (commit per phase). The first sub-orch
+session landed the server wrapper + Python module (commit `3f6debf`)
+before stalling on the watchdog. This continuation sub-orch session
+landed the remaining four phases:
+
+1. **`bin/export_lr_forecast_history.sh`** — commit `8e3cb7d`.
+2. **`apps/iEasyHydroForecast/tests/test_export_lr_forecast.py` +
+   `apps/iEasyHydroForecast/tests/test_initialize_lr_forecast.py` +
+   sentinel fixtures (pentad + decade CSV + manifest pairs)** — commit
+   `a440223`. Full iEasyHydroForecast suite: 437 passed.
+3. **`doc/prod/update_data_migration_runbook.md` §6.3** — commit
+   `66b9a02`. Inserted between §6 preamble and §7 without disturbing
+   sibling sections.
+4. **This gi_draft** — final commit; triggers PR open against
+   `develop_migration_toolkit`.
+
+## Key Design Decisions
+
+### Source DB is postprocessing-db, not preprocessing-db
+
+The wrapper docstring, the wrapper's MODE-detection psql block, the
+runbook §6.3 background, the acceptance SQL, and the operator-facing
+"Next steps" message all consistently point at
+`sapphire-postprocessing-db` / `postprocessing_db` / API port 8003.
+The laptop-export script does NOT itself open a Docker connection; it
+goes through standard PG* env vars + `~/.pgpass`, but the runbook
+explicitly notes the canonical dev port is `5433` (the laptop
+postprocessing-db) to avoid operator confusion between the two
+sapphire DB ports.
+
+### Column aliasing: DB `horizon_value` → CSV `pentad_in_month` / `decad_in_month`
+
+The `lr_forecasts` table has literal columns `horizon_value` and
+`horizon_in_year`. The legacy CSV-source flow used by
+`data_migrator.py::LRForecastDataMigrator` instead expects the names
+`pentad_in_month` / `pentad_in_year` (for pentad) or `decad_in_month` /
+`decad_in_year` (for decade). The export script's `COPY (SELECT ...)`
+aliases the DB columns OUT to the legacy CSV names so the server-side
+helper's column-mapping table finds them unchanged. This keeps the
+CSV shape uniform with the rest of the laptop-export family and means
+the Python helper does NOT need a special-case path for "we're on the
+DB-export path versus the legacy CSV path".
+
+Trade-offs:
+
+- **Pro:** Python helper has a single column-mapping table; one CSV
+  shape for both source paths.
+- **Pro:** the existing migration_py.lr_forecast module (from commit
+  `3f6debf`) requires zero changes.
+- **Con:** the export CSV's column names diverge slightly from the
+  underlying DB column names. Mitigated by the wrapper docstring and
+  the runbook §6.3 background explicitly documenting the aliasing.
+
+### Lowercase horizon_type enum (architecture §Q4)
+
+The Python helper, the wrapper's MODE psql query, and the export
+script's `COPY` all use lowercase `'pentad'` / `'decade'`. Uppercase
+would be silently dropped by the Pydantic boundary (the Pydantic
+`HorizonType` enum has value `'pentad'`, not `'PENTAD'`). The fixture
+files emit lowercase explicitly; the test
+`test_pentad_fixture_uses_lowercase_horizon_type` (and its decade
+sibling) pin this contract so a future regeneration of the fixture
+cannot drift to uppercase by accident.
+
+This intentionally contrasts with the preprocessing-side
+`hydrographs.horizon_type` which uses uppercase `'PENTAD'` /
+`'DECADE'`. Operators must respect each table's enum case as locked;
+the wrappers do not auto-coerce.
+
+### No `model_type` column in `lr_forecasts`
+
+The wrapper's `COPY (SELECT ...)` does NOT select `model_type` from
+the source DB (the column does not exist there). The Python helper's
+`_build_record` does NOT include `model_type` in the payload (even
+defensively when a stray cell appears in the CSV — see the test
+`test_build_record_does_not_emit_model_type`). The runbook §6.3
+background explicitly warns operators that "LR is implicit in this
+table".
+
+The downstream consequence (LR rows are filtered OUT of
+`combined_forecasts` by the P-postprocessing combined_forecasts
+migrator) is cross-linked in both the wrapper docstring and the
+runbook background, so operators reading the LR migration in
+sequence with the combined_forecasts migration understand why the
+counts will not add up to a naive expectation.
+
+### Location guard with two bypass paths
+
+The export wrapper checks for
+`sapphire-{preprocessing,postprocessing,api-gateway}-...` containers
+via `docker ps` and refuses if any are running (Stage E #6). Two
+bypass paths:
+
+- **`_P4A_EXPORT_SKIP_LOCATION_GUARD=1` env var.** Used only by the
+  test suite (`_run_wrapper` helper sets it by default), so
+  developer-laptop tests reach downstream validation paths. Explicitly
+  NOT set by operators.
+- **`--i-am-on-laptop` CLI flag.** For the developer machine that
+  intentionally runs the SAPPHIRE stack locally and the operator
+  *knows* the laptop is also the only DB host they have access to.
+  The flag prints a YELLOW WARNING to stderr to make the override
+  visible in logs.
+
+The test
+`test_location_guard_fires_when_sapphire_containers_present` exercises
+the positive path on machines where the guard CAN actually fire, and
+is skipif-gated on the developer-machine state — NOT a hidden-bug
+skip; the skip predicate is deterministic and documented.
+
+### Stat erasure not actively defended
+
+LR rows in practice tend to be either fully populated or fully missing
+per forecast-cycle output, so partial-NULL erasure is less of a
+concern than for the wide hydrograph rows. The universal safe-write
+rule (omit NULL-like fields rather than POSTing `null`) still applies;
+P4a does NOT ship a `--strict-merge` opt-in flag (which P2b did for
+hydrograph period rows). If operators observe stat erasure in LR
+production data, file a follow-up issue referencing this gi_draft.
+
+## Acceptance Criteria
+
+### A. Export wrapper
+
+- [x] `bin/export_lr_forecast_history.sh` exists; sources
+      `update_migration_helpers.sh`.
+- [x] CLI: positional `env_file_path`, required `--horizon pentad|decade`,
+      plus `--output-dir`, `--station-list-file`, `--dry-run`,
+      `--i-am-on-laptop`. Each flag rejects missing / invalid values.
+- [x] Location guard refuses with documented error when sapphire-*
+      containers are detected; env-var bypass for unit tests AND CLI
+      bypass (`--i-am-on-laptop`) for developer-laptop overrides.
+- [x] SQL-injection guard: a station code containing an apostrophe is
+      rejected with a clear error.
+- [x] PG env-var presence check fires before any DB connection attempt.
+- [x] Emits CSV (mode 0600) + sidecar manifest (mode 0600) with the 5
+      P0-required keys (`export_type=lr_forecast`, `row_count`,
+      `station_count`, `date_min`, `date_max`) plus a
+      `horizon=<value>` annotation.
+- [x] `shellcheck -x` zero findings.
+- [x] `bash bin/export_lr_forecast_history.sh --help` returns 0
+      with usage text.
+
+### B. Server-side import wrapper (already committed in `3f6debf`)
+
+- [x] `bin/initialize_lr_forecast_history.sh` exists; sources
+      `update_migration_helpers.sh`; uses `umh_resolve_image` /
+      `umh_acquire_temp_workspace` / `umh_log_redacted` /
+      `umh_print_image_resolution_line` /
+      `umh_validate_export_manifest`.
+- [x] CLI: positional env_file_path, required `--from-export`,
+      required `--horizon pentad|decade`, plus `--dry-run`,
+      `--api-url`, `--batch-size`, `--image`, `--station-filter`.
+- [x] `--station-filter <code>` honored (P0 binding contract).
+- [x] Manifest validation runs FIRST (before image work or psql).
+- [x] Per-horizon MODE detection against postprocessing-db's
+      `lr_forecasts` filtered on the lowercase `horizon_type`.
+- [x] `shellcheck -x` zero findings.
+
+### C. Python module (already committed in `3f6debf`)
+
+- [x] `bin/utils/migration_py/lr_forecast.py` exposes `main()`
+      publicly; helpers private (`_build_record`,
+      `_read_filtered_records`, `_post_batch`,
+      `_print_dry_run_inventory`, `_build_arg_parser`,
+      `_parse_float`, `_parse_int`).
+- [x] Stdlib-only (verified by
+      `test_lr_forecast_module_imports_only_stdlib_and_intra_package`).
+- [x] Refuses unknown horizon values with `ValueError`.
+- [x] No `model_type` in the payload even when present in the CSV row.
+
+### D. Tests
+
+- [x] All 437 iEasyHydroForecast tests pass.
+- [x] New P4a tests cover: CLI surfaces (export + import), payload
+      shape per horizon, NULL handling for all 9 nullable fields,
+      non-finite-float rejection, station / cutoff filters, dry-run
+      inventory shape, no-model_type cross-check, stdlib audit,
+      fixture round-trip, location guard (bypass + positive).
+- [x] Zero unexpected skips. The one `skipif` (location-guard positive
+      path) has a deterministic predicate and an explicit message.
+
+### E. Fixtures
+
+- [x] Four files in
+      `apps/iEasyHydroForecast/tests/fixtures/migration_csv/lr_forecast/`:
+      `pentad_sample.csv` + `pentad_sample.csv.manifest`,
+      `decade_sample.csv` + `decade_sample.csv.manifest`.
+- [x] Only sentinel code `19999`. Manifests added with `git add -f`
+      because the repo `.gitignore` excludes `*.manifest` globally
+      (a CI policy for operator-generated manifests); test fixtures
+      are safe to commit because they contain no real codes or values.
+- [x] Fixture-guard test (`test_migration_fixture_guard.py`) still
+      passes.
+- [x] Each fixture row uses lowercase `'pentad'` / `'decade'` for
+      `horizon_type` per architecture §Q4 lock.
+
+### F. Runbook
+
+- [x] §6.3 written between the §6 preamble and §7 in
+      `doc/prod/update_data_migration_runbook.md`.
+- [x] §6 preamble, §6.1 (P2a slot), §6.2 (P2b slot), §6.4 (P4b slot),
+      §6.5 (P5 slot), §7+ (P6/P7 territory), and all §5 subsections
+      untouched.
+- [x] Section explicitly notes "postprocessing-db, NOT preprocessing-db"
+      to prevent operator context confusion when reading §6.2 then §6.3
+      in sequence.
+- [x] Acceptance SQL points at `sapphire-postprocessing-db` /
+      `postprocessing_db` (correct DB).
+
+### G. Repo-wide
+
+- [x] No real station codes / discharge values / env-file contents
+      anywhere in modified files.
+- [x] No files outside the brief's file-scope list modified.
+- [x] No edits to `sapphire/services/` (Charter §10).
+- [x] PR opens against `develop_migration_toolkit`.
+
+## Testing
+
+### Unit tests
+
+53 functions across the two new test files, all green locally on the
+sub-orchestrator's worktree. CI will re-verify on the PR.
+
+The full iEasyHydroForecast suite (437 tests including new + existing
+P0/P1a/P1b/P1c/P3 migration tests) passes with zero failures and one
+deterministic skipif (location-guard positive path on machines
+without sapphire containers running).
+
+### Linting
+
+- Shellcheck: `shellcheck -x bin/export_lr_forecast_history.sh` clean
+  (verified via the pre-commit hook on the commit `8e3cb7d`).
+  `bin/initialize_lr_forecast_history.sh` was already clean from the
+  prior sub-orch session.
+- Ruff: pre-commit hook ran ruff on the test files at commit time
+  (reformatted them once during the Phase 2 commit, then passed
+  cleanly on the re-commit).
+
+### CI
+
+The new export wrapper falls under the migration-pattern regex of both
+the pre-commit hook
+(`^bin/(initialize_[a-z0-9_]+_history|export_[a-z0-9_]+_history)\.sh$`)
+and the `shellcheck_migration_scripts` CI job's glob
+(`bin/(initialize|export)_*_history.sh`). After this PR merges, the
+gate is scanning at least 5 wrappers (snow, runoff DAY, meteo,
+hydrograph DAY, plus this export script — once P2a/P2b/P4b/P5 also
+merge it will scan the rest).
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Operator runs the export script on the deployment server by accident | Location guard fires before any DB connection, with an explicit error message pointing at the server-side wrapper. Env-var bypass is documented as test-only; CLI bypass (`--i-am-on-laptop`) prints a YELLOW WARNING to stderr. |
+| Operator transfers only the CSV (not the manifest) | Server-side wrapper fails fast with `manifest file not found beside export CSV` before any image work. Manifest validation is the first server-side step. |
+| Stale CSV on the server (operator forgot to refresh after laptop DB updates) | Manifest validation checks `row_count`, `station_count`, `date_min`, `date_max` against the CSV's actual contents — date-range or row-count mismatch raises a typed exception. |
+| Cross-org station codes leak from laptop DB | Optional `--station-list-file` filter (export side) + `--station-filter` flag (server side) ensure only the deployment's codes are exported / imported. The manifest's `station_count` is the cross-check. |
+| Operator confuses postprocessing-db with preprocessing-db when running §6.2 then §6.3 in sequence | Runbook §6.3 has an explicit "POSTPROCESSING-DB, NOT preprocessing-db" call-out in the source description; the dev port note (5433) is included; acceptance SQL uses `sapphire-postprocessing-db`. |
+| Service-side `_has_changes` overwrites existing non-NULL stat with incoming NULL | Universal safe-write rule: only non-NULL source fields are POSTed. Cannot trigger the bug from this wrapper. |
+| Upper-case horizon_type cells leak through the CSV | The wrapper validates `--horizon ∈ {pentad,decade}`; the `COPY` emits `lower(horizon_type::text)`; the server-side helper double-checks the enum in `_build_record`. Test pins this on the fixture. |
+| Stray `model_type` cell in CSV silently overrides intent | `_build_record` does NOT include `model_type` in the payload even if present in the row dict. Test `test_build_record_does_not_emit_model_type` pins this. |
+| SQL injection via crafted station code | Station list file is line-by-line parsed; any line containing `'` triggers a hard reject before query construction. Documented in the wrapper. |
+
+## Out of Scope
+
+- `--strict-merge` (read-before-merge) opt-in — not added for P4a.
+  LR rows in practice are either fully populated or fully missing
+  per forecast-cycle, so partial-NULL erasure is less of a concern
+  than for hydrograph rows (P2b ships the stub flag; P4a does not).
+  If operators observe LR stat erasure, file a follow-up issue.
+- ML forecast (TFT / TiDE / TSMixer) migration — that's P4b
+  (`forecasts` table with `model_type`).
+- `combined_forecasts` migration — separate
+  (P-postprocessing-combined_forecasts) phase. Per Stage A.2 §C, LR
+  rows are filtered OUT of `combined_forecasts` because the LR
+  forecast of record lives here.
+- Service-side CRUD `_has_changes` fix — separate coordination with
+  `sapphire/services/` owner.
+- Disposable integration tests against a live docker stack —
+  architecture §Q7 says these belong to a separate sprint.
+- Modification of `data_migrator.py` — READ-ONLY reference; this
+  wrapper replaces operator use of it (architecture §Q1).
+
+## Dependencies
+
+- **Depends on:** P0 (foundation —
+  `bin/utils/update_migration_helpers.sh` +
+  `bin/utils/migration_py/_common.py`).
+- **Sibling to:** P2a (runoff PENTAD/DECADE — preprocessing-db
+  source), P2b (hydrograph PENTAD/DECADE — preprocessing-db source),
+  P4b (ML forecasts — postprocessing-db source, but for the
+  `forecasts` table with `model_type` instead of this dedicated
+  table), P5 (long forecasts).
+- **Blocks:** none directly. P6 (regenerate hooks) covers tables
+  that this wrapper does not (snow stats, hydrograph
+  MONTH/SEASON/QUARTER, short / long-term skill metrics).
+
+## References
+
+- Architecture plan §Q1, §Q2, §Q3, §Q4, §Q5 — strategy table,
+  safe-write rule, laptop-export workflow, horizon-type enum lock,
+  manifest contract.
+- P0 foundation: PR #343 (`cd01339`).
+- P2b sibling structure (laptop-export pattern): PR pending against
+  `develop_migration_toolkit` from `feature_p2b_hydrograph_period_history`
+  branch.
+- P4b sibling (ML forecasts on postprocessing-db `forecasts` table):
+  staged in `feature_p4b_ml_forecast_history` work.
+- LR schema: `sapphire/services/postprocessing/app/schemas.py`
+  (`LRForecastBase` lines 125–143).
+- LR model: `sapphire/services/postprocessing/app/models.py`
+  (`LRForecast` lines 160–192).
+- Legacy reference: `sapphire/services/postprocessing/app/data_migrator.py`
+  (`LRForecastDataMigrator` lines 276–331).
+- HorizonType enum lock: `sapphire/services/postprocessing/app/models.py`
+  lines 9–14.
+- Sub-orchestrator Charter v2:
+  `doc/plans/working/update_migration_suborchestrator_charter.md`.
+
+## Process note (sub-orchestrator)
+
+The P4a phase was split across two sub-orchestrator sessions per
+Charter v2's watchdog-mitigation protocol. The first session
+(commit `3f6debf`) landed the server wrapper + Python helper module
+before stalling on the 600s watchdog. This continuation sub-orch
+(Opus 4.7) picked up cleanly from `origin/feature_p4a_lr_forecast_history`
+HEAD `3f6debf` and completed the remaining four phases without any
+edits to the previously-committed files (file-scope discipline
+preserved per Charter §6). Each phase was committed individually
+(`8e3cb7d` export script; `a440223` tests + fixtures; `66b9a02`
+runbook §6.3; this commit gi_draft). After the runbook commit the
+branch was pushed to `origin/feature_p4a_lr_forecast_history`. No
+edits to `sapphire/services/` (Charter §10). The code-review skill
+was NOT run on the diff — operator + reviewers will surface any
+issues on the PR.

--- a/doc/prod/update_data_migration_runbook.md
+++ b/doc/prod/update_data_migration_runbook.md
@@ -609,6 +609,274 @@ cutoff. For full-import mode, both should match the source date range.
   containers are present (Stage E item #6 for export scripts).
 ]
 
+### 6.3 LR forecasts (linear regression — pentad / decade)
+
+Source: laptop's local `sapphire-postprocessing-db.lr_forecasts` table
+(**postprocessing-db, NOT preprocessing-db** — `lr_forecasts` is owned by
+the postprocessing service), filtered on `horizon_type IN ('pentad','decade')`
+(lowercase per architecture §Q4 enum lock) and optionally on the
+deployment's station list. Target: `lr_forecasts` rows with
+`horizon_type='pentad'` or `horizon_type='decade'` (one wrapper run per
+horizon). MODE branches on target state per-horizon — empty target =
+`full-import`; populated target = `pre-cutoff (cutoff=MIN(date))`. Reruns
+are idempotent (service-side upsert on `(horizon_type, code, date)`).
+
+#### Background
+
+The `lr_forecasts` table stores the operational linear-regression forecasts
+produced by `apps/linear_regression`. Each row records a pentad-or-decade
+forecast and its supporting model statistics. Required fields per row are
+`horizon_type`, `code`, `date`, `horizon_value`, `horizon_in_year`. Optional
+(nullable) model-stat fields are `discharge_avg`, `predictor`, `slope`,
+`intercept`, `forecasted_discharge`, `q_mean`, `q_std_sigma`, `delta`,
+`rsquared`.
+
+**No `model_type` column.** Unlike the `forecasts` table (which uses
+`model_type` to distinguish TFT / TiDE / TSMixer / LR rows), `lr_forecasts`
+has the DB unique key `(horizon_type, code, date)` — LR is implicit. This
+is also the reason the P-postprocessing `combined_forecasts` migrator
+filters LR rows OUT of `combined_forecasts` (Stage A.2 §C): the LR forecast
+of record lives here, in this dedicated table. The export script's
+`COPY (SELECT ...)` therefore does NOT emit a `model_type` column, and the
+server-side helper actively drops any stray `model_type` cell that happens
+to appear in a malformed CSV.
+
+**Horizon-type enum (architecture §Q4 lock).** The API accepts
+`HorizonType` values `'pentad'` and `'decade'` in lowercase. Uppercase
+`'PENTAD'` / `'DECADE'` would be rejected at the Pydantic boundary. The
+laptop export emits the lowercase form (`lower(horizon_type::text)` in
+the `COPY`), the wrapper rejects any other `--horizon` value, and the
+server-side helper double-checks the enum before constructing the
+payload.
+
+**Per-horizon column mapping (CSV legacy).** The `lr_forecasts` DB has
+literal columns `horizon_value` / `horizon_in_year`. The legacy CSV-source
+flow used in `data_migrator.py::LRForecastDataMigrator` instead expects
+the names `pentad_in_month` / `pentad_in_year` (or `decad_in_month` /
+`decad_in_year`). The export script ALIASES the DB columns out to the
+legacy CSV names so the server-side helper's column-mapping table finds
+them. This keeps the CSV shape uniform with the rest of the laptop-export
+family.
+
+**Safe-write policy (architecture §Q2 layer 2).** The wrapper sends only
+non-NULL source fields per the universal safe-write rule. The nine
+nullable model-stat fields are omitted from the payload whenever the
+source CSV cell is empty / `nan` / `null` / unparseable — never sent as
+`field: null`. The service-side `_has_changes + setattr` overwrite-with-
+NULL path is therefore not triggered by this wrapper. (LR rows in
+practice tend to be either fully populated or fully missing per
+forecast-cycle output, so partial-NULL erasure is uncommon for LR
+specifically; the universal rule still applies.)
+
+#### 6.3.1 Laptop side — export
+
+Run on the OPERATOR LAPTOP / jump host. The export script refuses to run
+on the deployment server (a
+`sapphire-{preprocessing,postprocessing,api-gateway}-...` container
+detected via `docker ps` triggers an explicit error — Stage E #6). For a
+developer machine that intentionally runs the SAPPHIRE stack locally,
+pass `--i-am-on-laptop` to acknowledge the override; operators do NOT
+set this in real workflows.
+
+Pre-requisites (per §3):
+
+- `~/.pgpass` mode `0600` with credentials for the laptop's
+  postprocessing-db. The canonical local dev port is `PGPORT=5433`.
+- `PGHOST` / `PGPORT` / `PGUSER` / `PGDATABASE` env vars set (no
+  password in CLI).
+- Optional `<station_list_file>` listing the deployment's station
+  codes, one per line. When supplied, `code IN (<list>)` is appended to
+  the `COPY` query so cross-org codes never leak. Generate from the
+  deployment's `intermediate_data/runoff_day.csv`
+  (e.g. `awk -F, 'NR>1 {print $1}' /data/<org>_data/intermediate_data/runoff_day.csv | sort -u > /tmp/stations.txt`).
+
+```bash
+# Pentad export, dry-run first to confirm the COUNT(*) matches expectations.
+bash bin/export_lr_forecast_history.sh ~/.env_<org> \
+    --horizon pentad \
+    --station-list-file /tmp/stations.txt \
+    --output-dir /tmp/lr_export \
+    --dry-run
+
+# If the count looks right, run without --dry-run:
+bash bin/export_lr_forecast_history.sh ~/.env_<org> \
+    --horizon pentad \
+    --station-list-file /tmp/stations.txt \
+    --output-dir /tmp/lr_export
+
+# Decade export (same flags; different --horizon).
+bash bin/export_lr_forecast_history.sh ~/.env_<org> \
+    --horizon decade \
+    --station-list-file /tmp/stations.txt \
+    --output-dir /tmp/lr_export
+```
+
+Each export emits TWO files in `<output-dir>`:
+
+```
+lr_forecast_<horizon>_<UTC_timestamp>.csv
+lr_forecast_<horizon>_<UTC_timestamp>.csv.manifest
+```
+
+Both files have mode `0600`. The manifest contains the 5 P0-required
+keys (`export_type=lr_forecast`, `row_count`, `station_count`, `date_min`,
+`date_max`) plus a `horizon=<pentad|decade>` annotation and a
+generation-timestamp comment. `station_count` and `date_min` / `date_max`
+are recomputed from the produced CSV (not the input station list), so
+manifest validation on the server side catches any mid-flight tampering.
+
+Transfer BOTH files together to the deployment server's data root logs
+directory (or wherever the operator chooses):
+
+```bash
+scp /tmp/lr_export/lr_forecast_pentad_*.csv* \
+    <user>@<server>:/data/<org>_data/logs/
+scp /tmp/lr_export/lr_forecast_decade_*.csv* \
+    <user>@<server>:/data/<org>_data/logs/
+```
+
+If only one file lands on the server, the server-side wrapper refuses
+with `manifest file not found beside export CSV`.
+
+#### 6.3.2 Server side — dry-run
+
+Validate the manifest, MODE, and filtered row count BEFORE any write:
+
+```bash
+bash bin/initialize_lr_forecast_history.sh "$ENV_FILE" \
+    --from-export /data/<org>_data/logs/lr_forecast_pentad_<UTC_timestamp>.csv \
+    --horizon pentad \
+    --dry-run
+```
+
+Expected inventory shape (per §4.4):
+
+```text
+MODE=<full-import (target empty) | pre-cutoff (cutoff=YYYY-MM-DD)>
+TARGET_TABLE=lr_forecasts
+HORIZON=<pentad|decade>
+CUTOFF=<date or none>
+SOURCE_FILES=['/lr_forecast.csv']
+SOURCE_ROW_COUNT=<n>
+FILTERED_ROW_COUNT=<n>
+SOURCE_DATE_MIN=<date>
+SOURCE_DATE_MAX=<date>
+DISTINCT_STATION_COUNT_REDACTED=<n>
+SKIPPED_PARSE=<n> SKIPPED_CUTOFF=<n> SKIPPED_STATION=<n>
+post_filter_stations: count=<n> (all redacted)
+IMAGE=mabesa/sapphire-prepgateway:<tag> source=<cli|configured|fallback>
+```
+
+If `HORIZON`, `MODE`, source counts, or `IMAGE` line look unexpected,
+STOP and investigate. Do NOT proceed to write.
+
+Common dry-run failure causes:
+
+- **Manifest validation error.** A typo in the station list file, a
+  stale CSV, or the wrong `--horizon` flag. The error names the failing
+  key (`row_count`, `station_count`, `date_min`, `date_max`, or
+  `export_type`). Re-run the laptop export to regenerate the manifest.
+- **`CSV is missing required column(s)`.** The CSV header is missing
+  the per-horizon column the helper expects: `pentad_in_month` /
+  `pentad_in_year` for `--horizon pentad`, or `decad_in_month` /
+  `decad_in_year` for `--horizon decade`. Most commonly caused by
+  invoking the wrapper with the wrong `--horizon` for the file.
+- **Empty `FILTERED_ROW_COUNT`.** Either the cutoff is later than the
+  source's `date_max`, the station-filter was set to a code not in the
+  CSV, or the station list excluded every code the laptop DB has LR
+  rows for. Inspect `SOURCE_ROW_COUNT`, `SOURCE_DATE_MAX`, and
+  `SKIPPED_*` to diagnose.
+
+#### 6.3.3 Canary (single station, per §4.3 acceptance criterion)
+
+Run with a single sentinel / low-risk station code before full
+population. Substitute `<code>` with the canary code (`19999` sentinel
+when available, otherwise a single low-risk operational code):
+
+```bash
+# Canary dry-run
+bash bin/initialize_lr_forecast_history.sh "$ENV_FILE" \
+    --from-export /data/<org>_data/logs/lr_forecast_pentad_<UTC_timestamp>.csv \
+    --horizon pentad \
+    --dry-run --station-filter <code>
+
+# Canary write (one station only)
+bash bin/initialize_lr_forecast_history.sh "$ENV_FILE" \
+    --from-export /data/<org>_data/logs/lr_forecast_pentad_<UTC_timestamp>.csv \
+    --horizon pentad \
+    --station-filter <code>
+```
+
+Verify the canary row count via the §8 acceptance SQL (filtered on the
+same `code`). Then proceed to full population.
+
+#### 6.3.4 Full population (per horizon)
+
+```bash
+# Pentad
+bash bin/initialize_lr_forecast_history.sh "$ENV_FILE" \
+    --from-export /data/<org>_data/logs/lr_forecast_pentad_<UTC_timestamp>.csv \
+    --horizon pentad
+
+# Decade
+bash bin/initialize_lr_forecast_history.sh "$ENV_FILE" \
+    --from-export /data/<org>_data/logs/lr_forecast_decade_<UTC_timestamp>.csv \
+    --horizon decade
+```
+
+Tunables:
+
+- `--batch-size <N>` — records per POST batch (default `500`). Lower to
+  diagnose API-side timeouts; raise if the API tolerates larger
+  envelopes.
+- `--api-url <URL>` — override target endpoint (default
+  `http://localhost:8003/lr-forecast/`). Note: this targets the
+  POSTPROCESSING API (port 8003), NOT the preprocessing API (8002).
+- `--image <IMAGE>` — pin a specific Docker image (overrides resolution
+  via env file's `ieasyhydroforecast_backend_docker_image_tag`).
+- `--station-filter <CODE>` — restrict the run to a single station code
+  (binding interface contract from P0; honored by all migration
+  wrappers).
+
+#### 6.3.5 Acceptance SQL pointer
+
+After completion (per horizon), run the §8 acceptance block. For a
+quick local check (note: postprocessing-db, not preprocessing-db):
+
+```bash
+docker exec -i sapphire-postprocessing-db \
+  psql -U postgres -d postprocessing_db -P pager=off <<SQL
+SELECT horizon_type, COUNT(*) AS rows,
+       COUNT(forecasted_discharge) AS forecast_rows,
+       COUNT(slope) AS slope_rows,
+       COUNT(intercept) AS intercept_rows,
+       COUNT(rsquared) AS rsquared_rows,
+       MIN(date), MAX(date)
+FROM lr_forecasts
+WHERE horizon_type IN ('pentad','decade')
+GROUP BY horizon_type
+ORDER BY horizon_type;
+SQL
+```
+
+Compare `rows` and `MAX(date)` against the dry-run's
+`FILTERED_ROW_COUNT` and `SOURCE_DATE_MAX`. `forecast_rows`,
+`slope_rows`, `intercept_rows`, `rsquared_rows` reflect the
+enrichment-only safe-write policy: an existing row whose stat field was
+already populated stays populated even if the new source row had that
+field absent. For pre-cutoff mode, expect `MIN(date)` to be the
+earliest source date AND `MAX(date)` to be one day before the prior
+cutoff. For full-import mode, both should match the source date range.
+
+#### 6.3.6 Idempotency and rerun
+
+The natural key `(horizon_type, code, date)` is upserted service-side,
+so rerunning the same wrapper with the same args is safe. To narrow a
+rerun on failure, combine `--station-filter <code>` with a smaller
+`--batch-size` (e.g. `--batch-size 200`). On the laptop side, re-export
+into a fresh `--output-dir` if the source DB has changed since the
+last export.
+
 ## 7. Regenerate / gap-backfill hooks
 
 [Filled by P6. Required content per architecture §Q10:


### PR DESCRIPTION
## Summary

Adds the laptop-export → CSV + manifest → server-import migration pipeline
for the `lr_forecasts` rows of `sapphire-postprocessing-db`. P4a is the
first laptop-export wrapper targeting the postprocessing service's tables
(sibling P2a / P2b target the preprocessing service); P4b will follow for
the ML rows in the `forecasts` table.

Three P4a-specific design points are documented in
`doc/plans/issues/high_prio_gi_draft_update_migration_p4a_lr_forecast.md`:

- **Source DB is `sapphire-postprocessing-db`** (NOT preprocessing-db).
  Runbook §6.3, the wrapper docstrings, and the acceptance SQL all
  point at port 8003 / `postprocessing_db`. Operators reading §6.2 →
  §6.3 in sequence must switch context.
- **`lr_forecasts` has NO `model_type` column.** Unique key is
  `(horizon_type, code, date)`; LR is implicit. (This is also why the
  P-postprocessing `combined_forecasts` migrator filters LR rows OUT
  of `combined_forecasts` per Stage A.2 §C.) The `COPY (SELECT ...)`
  does not include `model_type`; the server-side helper defensively
  rejects any stray `model_type` cell in a malformed CSV.
- **`horizon_type` enum is lowercase** (`'pentad'` / `'decade'`) per
  architecture §Q4 lock. Uppercase would be rejected at the Pydantic
  boundary. Contrasts with the preprocessing-side
  `hydrographs.horizon_type` which uses uppercase.

## Commits

- `3f6debf` — P4a: add LR forecast server wrapper + Python helper module
  (landed by prior sub-orch session before watchdog stall).
- `8e3cb7d` — P4a: add laptop-side export script for LR forecast history.
- `a440223` — P4a: add LR forecast tests + sentinel fixtures (53 tests,
  all green; full iEasyHydroForecast suite 437 passing).
- `66b9a02` — P4a: add §6.3 LR forecasts runbook section.
- `265d25b` — P4a: add gi_draft documenting the LR forecast laptop-
  export migration.

## File scope

- `bin/export_lr_forecast_history.sh` (NEW; ~582 LOC, shellcheck clean)
- `bin/initialize_lr_forecast_history.sh` (committed in `3f6debf`)
- `bin/utils/migration_py/lr_forecast.py` (committed in `3f6debf`)
- `apps/iEasyHydroForecast/tests/test_export_lr_forecast.py` (23 tests)
- `apps/iEasyHydroForecast/tests/test_initialize_lr_forecast.py` (30 tests)
- `apps/iEasyHydroForecast/tests/fixtures/migration_csv/lr_forecast/{pentad,decade}_sample.csv{,.manifest}`
- `doc/prod/update_data_migration_runbook.md` — §6.3 added between
  §6 preamble and §7; §6.1 / §6.2 / §6.4 untouched.
- `doc/plans/issues/high_prio_gi_draft_update_migration_p4a_lr_forecast.md`

## Test plan

- [x] `SAPPHIRE_TEST_ENV=True bash run_tests.sh iEasyHydroForecast`
  passes (437 passed, 0 failed, 0 unexpected skips). The single
  `skipif` (location-guard positive path on machines without the
  SAPPHIRE stack running) is deterministic and explicit — not a
  hidden-bug skip.
- [x] `shellcheck -x bin/export_lr_forecast_history.sh` clean (via
  pre-commit hook on the commit).
- [x] Ruff format + check pass on the new Python test files.
- [ ] Operator-side canary run on a staging deployment per runbook
  §6.3.3 (deferred to merge prep; cannot run in worktree).
- [ ] Acceptance SQL verification (§6.3.5) after canary.

## Charter compliance

- File-scope discipline preserved: no edits to the previously-
  committed `3f6debf` files; no edits to `sapphire/services/`
  (colleague-managed); no edits outside the brief's scope list.
- Sentinel codes only (`19999`); no real station codes / discharge
  values / env-file contents anywhere in modified files.
- Stage E item #2 (manifest validation) + #6 (location guard) +
  #11 (no test_*.py in fixtures) all enforced.