### PR TITLE
P2a: runoff PENTAD/DECADE laptop-export → CSV → API

### DIFF
--- a/apps/iEasyHydroForecast/tests/fixtures/migration_csv/runoff_period/decade_sample.csv
+++ b/apps/iEasyHydroForecast/tests/fixtures/migration_csv/runoff_period/decade_sample.csv
@@ -1,0 +1,4 @@
+horizon_type,code,date,discharge,predictor,horizon_value,horizon_in_year
+decade,19999,2026-01-01,12.5,11.8,1,1
+decade,19999,2026-01-11,13.4,12.7,2,2
+decade,19999,2026-01-21,14.6,13.9,3,3

--- a/apps/iEasyHydroForecast/tests/fixtures/migration_csv/runoff_period/decade_sample.csv.manifest
+++ b/apps/iEasyHydroForecast/tests/fixtures/migration_csv/runoff_period/decade_sample.csv.manifest
@@ -1,0 +1,7 @@
+# Fixture manifest for runoff_period (decade). Sentinel codes only.
+export_type=runoff_period
+horizon=decade
+row_count=3
+station_count=1
+date_min=2026-01-01
+date_max=2026-01-21

--- a/apps/iEasyHydroForecast/tests/fixtures/migration_csv/runoff_period/pentad_sample.csv
+++ b/apps/iEasyHydroForecast/tests/fixtures/migration_csv/runoff_period/pentad_sample.csv
@@ -1,0 +1,4 @@
+horizon_type,code,date,discharge,predictor,horizon_value,horizon_in_year
+pentad,19999,2026-01-01,12.5,11.8,1,1
+pentad,19999,2026-01-06,13.1,12.4,2,2
+pentad,19999,2026-01-11,14.2,13.6,3,3

--- a/apps/iEasyHydroForecast/tests/fixtures/migration_csv/runoff_period/pentad_sample.csv.manifest
+++ b/apps/iEasyHydroForecast/tests/fixtures/migration_csv/runoff_period/pentad_sample.csv.manifest
@@ -1,0 +1,7 @@
+# Fixture manifest for runoff_period (pentad). Sentinel codes only.
+export_type=runoff_period
+horizon=pentad
+row_count=3
+station_count=1
+date_min=2026-01-01
+date_max=2026-01-11

--- a/apps/iEasyHydroForecast/tests/test_export_runoff_period.py
+++ b/apps/iEasyHydroForecast/tests/test_export_runoff_period.py
@@ -372,3 +372,33 @@ def test_decade_csv_uses_discharge_not_discharge_avg():
     cols = [c.strip() for c in header.split(",")]
     assert "discharge" in cols
     assert "discharge_avg" not in cols
+
+
+def test_export_help_documents_i_am_on_laptop_flag():
+    """Review feedback: location-guard bypass MUST be operator-facing
+    --i-am-on-laptop (charter Stage E #6), not just a hidden env var."""
+    import subprocess
+
+    result = subprocess.run(
+        ["bash", str(_REPO_ROOT / "bin" / "export_runoff_period_history.sh"), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert "--i-am-on-laptop" in result.stdout
+
+
+def test_export_rejects_zero_row_filter():
+    """Review feedback: zero-row exports must abort with a clear error and no
+    manifest written. String-level check on the script source confirms the
+    early-exit lives between row_count computation and manifest emission."""
+    src = (_REPO_ROOT / "bin" / "export_runoff_period_history.sh").read_text(encoding="utf-8")
+    # The guard checks row_count -eq 0 and exits.
+    assert "row_count" in src and 'row_count" -eq 0' in src
+    # The operator-facing error message is specific.
+    assert "no rows matched filter" in src
+    # The early-exit lives BEFORE the manifest heredoc.
+    pre_manifest, _, post_manifest = src.partition('cat > "${manifest_path}"')
+    assert "no rows matched filter" in pre_manifest
+    assert "no rows matched filter" not in post_manifest

--- a/apps/iEasyHydroForecast/tests/test_export_runoff_period.py
+++ b/apps/iEasyHydroForecast/tests/test_export_runoff_period.py
@@ -1,0 +1,374 @@
+"""Tests for the P2a LAPTOP-SIDE export wrapper
+
+``bin/export_runoff_period_history.sh``.
+
+These tests exercise CLI surface, argument validation, and the location guard
+(Stage E #6). The wrapper's actual psql COPY path is integration-only and is
+NOT exercised here (architecture §Q7 — disposable integration is a separate
+sprint; the export script's real-DB code path is operator-tested via the
+runbook §6.1 canary).
+
+Sentinel codes (19999-class) only. No real station codes anywhere in this file.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Repo root: apps/iEasyHydroForecast/tests/test_*.py -> parents[3]
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT / "bin" / "utils"))
+
+from migration_py import _common  # noqa: E402
+
+_EXPORT_WRAPPER = _REPO_ROOT / "bin" / "export_runoff_period_history.sh"
+_FIXTURE_DIR = (
+    _REPO_ROOT
+    / "apps"
+    / "iEasyHydroForecast"
+    / "tests"
+    / "fixtures"
+    / "migration_csv"
+    / "runoff_period"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_wrapper(
+    args: list[str],
+    env: dict[str, str] | None = None,
+    *,
+    bypass_location_guard: bool = True,
+) -> subprocess.CompletedProcess:
+    """Invoke the export wrapper with the given args + env.
+
+    By default the location guard is bypassed (via the
+    ``_P2A_EXPORT_SKIP_LOCATION_GUARD=1`` testing-only env hook) so the
+    tests can exercise the wrapper's downstream validation paths even when
+    the developer laptop has the SAPPHIRE stack running locally. The
+    location guard itself is exercised in a dedicated positive test
+    (``test_location_guard_fires_when_sapphire_containers_present``).
+    """
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    if bypass_location_guard:
+        full_env["_P2A_EXPORT_SKIP_LOCATION_GUARD"] = "1"
+    return subprocess.run(
+        ["bash", str(_EXPORT_WRAPPER), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=full_env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Wrapper exists + --help returns 0
+# ---------------------------------------------------------------------------
+
+
+def test_export_wrapper_exists_on_disk():
+    assert _EXPORT_WRAPPER.is_file(), f"export wrapper missing: {_EXPORT_WRAPPER}"
+
+
+def test_export_wrapper_help_returns_zero_and_prints_usage():
+    result = _run_wrapper(["--help"])
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}: {result.stderr}"
+    assert "Usage" in result.stdout
+    # All three required flags are documented.
+    assert "--horizon" in result.stdout
+    assert "--stations-file" in result.stdout
+    assert "--out-dir" in result.stdout
+
+
+def test_export_wrapper_short_help_works():
+    result = _run_wrapper(["-h"])
+    assert result.returncode == 0
+    assert "Usage" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# 2. Argument validation
+# ---------------------------------------------------------------------------
+
+
+def test_export_wrapper_rejects_missing_horizon(tmp_path):
+    stations = tmp_path / "stations.txt"
+    stations.write_text("19999\n", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    result = _run_wrapper(["--stations-file", str(stations), "--out-dir", str(out_dir)])
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "--horizon" in combined or "horizon" in combined
+
+
+def test_export_wrapper_rejects_invalid_horizon(tmp_path):
+    stations = tmp_path / "stations.txt"
+    stations.write_text("19999\n", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    result = _run_wrapper(
+        [
+            "--horizon",
+            "month",  # not pentad/decade
+            "--stations-file",
+            str(stations),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+    assert result.returncode != 0
+
+
+def test_export_wrapper_rejects_missing_stations_file(tmp_path):
+    out_dir = tmp_path / "out"
+    result = _run_wrapper(["--horizon", "pentad", "--out-dir", str(out_dir)])
+    assert result.returncode != 0
+
+
+def test_export_wrapper_rejects_nonexistent_stations_file(tmp_path):
+    nonexistent = tmp_path / "no_such_stations.txt"
+    out_dir = tmp_path / "out"
+    result = _run_wrapper(
+        [
+            "--horizon",
+            "pentad",
+            "--stations-file",
+            str(nonexistent),
+            "--out-dir",
+            str(out_dir),
+        ],
+        env={
+            # Have to provide PG* env so we get past the env-var check;
+            # the actual failure should be on the stations file.
+            "PGHOST": "127.0.0.1",
+            "PGUSER": "postgres",
+            "PGDATABASE": "test",
+        },
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "stations" in combined or "not found" in combined
+
+
+def test_export_wrapper_rejects_missing_pg_env(tmp_path):
+    """When PGHOST/PGUSER/PGDATABASE are unset, refuse before doing anything."""
+    stations = tmp_path / "stations.txt"
+    stations.write_text("19999\n", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    # Explicitly UNSET PG vars. Use a minimal env. Bypass location guard
+    # so this developer-laptop test reaches the PG-env check.
+    result = subprocess.run(
+        [
+            "bash",
+            str(_EXPORT_WRAPPER),
+            "--horizon",
+            "pentad",
+            "--stations-file",
+            str(stations),
+            "--out-dir",
+            str(out_dir),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": os.environ.get("HOME", ""),
+            "_P2A_EXPORT_SKIP_LOCATION_GUARD": "1",
+        },
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "pghost" in combined or "pguser" in combined or "pgdatabase" in combined
+
+
+def test_export_wrapper_rejects_apostrophe_in_stations_file(tmp_path):
+    """SQL-injection guard: a station code containing an apostrophe is rejected."""
+    stations = tmp_path / "stations.txt"
+    # Intentionally include an apostrophe; the wrapper should reject.
+    stations.write_text("19999\nbad'code\n", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    result = _run_wrapper(
+        [
+            "--horizon",
+            "pentad",
+            "--stations-file",
+            str(stations),
+            "--out-dir",
+            str(out_dir),
+        ],
+        env={
+            "PGHOST": "127.0.0.1",
+            "PGUSER": "postgres",
+            "PGDATABASE": "test",
+        },
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "apostrophe" in combined or "injection" in combined or "reject" in combined
+
+
+# ---------------------------------------------------------------------------
+# 3. Location guard (Stage E #6)
+# ---------------------------------------------------------------------------
+
+
+def test_export_wrapper_help_mentions_location_guard():
+    """Help text documents the location-guard behavior so operators understand."""
+    result = _run_wrapper(["--help"])
+    assert result.returncode == 0
+    low = result.stdout.lower()
+    # Must mention "deployment server" or "laptop" or "jump host" so the
+    # operator knows where to run this.
+    assert "laptop" in low or "deployment" in low or "jump" in low
+
+
+def _sapphire_containers_present() -> bool:
+    """Return True iff at least one sapphire-* deployment container is running.
+
+    Used to decide whether to exercise the location guard's positive path
+    (it can only fire if the docker probe actually sees a container).
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "--filter", "name=sapphire-preprocessing-db", "--quiet"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return bool(result.stdout.strip())
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+@pytest.mark.skipif(
+    not _sapphire_containers_present(),
+    reason=(
+        "Location-guard positive test requires sapphire-* containers running "
+        "locally (developer laptop with the SAPPHIRE stack up). On CI / "
+        "clean machines this test is skipped because the guard physically "
+        "cannot fire without the trigger condition."
+    ),
+)
+def test_location_guard_fires_when_sapphire_containers_present(tmp_path):
+    """Positive path: with sapphire containers running AND the bypass NOT set,
+    the wrapper refuses with the documented deployment-server message.
+
+    This test depends on the developer machine state (the SAPPHIRE stack
+    must be up). It is automatically skipped where the guard cannot fire —
+    NOT a hidden-bug skip per the Zero Skips Policy; the skip predicate is
+    deterministic and the message is explicit.
+    """
+    stations = tmp_path / "stations.txt"
+    stations.write_text("19999\n", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    # Explicitly DO NOT pass the bypass env var.
+    result = _run_wrapper(
+        [
+            "--horizon",
+            "pentad",
+            "--stations-file",
+            str(stations),
+            "--out-dir",
+            str(out_dir),
+        ],
+        env={
+            "PGHOST": "127.0.0.1",
+            "PGUSER": "postgres",
+            "PGDATABASE": "test",
+        },
+        bypass_location_guard=False,
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    # The documented error message includes "deployment-server containers".
+    assert "deployment-server containers" in combined or "deployment server" in combined
+
+
+# ---------------------------------------------------------------------------
+# 4. Fixture sanity (sentinel-only)
+# ---------------------------------------------------------------------------
+
+
+def test_pentad_sample_fixture_sentinel_only():
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    assert csv.is_file(), f"fixture missing: {csv}"
+    text = csv.read_text(encoding="utf-8")
+    five_digit = re.findall(r"\b\d{5}\b", text)
+    allowed = {"19999"} | {f"0000{i}" for i in range(10)}
+    for code in five_digit:
+        assert code in allowed, f"non-sentinel code {code!r} found in fixture"
+
+
+def test_decade_sample_fixture_sentinel_only():
+    csv = _FIXTURE_DIR / "decade_sample.csv"
+    assert csv.is_file(), f"fixture missing: {csv}"
+    text = csv.read_text(encoding="utf-8")
+    five_digit = re.findall(r"\b\d{5}\b", text)
+    allowed = {"19999"} | {f"0000{i}" for i in range(10)}
+    for code in five_digit:
+        assert code in allowed, f"non-sentinel code {code!r} found in fixture"
+
+
+def test_pentad_sample_manifest_validates():
+    """The fixture manifest passes P0 manifest validation."""
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    result = _common.validate_manifest(csv, "runoff_period")
+    assert result["export_type"] == "runoff_period"
+    assert result["row_count"] == "3"
+    assert result["station_count"] == "1"
+    assert result["date_min"] == "2026-01-01"
+    assert result["date_max"] == "2026-01-11"
+
+
+def test_decade_sample_manifest_validates():
+    csv = _FIXTURE_DIR / "decade_sample.csv"
+    result = _common.validate_manifest(csv, "runoff_period")
+    assert result["export_type"] == "runoff_period"
+    assert result["row_count"] == "3"
+    assert result["station_count"] == "1"
+    assert result["date_min"] == "2026-01-01"
+    assert result["date_max"] == "2026-01-21"
+
+
+def test_pentad_fixture_rejects_wrong_export_type():
+    """Manifest validation should fail if the wrapper asks for a different type."""
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    with pytest.raises(_common.ManifestExportTypeMismatchError):
+        _common.validate_manifest(csv, "hydrograph_period")
+
+
+def test_pentad_csv_uses_discharge_not_discharge_avg():
+    """Schema correction check: the CSV header uses ``discharge`` (DB column
+    name), NOT ``discharge_avg`` (the CSV-source migrator name).
+
+    This locks in the brief's load-bearing column-name correction at the
+    fixture level so a future contributor cannot silently rename it back.
+    """
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    header = csv.read_text(encoding="utf-8").splitlines()[0]
+    cols = [c.strip() for c in header.split(",")]
+    assert "discharge" in cols, f"expected 'discharge' in CSV header, got: {cols}"
+    assert "discharge_avg" not in cols, (
+        f"CSV header must not use legacy CSV-migrator column 'discharge_avg', got: {cols}"
+    )
+
+
+def test_decade_csv_uses_discharge_not_discharge_avg():
+    """Same lock-in for the decade fixture (see pentad analog above)."""
+    csv = _FIXTURE_DIR / "decade_sample.csv"
+    header = csv.read_text(encoding="utf-8").splitlines()[0]
+    cols = [c.strip() for c in header.split(",")]
+    assert "discharge" in cols
+    assert "discharge_avg" not in cols

--- a/apps/iEasyHydroForecast/tests/test_export_runoff_period.py
+++ b/apps/iEasyHydroForecast/tests/test_export_runoff_period.py
@@ -402,3 +402,60 @@ def test_export_rejects_zero_row_filter():
     pre_manifest, _, post_manifest = src.partition('cat > "${manifest_path}"')
     assert "no rows matched filter" in pre_manifest
     assert "no rows matched filter" not in post_manifest
+
+
+def test_export_rejects_zero_row_behaviorally(tmp_path):
+    """Round-2 review feedback: prior zero-row test was source-text only.
+    This stubs psql via PATH so the wrapper actually runs through its
+    post-COPY control flow with a header-only CSV, verifying behavior
+    (non-zero exit, error message, no manifest written)."""
+    import os
+    import stat
+
+    fake_bin = tmp_path / "fake_bin"
+    fake_bin.mkdir()
+    fake_psql = fake_bin / "psql"
+    fake_psql.write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "horizon_type,code,date,discharge,predictor,horizon_value,horizon_in_year"\n'
+        "exit 0\n"
+    )
+    fake_psql.chmod(fake_psql.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    stations = tmp_path / "stations.txt"
+    stations.write_text("19999\n")
+    out_dir = tmp_path / "out"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    env["PGHOST"] = "127.0.0.1"
+    env["PGUSER"] = "postgres"
+    env["PGDATABASE"] = "test"
+    env["_P2A_EXPORT_SKIP_LOCATION_GUARD"] = "1"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(_REPO_ROOT / "bin" / "export_runoff_period_history.sh"),
+            "--horizon",
+            "pentad",
+            "--stations-file",
+            str(stations),
+            "--out-dir",
+            str(out_dir),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+    assert result.returncode != 0, (
+        f"expected non-zero exit on zero-row export, got {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    combined = (result.stdout + result.stderr).lower()
+    assert "no rows matched filter" in combined
+    # Manifest sidecar must NOT exist (guard runs BEFORE manifest write).
+    manifests = list(out_dir.glob("*.manifest")) if out_dir.exists() else []
+    assert manifests == [], f"manifest should not exist after zero-row reject, got {manifests}"

--- a/apps/iEasyHydroForecast/tests/test_initialize_runoff_period.py
+++ b/apps/iEasyHydroForecast/tests/test_initialize_runoff_period.py
@@ -1,0 +1,812 @@
+"""Tests for the P2a SERVER-SIDE import wrapper +
+``migration_py.runoff_period``.
+
+Covers:
+- Bash wrapper CLI surface (--help, missing env file rejection, --from-export
+  + --horizon required-flag enforcement, --station-filter contract).
+- ``_build_record`` payload shape per HORIZON: required fields, optional
+  ``discharge`` / ``predictor`` (NULL handling).
+- DB column name correction: ``discharge`` (NOT ``discharge_avg``).
+- ``_read_filtered_records_with_manifest`` filters (cutoff, station_filter),
+  manifest validation failures bubble up cleanly.
+- ``main()`` dry-run output shape per the §4.4 inventory contract.
+- Stdlib-only import audit covers runoff_period.
+
+Integration against a live docker stack is out of scope per architecture §Q7
+(disposable integration belongs to a separate sprint). The wrapper's
+docker-run path is exercised manually in the runbook §6.1 canary.
+
+Sentinel codes (19999-class) only.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Repo root: apps/iEasyHydroForecast/tests/test_*.py -> parents[3]
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT / "bin" / "utils"))
+
+from migration_py import _common, runoff_period  # noqa: E402
+
+_WRAPPER = _REPO_ROOT / "bin" / "initialize_runoff_period_history.sh"
+_FIXTURE_DIR = (
+    _REPO_ROOT
+    / "apps"
+    / "iEasyHydroForecast"
+    / "tests"
+    / "fixtures"
+    / "migration_csv"
+    / "runoff_period"
+)
+
+
+# ---------------------------------------------------------------------------
+# CSV helper
+# ---------------------------------------------------------------------------
+
+_DEFAULT_HEADER = [
+    "horizon_type",
+    "code",
+    "date",
+    "discharge",
+    "predictor",
+    "horizon_value",
+    "horizon_in_year",
+]
+
+
+def _write_csv_and_manifest(
+    tmp_path: Path,
+    rows: list[dict[str, str]],
+    *,
+    horizon: str = "pentad",
+    header: list[str] | None = None,
+    manifest_override: dict[str, str] | None = None,
+    csv_name: str = "fixture.csv",
+) -> tuple[Path, Path]:
+    """Write a CSV + matching manifest. Returns (csv_path, manifest_path).
+
+    If `manifest_override` is supplied, those keys override the auto-computed
+    manifest fields (useful for testing manifest validation failures).
+    """
+    if header is None:
+        header = list(_DEFAULT_HEADER)
+    csv_path = tmp_path / csv_name
+    lines = [",".join(header)]
+    for row in rows:
+        lines.append(",".join(row.get(col, "") for col in header))
+    csv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    # Auto-compute manifest fields from the written rows.
+    codes: set[str] = set()
+    dates: list[str] = []
+    for row in rows:
+        c = (row.get("code") or "").strip()
+        if c:
+            codes.add(c)
+        d = (row.get("date") or "").strip()
+        if d:
+            dates.append(d)
+    manifest_fields = {
+        "export_type": "runoff_period",
+        "horizon": horizon,
+        "row_count": str(len(rows)),
+        "station_count": str(len(codes)),
+        "date_min": min(dates) if dates else "1970-01-01",
+        "date_max": max(dates) if dates else "1970-01-01",
+    }
+    if manifest_override:
+        manifest_fields.update(manifest_override)
+
+    manifest_path = tmp_path / (csv_name + ".manifest")
+    manifest_path.write_text(
+        "\n".join(f"{k}={v}" for k, v in manifest_fields.items()) + "\n",
+        encoding="utf-8",
+    )
+    return csv_path, manifest_path
+
+
+# ===========================================================================
+# 1. Wrapper CLI surface
+# ===========================================================================
+
+
+def test_wrapper_exists_on_disk():
+    assert _WRAPPER.is_file(), f"wrapper missing: {_WRAPPER}"
+
+
+def test_wrapper_help_returns_zero_and_prints_usage():
+    result = subprocess.run(
+        ["bash", str(_WRAPPER), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}: {result.stderr}"
+    assert "Usage" in result.stdout
+    # All P2a-specific flags are documented.
+    assert "--from-export" in result.stdout
+    assert "--horizon" in result.stdout
+    assert "--station-filter" in result.stdout
+
+
+def test_wrapper_rejects_missing_env_file(tmp_path):
+    nonexistent = tmp_path / "no_such_env_file"
+    csv = tmp_path / "x.csv"
+    csv.write_text(",".join(_DEFAULT_HEADER) + "\n", encoding="utf-8")
+    result = subprocess.run(
+        [
+            "bash",
+            str(_WRAPPER),
+            str(nonexistent),
+            "--from-export",
+            str(csv),
+            "--horizon",
+            "pentad",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "env file" in combined or "not found" in combined
+
+
+def test_wrapper_rejects_missing_from_export(tmp_path):
+    env = tmp_path / "fake.env"
+    env.write_text("# stub\n", encoding="utf-8")
+    result = subprocess.run(
+        ["bash", str(_WRAPPER), str(env), "--horizon", "pentad"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "from-export" in combined or "required" in combined
+
+
+def test_wrapper_rejects_missing_horizon(tmp_path):
+    env = tmp_path / "fake.env"
+    env.write_text("# stub\n", encoding="utf-8")
+    csv = tmp_path / "x.csv"
+    csv.write_text("\n", encoding="utf-8")
+    result = subprocess.run(
+        ["bash", str(_WRAPPER), str(env), "--from-export", str(csv)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "horizon" in combined
+
+
+def test_wrapper_rejects_invalid_horizon(tmp_path):
+    env = tmp_path / "fake.env"
+    env.write_text("# stub\n", encoding="utf-8")
+    csv = tmp_path / "x.csv"
+    csv.write_text("\n", encoding="utf-8")
+    result = subprocess.run(
+        [
+            "bash",
+            str(_WRAPPER),
+            str(env),
+            "--from-export",
+            str(csv),
+            "--horizon",
+            "day",  # not pentad/decade — DAY is P1a's territory
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+
+
+def test_wrapper_help_documents_station_filter_contract():
+    """The --station-filter flag is the P0 binding contract; must be documented."""
+    result = subprocess.run(
+        ["bash", str(_WRAPPER), "-h"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert "--station-filter" in result.stdout
+    assert (
+        "contract" in result.stdout.lower()
+        or "interface" in result.stdout.lower()
+        or "binding" in result.stdout.lower()
+    )
+
+
+# ===========================================================================
+# 2. Fixture sanity
+# ===========================================================================
+
+
+def test_pentad_sample_fixture_only_sentinel_codes():
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    assert csv.is_file()
+    text = csv.read_text(encoding="utf-8")
+    five_digit = re.findall(r"\b\d{5}\b", text)
+    allowed = {"19999"} | {f"0000{i}" for i in range(10)}
+    for code in five_digit:
+        assert code in allowed, f"non-sentinel code {code!r} found in fixture"
+
+
+def test_decade_sample_fixture_only_sentinel_codes():
+    csv = _FIXTURE_DIR / "decade_sample.csv"
+    assert csv.is_file()
+    text = csv.read_text(encoding="utf-8")
+    five_digit = re.findall(r"\b\d{5}\b", text)
+    allowed = {"19999"} | {f"0000{i}" for i in range(10)}
+    for code in five_digit:
+        assert code in allowed, f"non-sentinel code {code!r} found in fixture"
+
+
+# ===========================================================================
+# 3. _build_record — payload shape
+# ===========================================================================
+
+
+def test_build_record_pentad_includes_required_fields():
+    """All RunoffBase required fields are emitted for a PENTAD record."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "horizon_value": "1",
+        "horizon_in_year": "1",
+        "discharge": "12.5",
+    }
+    rec = runoff_period._build_record(row, "pentad")
+    assert rec is not None
+    assert rec["horizon_type"] == "pentad"
+    assert rec["code"] == "19999"
+    assert rec["date"] == "2026-01-01"
+    assert rec["horizon_value"] == 1
+    assert rec["horizon_in_year"] == 1
+    assert rec["discharge"] == 12.5
+
+
+def test_build_record_decade_horizon_type_value():
+    """DECADE input produces ``horizon_type='decade'``."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "horizon_value": "1",
+        "horizon_in_year": "1",
+    }
+    rec = runoff_period._build_record(row, "decade")
+    assert rec is not None
+    assert rec["horizon_type"] == "decade"
+
+
+def test_build_record_rejects_unknown_horizon():
+    """Anything other than 'pentad'/'decade' returns None."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "horizon_value": "1",
+        "horizon_in_year": "1",
+    }
+    # 'month' is reserved for the LT regenerate hook; this module rejects it.
+    assert runoff_period._build_record(row, "month") is None
+    assert runoff_period._build_record(row, "day") is None
+
+
+def test_build_record_returns_none_for_missing_required():
+    """Row missing code / date / one of the horizon-required ints -> None."""
+    base = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "horizon_value": "1",
+        "horizon_in_year": "1",
+    }
+    # Missing code.
+    bad = dict(base)
+    bad["code"] = ""
+    assert runoff_period._build_record(bad, "pentad") is None
+    # Missing date.
+    bad = dict(base)
+    bad["date"] = ""
+    assert runoff_period._build_record(bad, "pentad") is None
+    # Unparseable date.
+    bad = dict(base)
+    bad["date"] = "not-a-date"
+    assert runoff_period._build_record(bad, "pentad") is None
+    # Missing horizon_value (int).
+    bad = dict(base)
+    bad["horizon_value"] = ""
+    assert runoff_period._build_record(bad, "pentad") is None
+    # Missing horizon_in_year.
+    bad = dict(base)
+    bad["horizon_in_year"] = ""
+    assert runoff_period._build_record(bad, "pentad") is None
+
+
+def test_build_record_pentad_includes_predictor_when_present():
+    """When predictor is non-NULL in the CSV, it appears in the record."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "horizon_value": "1",
+        "horizon_in_year": "1",
+        "discharge": "12.5",
+        "predictor": "11.8",
+    }
+    rec = runoff_period._build_record(row, "pentad")
+    assert rec is not None
+    assert rec["discharge"] == 12.5
+    assert rec["predictor"] == 11.8
+
+
+def test_build_record_excludes_null_discharge_and_predictor():
+    """``discharge`` / ``predictor`` with NULL/empty/NaN source value are OMITTED."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "horizon_value": "1",
+        "horizon_in_year": "1",
+        "discharge": "",  # NULL
+        "predictor": "nan",  # null-like
+    }
+    rec = runoff_period._build_record(row, "pentad")
+    assert rec is not None
+    # NULL fields must be ABSENT, not present-with-null.
+    assert "discharge" not in rec
+    assert "predictor" not in rec
+    # Required fields are still present.
+    assert rec["horizon_type"] == "pentad"
+    assert rec["code"] == "19999"
+
+
+def test_build_record_uses_discharge_not_discharge_avg():
+    """Schema correction: the payload key is ``discharge``, not ``discharge_avg``.
+
+    This is the load-bearing schema check called out in the brief: an
+    earlier version mistakenly used ``discharge_avg``. The actual DB column
+    on ``runoffs`` is ``discharge`` (and the API field on RunoffBase is
+    ``discharge``). The CSV header uses ``discharge`` as well — there is
+    no rename anywhere in this module.
+    """
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "horizon_value": "1",
+        "horizon_in_year": "1",
+        "discharge": "12.5",
+        "discharge_avg": "99.9",  # legacy CSV-source migrator name — should NOT be used
+    }
+    rec = runoff_period._build_record(row, "pentad")
+    assert rec is not None
+    assert rec["discharge"] == 12.5
+    # The legacy name must NEVER leak into the payload.
+    assert "discharge_avg" not in rec
+
+
+def test_build_record_rejects_non_finite_floats():
+    """NaN / +/-Inf source values are rejected as None (cannot JSON-serialize)."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "horizon_value": "1",
+        "horizon_in_year": "1",
+        "discharge": "inf",
+    }
+    rec = runoff_period._build_record(row, "pentad")
+    assert rec is not None
+    assert "discharge" not in rec
+
+
+# ===========================================================================
+# 4. _read_filtered_records_with_manifest — filtering + manifest validation
+# ===========================================================================
+
+
+def test_read_filtered_records_happy_path_pentad(tmp_path):
+    csv, manifest = _write_csv_and_manifest(
+        tmp_path,
+        [
+            {
+                "code": "19999",
+                "date": "2026-01-01",
+                "horizon_value": "1",
+                "horizon_in_year": "1",
+                "discharge": "12.5",
+            },
+            {
+                "code": "19999",
+                "date": "2026-01-06",
+                "horizon_value": "2",
+                "horizon_in_year": "2",
+                "discharge": "13.1",
+            },
+        ],
+        horizon="pentad",
+    )
+    records, counters, codes, dmin, dmax = runoff_period._read_filtered_records_with_manifest(
+        csv, manifest, "pentad", cutoff=None, station_filter=None
+    )
+    assert counters["source_row_count"] == 2
+    assert counters["filtered_row_count"] == 2
+    assert codes == {"19999"}
+    assert dmin == "2026-01-01"
+    assert dmax == "2026-01-06"
+    assert all(r["horizon_type"] == "pentad" for r in records)
+    # Every record has ``discharge`` populated (since the source had it).
+    assert all("discharge" in r for r in records)
+
+
+def test_read_filtered_records_station_filter(tmp_path):
+    csv, manifest = _write_csv_and_manifest(
+        tmp_path,
+        [
+            {
+                "code": "19999",
+                "date": "2026-01-01",
+                "horizon_value": "1",
+                "horizon_in_year": "1",
+            },
+            {
+                "code": "19999",
+                "date": "2026-01-06",
+                "horizon_value": "2",
+                "horizon_in_year": "2",
+            },
+            {
+                "code": "00000",
+                "date": "2026-01-11",
+                "horizon_value": "3",
+                "horizon_in_year": "3",
+            },
+        ],
+        horizon="pentad",
+    )
+    records, counters, codes, _, _ = runoff_period._read_filtered_records_with_manifest(
+        csv, manifest, "pentad", cutoff=None, station_filter="19999"
+    )
+    assert counters["source_row_count"] == 3
+    assert counters["filtered_row_count"] == 2
+    assert counters["skipped_station"] == 1
+    assert codes == {"19999"}
+    for rec in records:
+        assert rec["code"] == "19999"
+
+
+def test_read_filtered_records_cutoff_drops_on_or_after(tmp_path):
+    csv, manifest = _write_csv_and_manifest(
+        tmp_path,
+        [
+            {
+                "code": "19999",
+                "date": "2026-01-01",
+                "horizon_value": "1",
+                "horizon_in_year": "1",
+            },
+            {
+                "code": "19999",
+                "date": "2026-01-06",
+                "horizon_value": "2",
+                "horizon_in_year": "2",
+            },
+            {
+                "code": "19999",
+                "date": "2026-01-11",
+                "horizon_value": "3",
+                "horizon_in_year": "3",
+            },
+        ],
+        horizon="pentad",
+    )
+    records, counters, _, _, _ = runoff_period._read_filtered_records_with_manifest(
+        csv, manifest, "pentad", cutoff="2026-01-06", station_filter=None
+    )
+    # Only the row strictly < cutoff survives.
+    assert counters["filtered_row_count"] == 1
+    assert counters["skipped_cutoff"] == 2
+    assert records[0]["date"] == "2026-01-01"
+
+
+def test_read_filtered_records_rejects_csv_missing_required_columns(tmp_path):
+    bad = tmp_path / "bad.csv"
+    bad.write_text("code,date\n19999,2026-01-01\n", encoding="utf-8")
+    manifest = tmp_path / "bad.csv.manifest"
+    manifest.write_text(
+        "export_type=runoff_period\nrow_count=1\nstation_count=1\n"
+        "date_min=2026-01-01\ndate_max=2026-01-01\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="missing required column"):
+        runoff_period._read_filtered_records_with_manifest(
+            bad, manifest, "pentad", cutoff=None, station_filter=None
+        )
+
+
+def test_read_filtered_records_manifest_missing_raises(tmp_path):
+    """If the manifest file is absent, validation raises a ManifestMissingError."""
+    csv = tmp_path / "lonely.csv"
+    csv.write_text(",".join(_DEFAULT_HEADER) + "\n", encoding="utf-8")
+    with pytest.raises(_common.ManifestMissingError):
+        runoff_period._read_filtered_records_with_manifest(
+            csv,
+            tmp_path / "lonely.csv.manifest",
+            "pentad",
+            cutoff=None,
+            station_filter=None,
+        )
+
+
+def test_read_filtered_records_manifest_row_count_mismatch_raises(tmp_path):
+    csv, _ = _write_csv_and_manifest(
+        tmp_path,
+        [
+            {
+                "code": "19999",
+                "date": "2026-01-01",
+                "horizon_value": "1",
+                "horizon_in_year": "1",
+            },
+        ],
+        horizon="pentad",
+        manifest_override={"row_count": "999"},
+    )
+    with pytest.raises(_common.ManifestRowCountMismatchError):
+        runoff_period._read_filtered_records_with_manifest(
+            csv,
+            csv.with_name(csv.name + ".manifest"),
+            "pentad",
+            cutoff=None,
+            station_filter=None,
+        )
+
+
+def test_read_filtered_records_manifest_wrong_export_type_raises(tmp_path):
+    """A manifest claiming hydrograph_period on a runoff_period wrapper is rejected."""
+    csv, _ = _write_csv_and_manifest(
+        tmp_path,
+        [
+            {
+                "code": "19999",
+                "date": "2026-01-01",
+                "horizon_value": "1",
+                "horizon_in_year": "1",
+            },
+        ],
+        horizon="pentad",
+        manifest_override={"export_type": "hydrograph_period"},
+    )
+    with pytest.raises(_common.ManifestExportTypeMismatchError):
+        runoff_period._read_filtered_records_with_manifest(
+            csv,
+            csv.with_name(csv.name + ".manifest"),
+            "pentad",
+            cutoff=None,
+            station_filter=None,
+        )
+
+
+# ===========================================================================
+# 5. main() dry-run output shape
+# ===========================================================================
+
+
+def test_main_dry_run_with_station_filter_reduces_filtered_count(tmp_path, capsys):
+    csv, manifest = _write_csv_and_manifest(
+        tmp_path,
+        [
+            {
+                "code": "19999",
+                "date": "2026-01-01",
+                "horizon_value": "1",
+                "horizon_in_year": "1",
+            },
+            {
+                "code": "19999",
+                "date": "2026-01-06",
+                "horizon_value": "2",
+                "horizon_in_year": "2",
+            },
+            {
+                "code": "00000",
+                "date": "2026-01-11",
+                "horizon_value": "3",
+                "horizon_in_year": "3",
+            },
+        ],
+        horizon="pentad",
+    )
+    exit_code = runoff_period.main(
+        [
+            "--csv-path",
+            str(csv),
+            "--manifest-path",
+            str(manifest),
+            "--horizon",
+            "pentad",
+            "--api-url",
+            "http://localhost:8002/runoff/",
+            "--station-filter",
+            "19999",
+            "--dry-run",
+        ]
+    )
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "SOURCE_ROW_COUNT=3" in out
+    assert "FILTERED_ROW_COUNT=2" in out
+    assert "MODE=full-import" in out
+    assert "DISTINCT_STATION_COUNT_REDACTED=1" in out
+    assert "TARGET_TABLE=runoffs" in out
+    assert "HORIZON_TYPE=PENTAD" in out
+
+
+def test_main_dry_run_with_cutoff_emits_pre_cutoff(tmp_path, capsys):
+    csv, manifest = _write_csv_and_manifest(
+        tmp_path,
+        [
+            {
+                "code": "19999",
+                "date": "2026-01-01",
+                "horizon_value": "1",
+                "horizon_in_year": "1",
+            },
+            {
+                "code": "19999",
+                "date": "2026-01-06",
+                "horizon_value": "2",
+                "horizon_in_year": "2",
+            },
+        ],
+        horizon="decade",
+    )
+    exit_code = runoff_period.main(
+        [
+            "--csv-path",
+            str(csv),
+            "--manifest-path",
+            str(manifest),
+            "--horizon",
+            "decade",
+            "--api-url",
+            "http://localhost:8002/runoff/",
+            "--cutoff",
+            "2026-01-06",
+            "--dry-run",
+        ]
+    )
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "MODE=pre-cutoff (cutoff=2026-01-06)" in out
+    assert "FILTERED_ROW_COUNT=1" in out
+    assert "HORIZON_TYPE=DECADE" in out
+
+
+def test_main_dry_run_default_inventory_lists_enrichment_only_policy(tmp_path, capsys):
+    """The default inventory line is
+    ``SAFE_WRITE_POLICY=enrichment-only (default)`` — same as P2b."""
+    csv, manifest = _write_csv_and_manifest(
+        tmp_path,
+        [
+            {
+                "code": "19999",
+                "date": "2026-01-01",
+                "horizon_value": "1",
+                "horizon_in_year": "1",
+            },
+        ],
+        horizon="pentad",
+    )
+    exit_code = runoff_period.main(
+        [
+            "--csv-path",
+            str(csv),
+            "--manifest-path",
+            str(manifest),
+            "--horizon",
+            "pentad",
+            "--api-url",
+            "http://localhost:8002/runoff/",
+            "--dry-run",
+        ]
+    )
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "SAFE_WRITE_POLICY=enrichment-only (default)" in out
+
+
+def test_main_missing_csv_returns_nonzero(tmp_path):
+    exit_code = runoff_period.main(
+        [
+            "--csv-path",
+            str(tmp_path / "does_not_exist.csv"),
+            "--manifest-path",
+            str(tmp_path / "does_not_exist.csv.manifest"),
+            "--horizon",
+            "pentad",
+            "--api-url",
+            "http://localhost:8002/runoff/",
+            "--dry-run",
+        ]
+    )
+    assert exit_code != 0
+
+
+def test_main_missing_manifest_returns_nonzero(tmp_path):
+    csv = tmp_path / "lonely.csv"
+    csv.write_text(",".join(_DEFAULT_HEADER) + "\n", encoding="utf-8")
+    exit_code = runoff_period.main(
+        [
+            "--csv-path",
+            str(csv),
+            "--manifest-path",
+            str(tmp_path / "no_such.manifest"),
+            "--horizon",
+            "pentad",
+            "--api-url",
+            "http://localhost:8002/runoff/",
+            "--dry-run",
+        ]
+    )
+    assert exit_code != 0
+
+
+# ===========================================================================
+# 6. Stdlib-only audit covers runoff_period
+# ===========================================================================
+
+
+def test_runoff_period_module_imports_only_stdlib_and_intra_package():
+    """The runoff_period module passes the P0 stdlib-only audit alongside
+    _common."""
+    from migration_py import _audit
+
+    violations = _audit.audit_stdlib_only(_REPO_ROOT / "bin" / "utils" / "migration_py")
+    assert violations == [], (
+        f"stdlib-only audit reported violations under migration_py/: {violations}"
+    )
+
+
+# ===========================================================================
+# 7. Shipped fixtures round-trip through the parser
+# ===========================================================================
+
+
+def test_shipped_pentad_fixture_round_trips():
+    """The shipped ``pentad_sample.csv`` + manifest parses through the helper."""
+    csv = _FIXTURE_DIR / "pentad_sample.csv"
+    manifest = _FIXTURE_DIR / "pentad_sample.csv.manifest"
+    records, counters, codes, dmin, dmax = runoff_period._read_filtered_records_with_manifest(
+        csv, manifest, "pentad", cutoff=None, station_filter=None
+    )
+    assert counters["filtered_row_count"] == 3
+    assert codes == {"19999"}
+    assert dmin == "2026-01-01"
+    assert dmax == "2026-01-11"
+    for r in records:
+        assert r["horizon_type"] == "pentad"
+        # The shipped fixture populates both discharge and predictor.
+        assert "discharge" in r
+        assert "predictor" in r
+
+
+def test_shipped_decade_fixture_round_trips():
+    csv = _FIXTURE_DIR / "decade_sample.csv"
+    manifest = _FIXTURE_DIR / "decade_sample.csv.manifest"
+    records, counters, codes, dmin, dmax = runoff_period._read_filtered_records_with_manifest(
+        csv, manifest, "decade", cutoff=None, station_filter=None
+    )
+    assert counters["filtered_row_count"] == 3
+    assert codes == {"19999"}
+    assert dmin == "2026-01-01"
+    assert dmax == "2026-01-21"
+    for r in records:
+        assert r["horizon_type"] == "decade"

--- a/apps/iEasyHydroForecast/tests/test_initialize_runoff_period.py
+++ b/apps/iEasyHydroForecast/tests/test_initialize_runoff_period.py
@@ -628,8 +628,6 @@ def test_main_dry_run_with_station_filter_reduces_filtered_count(tmp_path, capsy
         [
             "--csv-path",
             str(csv),
-            "--manifest-path",
-            str(manifest),
             "--horizon",
             "pentad",
             "--api-url",
@@ -646,7 +644,7 @@ def test_main_dry_run_with_station_filter_reduces_filtered_count(tmp_path, capsy
     assert "MODE=full-import" in out
     assert "DISTINCT_STATION_COUNT_REDACTED=1" in out
     assert "TARGET_TABLE=runoffs" in out
-    assert "HORIZON_TYPE=PENTAD" in out
+    assert "HORIZON_TYPE=pentad" in out  # lowercase per Q4 (was uppercase pre-review)
 
 
 def test_main_dry_run_with_cutoff_emits_pre_cutoff(tmp_path, capsys):
@@ -672,8 +670,6 @@ def test_main_dry_run_with_cutoff_emits_pre_cutoff(tmp_path, capsys):
         [
             "--csv-path",
             str(csv),
-            "--manifest-path",
-            str(manifest),
             "--horizon",
             "decade",
             "--api-url",
@@ -687,7 +683,7 @@ def test_main_dry_run_with_cutoff_emits_pre_cutoff(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "MODE=pre-cutoff (cutoff=2026-01-06)" in out
     assert "FILTERED_ROW_COUNT=1" in out
-    assert "HORIZON_TYPE=DECADE" in out
+    assert "HORIZON_TYPE=decade" in out  # lowercase per Q4 (was uppercase pre-review)
 
 
 def test_main_dry_run_default_inventory_lists_enrichment_only_policy(tmp_path, capsys):
@@ -709,8 +705,6 @@ def test_main_dry_run_default_inventory_lists_enrichment_only_policy(tmp_path, c
         [
             "--csv-path",
             str(csv),
-            "--manifest-path",
-            str(manifest),
             "--horizon",
             "pentad",
             "--api-url",
@@ -728,8 +722,6 @@ def test_main_missing_csv_returns_nonzero(tmp_path):
         [
             "--csv-path",
             str(tmp_path / "does_not_exist.csv"),
-            "--manifest-path",
-            str(tmp_path / "does_not_exist.csv.manifest"),
             "--horizon",
             "pentad",
             "--api-url",
@@ -747,8 +739,6 @@ def test_main_missing_manifest_returns_nonzero(tmp_path):
         [
             "--csv-path",
             str(csv),
-            "--manifest-path",
-            str(tmp_path / "no_such.manifest"),
             "--horizon",
             "pentad",
             "--api-url",
@@ -810,3 +800,94 @@ def test_shipped_decade_fixture_round_trips():
     assert dmax == "2026-01-21"
     for r in records:
         assert r["horizon_type"] == "decade"
+
+
+def test_build_record_rejects_row_with_mismatched_horizon_type():
+    """Review feedback: when the CSV row carries its own ``horizon_type`` column
+    and it disagrees with the CLI flag, drop the row instead of silently
+    relabeling the payload from the CLI value."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "horizon_value": "1",
+        "horizon_in_year": "1",
+        "horizon_type": "decade",  # disagrees with the CLI value below
+    }
+    assert runoff_period._build_record(row, "pentad") is None
+
+
+def test_build_record_accepts_row_with_matching_horizon_type():
+    """When the CSV row's horizon_type agrees with the CLI flag, the record
+    is built normally."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "horizon_value": "1",
+        "horizon_in_year": "1",
+        "horizon_type": "pentad",
+    }
+    rec = runoff_period._build_record(row, "pentad")
+    assert rec is not None
+    assert rec["horizon_type"] == "pentad"
+
+
+def test_build_record_normalizes_case_in_row_horizon_type():
+    """Row horizon_type is case-normalized before comparison."""
+    row = {
+        "code": "19999",
+        "date": "2026-01-01",
+        "horizon_value": "1",
+        "horizon_in_year": "1",
+        "horizon_type": "PENTAD",
+    }
+    rec = runoff_period._build_record(row, "pentad")
+    assert rec is not None
+    assert rec["horizon_type"] == "pentad"
+
+
+def test_manifest_path_arg_removed():
+    """Review feedback: --manifest-path CLI argument was decorative
+    (existence-check-only; actual validation derives the sidecar path from
+    --csv-path). It was removed."""
+    parser = runoff_period._build_arg_parser()
+    actions = {a.option_strings[0] for a in parser._actions if a.option_strings}
+    assert "--csv-path" in actions
+    assert "--manifest-path" not in actions
+    # And the bash wrapper must stop passing it.
+    wrapper_text = (_REPO_ROOT / "bin" / "initialize_runoff_period_history.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "--manifest-path" not in wrapper_text
+
+
+def test_dry_run_output_uses_lowercase_horizon_type():
+    """Review feedback: dry-run HORIZON_TYPE was uppercase; enum lock (Q4)
+    requires lowercase to match the API/DB."""
+    import contextlib
+    import io
+
+    counters = {
+        "source_row_count": 0,
+        "filtered_row_count": 0,
+        "skipped_parse": 0,
+        "skipped_cutoff": 0,
+        "skipped_station": 0,
+        "skipped_horizon_mismatch": 0,
+    }
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        runoff_period._print_dry_run_inventory(
+            csv_path=Path("/tmp/x.csv"),
+            horizon="pentad",
+            counters=counters,
+            distinct_codes=set(),
+            date_min=None,
+            date_max=None,
+            mode="full-import",
+            cutoff=None,
+        )
+    out = buf.getvalue()
+    assert "HORIZON_TYPE=pentad" in out
+    assert "HORIZON_TYPE=PENTAD" not in out
+    # And the new counter is surfaced.
+    assert "SKIPPED_HORIZON_MISMATCH=0" in out

--- a/bin/export_runoff_period_history.sh
+++ b/bin/export_runoff_period_history.sh
@@ -1,0 +1,437 @@
+#!/usr/bin/env bash
+# ============================================================================
+# export_runoff_period_history.sh
+#
+# LAPTOP-SIDE export wrapper for P2a (runoff PENTAD/DECADE history).
+#
+# Connects to the laptop's local ``sapphire-preprocessing-db`` (or any source
+# DB reachable via the standard PG* environment variables) and dumps rows
+# from the ``runoffs`` table filtered on:
+#   1. ``horizon_type``: 'PENTAD' or 'DECADE' (the --horizon flag),
+#   2. ``code`` IN (deployment's station list) — read line-by-line from the
+#      ``--stations-file`` argument; one code per line.
+#
+# Emits TWO files in the operator-chosen ``--out-dir``:
+#   - ``runoff_period_<horizon>_<UTC_timestamp>.csv``
+#   - ``runoff_period_<horizon>_<UTC_timestamp>.csv.manifest``
+#
+# Manifest sidecar follows the P0 contract (per
+# ``migration_py._common.validate_manifest``); 5 required keys:
+#   export_type=runoff_period
+#   row_count=<n>          # excluding header
+#   station_count=<n>      # distinct ``code`` in CSV
+#   date_min=<YYYY-MM-DD>
+#   date_max=<YYYY-MM-DD>
+#
+# Column-name correction (vs the earlier sub-orch brief):
+#   The DB column on ``runoffs`` is ``discharge`` (NOT ``discharge_avg`` — the
+#   ``discharge_avg`` form lives in the CSV-source migrator at
+#   ``sapphire/services/preprocessing/app/data_migrator.py`` and is the wide
+#   CSV column name only). Both the SELECT and the resulting CSV header use
+#   ``discharge`` so the server-side wrapper maps the column straight through
+#   to the API payload key without any column renaming.
+#
+# Location guard (Stage E #6):
+#   This script REFUSES to run on a host where any
+#   ``sapphire-{preprocessing,postprocessing,api-gateway}-...`` container is
+#   detected. It is meant to run on the OPERATOR LAPTOP / a jump host, NOT on
+#   the deployment server (which has its own DB and would produce a confusing
+#   self-export).
+#
+# Credentials and secret hygiene (per runbook §3):
+#   - Uses PG* env vars + ``~/.pgpass`` (mode 0o600). No password in CLI.
+#   - Invokes psql with ``-X`` (skip .psqlrc) and ``-v ON_ERROR_STOP=1``.
+#   - Sets HISTFILE / PSQL_HISTORY to /dev/null.
+#   - umask 077 for all writes.
+#   - Never tees secrets into logs.
+#
+# Usage:
+#   bash bin/export_runoff_period_history.sh \
+#       --horizon pentad|decade \
+#       --stations-file PATH \
+#       --out-dir PATH \
+#       [--dry-run]
+#
+# Server side (after scp of both files):
+#   bash bin/initialize_runoff_period_history.sh <env_file> \
+#       --from-export <csv_path> \
+#       --horizon pentad|decade
+#
+# ============================================================================
+
+set -eo pipefail
+# NOTE: set -u intentionally omitted; we guard each variable with ${name:-}.
+
+# ---------------------------------------------------------------------------
+# Source shared helpers (P0 foundation) — for umh_log_redacted + manifest
+# helper functions. The laptop side does NOT call read_configuration, so we
+# don't need the deployment env file here.
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC1091  # path computed at runtime; can't be statically resolved
+source "$(dirname "$0")/utils/update_migration_helpers.sh"
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Defaults / flag variables
+# ---------------------------------------------------------------------------
+HORIZON=""
+STATIONS_FILE=""
+OUT_DIR=""
+DRY_RUN=false
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+print_usage() {
+    cat <<'USAGE'
+Usage: bash bin/export_runoff_period_history.sh [OPTIONS]
+
+LAPTOP-SIDE export of runoff PENTAD or DECADE history from the local
+sapphire-preprocessing-db into a CSV + manifest pair, for transfer to a
+deployment server via scp. Pair with `bin/initialize_runoff_period_history.sh`
+on the receiving side.
+
+Options:
+  --horizon pentad|decade   REQUIRED. Which horizon to export.
+  --stations-file PATH      REQUIRED. File listing deployment station codes,
+                            one per line. Used to filter the source DB rows
+                            so cross-org codes never leak.
+  --out-dir PATH            REQUIRED. Directory to write the CSV + manifest.
+                            Created with mode 0o700 if missing.
+  --dry-run                 Run the COUNT(*) query only; do NOT export rows.
+  -h, --help                Print this message and exit 0.
+
+Environment:
+  PGHOST / PGPORT / PGUSER / PGDATABASE   Standard libpq vars. No password
+                                          in CLI; use ~/.pgpass (mode 0600).
+
+Refuses to run if any sapphire-* container is detected locally (this script
+is for laptops / jump hosts, NOT deployment servers — Stage E #6).
+USAGE
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+parse_args() {
+    # Handle --help / -h before requiring args.
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help) print_usage; exit 0 ;;
+        esac
+    done
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --horizon)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --horizon requires 'pentad' or 'decade'.${NC}" >&2
+                    exit 1
+                fi
+                HORIZON="$2"
+                shift 2
+                ;;
+            --stations-file)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --stations-file requires a path.${NC}" >&2
+                    exit 1
+                fi
+                STATIONS_FILE="$2"
+                shift 2
+                ;;
+            --out-dir)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --out-dir requires a path.${NC}" >&2
+                    exit 1
+                fi
+                OUT_DIR="$2"
+                shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            -h|--help)
+                print_usage
+                exit 0
+                ;;
+            *)
+                echo -e "${RED}Error: unknown argument: $1${NC}" >&2
+                echo "" >&2
+                print_usage >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    # Validate required.
+    if [[ -z "$HORIZON" ]]; then
+        echo -e "${RED}Error: --horizon is required.${NC}" >&2
+        exit 1
+    fi
+    case "$HORIZON" in
+        pentad|decade) ;;
+        *)
+            echo -e "${RED}Error: --horizon must be 'pentad' or 'decade' (got: ${HORIZON}).${NC}" >&2
+            exit 1
+            ;;
+    esac
+    if [[ -z "$STATIONS_FILE" ]]; then
+        echo -e "${RED}Error: --stations-file is required.${NC}" >&2
+        exit 1
+    fi
+    if [[ -z "$OUT_DIR" ]]; then
+        echo -e "${RED}Error: --out-dir is required.${NC}" >&2
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Location guard (Stage E #6): refuse on a deployment-server host.
+#
+# Testing-only bypass: set ``_P2A_EXPORT_SKIP_LOCATION_GUARD=1`` in the
+# environment to skip the docker-ps probe. This is intended ONLY for the
+# unit-test suite (which runs on developer laptops that may themselves have
+# the SAPPHIRE stack running locally for development); it is NEVER set by
+# operators in real export workflows.
+# ---------------------------------------------------------------------------
+location_guard() {
+    if [[ "${_P2A_EXPORT_SKIP_LOCATION_GUARD:-}" == "1" ]]; then
+        # Testing-only bypass; see docstring above.
+        return 0
+    fi
+    if ! command -v docker >/dev/null 2>&1; then
+        # No docker — definitely not a deployment server. Proceed.
+        return 0
+    fi
+    local detected=""
+    for name in sapphire-preprocessing-db sapphire-postprocessing-db sapphire-api-gateway; do
+        if docker ps --filter "name=${name}" --quiet 2>/dev/null | grep -q .; then
+            detected="${detected}${name} "
+        fi
+    done
+    if [[ -n "$detected" ]]; then
+        echo -e "${RED}Error: deployment-server containers detected on this host: ${detected}${NC}" >&2
+        echo "" >&2
+        echo "This export script runs on the OPERATOR LAPTOP / jump host, not on the" >&2
+        echo "deployment server. Use the server-side initialize wrapper instead:" >&2
+        echo "    bash bin/initialize_runoff_period_history.sh <env_file> ..." >&2
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    parse_args "$@"
+
+    # Strict perms for everything we write below.
+    umask 077
+
+    # Suppress shell history that might capture credentials.
+    export HISTFILE=/dev/null
+    export PSQL_HISTORY=/dev/null
+
+    # Location guard FIRST — fail loudly before any DB connection.
+    location_guard
+
+    # Validate inputs on disk.
+    if [[ ! -f "$STATIONS_FILE" ]]; then
+        echo -e "${RED}Error: stations file not found: ${STATIONS_FILE}${NC}" >&2
+        exit 1
+    fi
+    if ! mkdir -p "$OUT_DIR"; then
+        echo -e "${RED}Error: cannot create out-dir: ${OUT_DIR}${NC}" >&2
+        exit 1
+    fi
+    chmod 700 "$OUT_DIR" 2>/dev/null || true
+
+    # PG env vars must be set (no password in CLI; use ~/.pgpass).
+    if [[ -z "${PGHOST:-}" || -z "${PGUSER:-}" || -z "${PGDATABASE:-}" ]]; then
+        echo -e "${RED}Error: PGHOST / PGUSER / PGDATABASE must be set (use ~/.pgpass for password).${NC}" >&2
+        exit 1
+    fi
+
+    local horizon_upper
+    horizon_upper="$(echo "$HORIZON" | tr '[:lower:]' '[:upper:]')"
+
+    local ts
+    ts="$(date -u +%Y%m%dT%H%M%SZ)"
+
+    local csv_path="${OUT_DIR}/runoff_period_${HORIZON}_${ts}.csv"
+    local manifest_path="${csv_path}.manifest"
+
+    # Log file (redacted; no codes ever appear here).
+    local log_file="${OUT_DIR}/export_${HORIZON}_${ts}.log"
+    export log_file
+
+    echo -e "${BOLD}========================================"
+    echo -e " RUNOFF ${horizon_upper} EXPORT (P2a)"
+    echo -e "========================================${NC}"
+    umh_log_redacted "  horizon:       ${HORIZON} (${horizon_upper})"
+    umh_log_redacted "  stations_file: ${STATIONS_FILE}"
+    umh_log_redacted "  out_dir:       ${OUT_DIR}"
+    umh_log_redacted "  csv_path:      ${csv_path}"
+    umh_log_redacted "  manifest_path: ${manifest_path}"
+    umh_log_redacted "  dry_run:       ${DRY_RUN}"
+
+    # Build a SQL-safe ``code IN (...)`` clause from the stations file.
+    # Each line is single-quoted and joined by commas. Lines that contain a
+    # single quote are rejected outright (defensive; station codes are
+    # numeric strings in this codebase).
+    local stations_clause=""
+    local station_count=0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Trim whitespace.
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        [[ -z "$line" ]] && continue
+        case "$line" in
+            *\'*)
+                echo -e "${RED}Error: stations file contains an apostrophe — rejecting (SQL-injection guard).${NC}" >&2
+                exit 1
+                ;;
+        esac
+        if [[ -z "$stations_clause" ]]; then
+            stations_clause="'${line}'"
+        else
+            stations_clause="${stations_clause},'${line}'"
+        fi
+        station_count=$((station_count + 1))
+    done < "$STATIONS_FILE"
+
+    if [[ "$station_count" -eq 0 ]]; then
+        echo -e "${RED}Error: stations file is empty (no codes after trim).${NC}" >&2
+        exit 1
+    fi
+
+    umh_log_redacted "  station_count_in_stations_file: ${station_count}"
+
+    # Dry-run path: COUNT(*) only.
+    if [[ "$DRY_RUN" == true ]]; then
+        umh_log_redacted "DRY RUN: running COUNT(*) only; no CSV / manifest will be written."
+        local count_sql
+        count_sql=$(cat <<SQL
+SELECT COUNT(*) AS row_count,
+       COUNT(DISTINCT code) AS station_count,
+       MIN(date)::text AS date_min,
+       MAX(date)::text AS date_max
+FROM runoffs
+WHERE horizon_type='${horizon_upper}'
+  AND code IN (${stations_clause});
+SQL
+)
+        psql -X -v ON_ERROR_STOP=1 -P pager=off -A -F $'\t' -c "${count_sql}" \
+            | tee -a "${log_file}"
+        echo ""
+        echo -e "${YELLOW}DRY RUN complete — no files written.${NC}"
+        exit 0
+    fi
+
+    # Real export: COPY (SELECT ...) TO STDOUT with CSV HEADER.
+    # The SELECT lists ALL writable RunoffBase columns; the CSV column names
+    # match the API payload keys so the server-side wrapper does NOT need to
+    # rename anything. ``discharge`` and ``predictor`` are the canonical DB
+    # column names (NOT ``discharge_avg``; see file docstring for the
+    # correction note). The lowercase horizon_type form is emitted as
+    # 'pentad' / 'decade' to match the payload convention.
+    local copy_sql
+    copy_sql=$(cat <<SQL
+COPY (
+    SELECT lower(horizon_type::text) AS horizon_type,
+           code,
+           date::text AS date,
+           discharge,
+           predictor,
+           horizon_value,
+           horizon_in_year
+    FROM runoffs
+    WHERE horizon_type='${horizon_upper}'
+      AND code IN (${stations_clause})
+    ORDER BY code, date
+) TO STDOUT WITH CSV HEADER;
+SQL
+)
+
+    umh_log_redacted "Running COPY to ${csv_path}"
+    psql -X -v ON_ERROR_STOP=1 -P pager=off -c "${copy_sql}" > "${csv_path}"
+    chmod 600 "${csv_path}"
+
+    # Compute manifest fields from the produced CSV (single canonical
+    # source: count -1 for header, count distinct ``code``, scan dates).
+    local row_count
+    row_count=$(($(wc -l < "${csv_path}") - 1))
+    if [[ "$row_count" -lt 0 ]]; then
+        row_count=0
+    fi
+
+    # distinct codes + date range — single python pass for performance.
+    local manifest_fields
+    manifest_fields=$(python3 - "$csv_path" <<'PYEOF'
+import csv, sys
+codes = set()
+date_min = None
+date_max = None
+with open(sys.argv[1], newline="") as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        c = (row.get("code") or "").strip()
+        if c:
+            codes.add(c)
+        d = (row.get("date") or "").strip()
+        if d:
+            if date_min is None or d < date_min:
+                date_min = d
+            if date_max is None or d > date_max:
+                date_max = d
+print(f"{len(codes)}\t{date_min or ''}\t{date_max or ''}")
+PYEOF
+)
+    local manifest_station_count manifest_date_min manifest_date_max
+    manifest_station_count="${manifest_fields%%$'\t'*}"
+    manifest_fields="${manifest_fields#*$'\t'}"
+    manifest_date_min="${manifest_fields%%$'\t'*}"
+    manifest_date_max="${manifest_fields#*$'\t'}"
+
+    # Build the manifest. station_count and date_min/max are computed from
+    # the produced CSV (NOT from the stations-file count) so manifest
+    # validation on the server side catches any mid-flight tampering.
+    cat > "${manifest_path}" <<MANIFEST
+# Generated by bin/export_runoff_period_history.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ)
+export_type=runoff_period
+horizon=${HORIZON}
+row_count=${row_count}
+station_count=${manifest_station_count}
+date_min=${manifest_date_min}
+date_max=${manifest_date_max}
+MANIFEST
+    chmod 600 "${manifest_path}"
+
+    umh_log_redacted "Wrote CSV:      ${csv_path} (${row_count} rows)"
+    umh_log_redacted "Wrote manifest: ${manifest_path}"
+    umh_log_redacted "  station_count (in csv): ${manifest_station_count}"
+    umh_log_redacted "  date_min:      ${manifest_date_min:-none}"
+    umh_log_redacted "  date_max:      ${manifest_date_max:-none}"
+
+    echo ""
+    echo -e "${GREEN}Export complete.${NC} Transfer BOTH files together to the deployment server:"
+    echo "  scp ${csv_path} ${manifest_path} <user>@<server>:<data_root>/logs/"
+    echo ""
+    echo "Then on the server:"
+    echo "  bash bin/initialize_runoff_period_history.sh \\"
+    echo "      <env_file> --from-export <transferred_csv> --horizon ${HORIZON}"
+}
+
+main "$@"

--- a/bin/export_runoff_period_history.sh
+++ b/bin/export_runoff_period_history.sh
@@ -86,6 +86,7 @@ HORIZON=""
 STATIONS_FILE=""
 OUT_DIR=""
 DRY_RUN=false
+I_AM_ON_LAPTOP=false
 
 # ---------------------------------------------------------------------------
 # Usage
@@ -108,6 +109,9 @@ Options:
   --out-dir PATH            REQUIRED. Directory to write the CSV + manifest.
                             Created with mode 0o700 if missing.
   --dry-run                 Run the COUNT(*) query only; do NOT export rows.
+  --i-am-on-laptop          BYPASS the location guard (charter Stage E #6).
+                            Use only when the laptop and deployment server
+                            are intentionally co-located on the same host.
   -h, --help                Print this message and exit 0.
 
 Environment:
@@ -115,7 +119,10 @@ Environment:
                                           in CLI; use ~/.pgpass (mode 0600).
 
 Refuses to run if any sapphire-* container is detected locally (this script
-is for laptops / jump hosts, NOT deployment servers — Stage E #6).
+is for laptops / jump hosts, NOT deployment servers — Stage E #6). Override
+with --i-am-on-laptop (operator-facing flag) when intentional. The
+``_P2A_EXPORT_SKIP_LOCATION_GUARD=1`` env var is retained as a
+testing-only bypass.
 USAGE
 }
 
@@ -159,6 +166,10 @@ parse_args() {
                 ;;
             --dry-run)
                 DRY_RUN=true
+                shift
+                ;;
+            --i-am-on-laptop)
+                I_AM_ON_LAPTOP=true
                 shift
                 ;;
             -h|--help)
@@ -208,6 +219,11 @@ parse_args() {
 location_guard() {
     if [[ "${_P2A_EXPORT_SKIP_LOCATION_GUARD:-}" == "1" ]]; then
         # Testing-only bypass; see docstring above.
+        return 0
+    fi
+    if [[ "$I_AM_ON_LAPTOP" == "true" ]]; then
+        # Operator-facing bypass (charter Stage E #6 / review feedback).
+        echo -e "${YELLOW}WARNING: running on apparent deployment host — bypass enabled by operator (--i-am-on-laptop).${NC}" >&2
         return 0
     fi
     if ! command -v docker >/dev/null 2>&1; then
@@ -375,6 +391,16 @@ SQL
     row_count=$(($(wc -l < "${csv_path}") - 1))
     if [[ "$row_count" -lt 0 ]]; then
         row_count=0
+    fi
+
+    # Reject zero-row exports up front (review feedback): a blank date_min /
+    # date_max manifest is non-ISO and the server-side validator rejects it.
+    # Surface this as a clear operator error before any sidecar is written.
+    if [[ "$row_count" -eq 0 ]]; then
+        umh_log_redacted "ERROR: no rows matched filter — nothing to export."
+        umh_log_redacted "Check the stations file and --horizon flag."
+        rm -f "${csv_path}"
+        exit 1
     fi
 
     # distinct codes + date range — single python pass for performance.

--- a/bin/initialize_runoff_period_history.sh
+++ b/bin/initialize_runoff_period_history.sh
@@ -1,0 +1,518 @@
+#!/usr/bin/env bash
+# ============================================================================
+# initialize_runoff_period_history.sh
+#
+# Runoff PENTAD/DECADE laptop-export CSV-to-API migration wrapper (P2a of
+# the update-time migration toolkit). Sibling to P2b (hydrograph
+# PENTAD/DECADE); same shape (laptop-export -> CSV+manifest -> server-side
+# import), different target table (``runoffs``) and payload (narrow row with
+# ``discharge`` + ``predictor``).
+#
+# Reads a CSV+manifest pair produced by
+# ``bin/export_runoff_period_history.sh`` on the operator's laptop, then
+# transferred to the deployment server via scp. The manifest sidecar
+# (<csv>.manifest, 5 required keys) is validated BEFORE any POST.
+#
+# Uses the P0 helper (bin/utils/update_migration_helpers.sh) for image
+# resolution, temp workspace, redacted logging, manifest validation, and
+# the uniform image log line. Mounts the P0 migration_py/ package into the
+# prepgateway container so the per-row POST logic lives in importable
+# stdlib-only Python — no embedded heredoc beyond a minimal entry shim.
+#
+# Column-name correction (vs the earlier sub-orch brief):
+#   The DB column on ``runoffs`` is ``discharge`` (NOT ``discharge_avg`` —
+#   that form is the CSV-source migrator's column name in
+#   ``sapphire/services/preprocessing/app/data_migrator.py:210``). The API
+#   payload key is also ``discharge``. The Python helper reads ``discharge``
+#   directly from the export CSV and forwards under the same key.
+#
+# Universal safe-write rule (architecture §Q2 layer 2):
+#   Runoff PENTAD/DECADE rows have two nullable float fields (discharge,
+#   predictor). By default the wrapper sends ONLY non-NULL source fields.
+#   The service-side _has_changes + setattr path overwrites existing
+#   non-NULL with incoming NULL, so the wrapper never injects null. Unlike
+#   P2b (hydrograph), there is no --strict-merge follow-up here — the
+#   narrow runoff row does not carry the wide stat-erasure risk that
+#   motivated --strict-merge for hydrograph.
+#
+# MODE detection: queries the target preprocessing-db once via docker exec
+# psql. Empty (count=0 OR min_date IS NULL) -> full-import; populated ->
+# pre-cutoff (cutoff = MIN(date)).
+#
+# Idempotency: the preprocessing service upserts on
+# (horizon_type, code, date). Reruns are safe.
+#
+# Forward interface contract (P0 gi_draft): --station-filter <code> is the
+# binding flag name reused by P1b / P1c / P3 / P2b.
+#
+# Usage:
+#   bash bin/initialize_runoff_period_history.sh <env_file_path> \
+#       --from-export <csv_path> \
+#       --horizon pentad|decade \
+#       [OPTIONS]
+#
+# Arguments:
+#   env_file_path        Path to the .env_<org> file (required, positional).
+#
+# Required flags:
+#   --from-export <PATH> Path to the transferred export CSV. The sibling
+#                        ``<PATH>.manifest`` file MUST exist.
+#   --horizon pentad|decade
+#                        Which horizon the export holds.
+#
+# Options:
+#   --dry-run            Read + filter; do NOT POST anything.
+#   --api-url <URL>      Target endpoint (default: http://localhost:8002/runoff/).
+#   --batch-size <N>     Records per POST batch (default: 500).
+#   --image <IMAGE>      Docker image override.
+#   --station-filter <CODE>
+#                        Filter source CSV rows to a single station code
+#                        (binding interface contract from P0 — honored by
+#                        all CSV-source AND DB-source wrappers).
+#   -h, --help           Print this message and exit 0.
+#
+# Examples:
+#   bash bin/initialize_runoff_period_history.sh /data/taj_data/config/.env_tjhm \
+#       --from-export /data/taj_data/logs/runoff_period_pentad_20260606T120000Z.csv \
+#       --horizon pentad --dry-run
+#
+#   bash bin/initialize_runoff_period_history.sh /data/taj_data/config/.env_tjhm \
+#       --from-export /data/taj_data/logs/runoff_period_decade_20260606T120100Z.csv \
+#       --horizon decade --station-filter 19999
+# ============================================================================
+
+set -eo pipefail
+# NOTE: set -u is intentionally omitted; common_functions.sh is not strict-mode safe.
+
+# ---------------------------------------------------------------------------
+# Source shared helpers (P0 foundation)
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC1091  # path computed at runtime; can't be statically resolved
+source "$(dirname "$0")/utils/update_migration_helpers.sh"
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Defaults / flag variables
+# ---------------------------------------------------------------------------
+ENV_FILE=""
+FROM_EXPORT=""
+HORIZON=""
+DRY_RUN=false
+API_URL="http://localhost:8002/runoff/"
+BATCH_SIZE=500
+IMAGE_OVERRIDE=""
+STATION_FILTER=""
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+print_usage() {
+    cat <<'USAGE'
+Usage: bash bin/initialize_runoff_period_history.sh <env_file_path> \
+            --from-export <csv_path> \
+            --horizon pentad|decade \
+            [OPTIONS]
+
+Server-side import of a runoff PENTAD or DECADE laptop-export CSV + manifest
+pair into the deployment's preprocessing API. Honors MODE=full-import vs
+pre-cutoff based on the target table state. Validates the sidecar
+``<csv>.manifest`` (P0 contract — 5 required keys: export_type, row_count,
+station_count, date_min, date_max) BEFORE any POST.
+
+Arguments:
+  env_file_path                Path to the .env_<org> file (required).
+
+Required flags:
+  --from-export <PATH>         Path to the transferred export CSV. The
+                               sibling <PATH>.manifest file MUST exist.
+  --horizon pentad|decade      Which horizon the export holds.
+
+Options:
+  --dry-run                    Read + filter; do NOT POST anything.
+  --api-url <URL>              Target endpoint (default:
+                               http://localhost:8002/runoff/).
+  --batch-size <N>             Records per POST batch (default: 500).
+  --image <IMAGE>              Docker image override.
+  --station-filter <CODE>      Filter source CSV rows to a single station
+                               code (binding interface contract from P0 —
+                               honored by all CSV-source AND DB-source
+                               wrappers).
+  -h, --help                   Print this message and exit 0.
+
+Examples:
+  bash bin/initialize_runoff_period_history.sh /data/taj_data/config/.env_tjhm \
+      --from-export /data/taj_data/logs/runoff_period_pentad_20260606T120000Z.csv \
+      --horizon pentad --dry-run
+
+  bash bin/initialize_runoff_period_history.sh /data/taj_data/config/.env_tjhm \
+      --from-export /data/taj_data/logs/runoff_period_decade_20260606T120100Z.csv \
+      --horizon decade --station-filter 19999
+USAGE
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+parse_args() {
+    # Handle --help / -h before requiring the positional arg.
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help) print_usage; exit 0 ;;
+        esac
+    done
+
+    if [[ $# -eq 0 ]]; then
+        echo -e "${RED}Error: env_file_path is required.${NC}" >&2
+        echo "" >&2
+        print_usage >&2
+        exit 1
+    fi
+
+    # First positional argument is the env file.
+    if [[ "$1" != -* ]]; then
+        ENV_FILE="$1"
+        shift
+    else
+        echo -e "${RED}Error: first argument must be the env_file_path (got: $1).${NC}" >&2
+        echo "" >&2
+        print_usage >&2
+        exit 1
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --from-export)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --from-export requires a CSV path.${NC}" >&2
+                    exit 1
+                fi
+                FROM_EXPORT="$2"
+                shift 2
+                ;;
+            --horizon)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --horizon requires 'pentad' or 'decade'.${NC}" >&2
+                    exit 1
+                fi
+                HORIZON="$2"
+                shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --api-url)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --api-url requires a URL value.${NC}" >&2
+                    exit 1
+                fi
+                API_URL="$2"
+                shift 2
+                ;;
+            --batch-size)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --batch-size requires a numeric value.${NC}" >&2
+                    exit 1
+                fi
+                BATCH_SIZE="$2"
+                shift 2
+                ;;
+            --image)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --image requires an image name.${NC}" >&2
+                    exit 1
+                fi
+                IMAGE_OVERRIDE="$2"
+                shift 2
+                ;;
+            --station-filter)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --station-filter requires a station code value.${NC}" >&2
+                    exit 1
+                fi
+                STATION_FILTER="$2"
+                shift 2
+                ;;
+            -h|--help)
+                print_usage
+                exit 0
+                ;;
+            *)
+                echo -e "${RED}Error: unknown argument: $1${NC}" >&2
+                echo "" >&2
+                print_usage >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    # Validate required.
+    if [[ -z "$FROM_EXPORT" ]]; then
+        echo -e "${RED}Error: --from-export <csv_path> is required.${NC}" >&2
+        exit 1
+    fi
+    if [[ -z "$HORIZON" ]]; then
+        echo -e "${RED}Error: --horizon pentad|decade is required.${NC}" >&2
+        exit 1
+    fi
+    case "$HORIZON" in
+        pentad|decade) ;;
+        *)
+            echo -e "${RED}Error: --horizon must be 'pentad' or 'decade' (got: ${HORIZON}).${NC}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Query the target preprocessing-db for MODE detection (per-horizon).
+# Echoes "count<TAB>min_date_or_empty" on stdout.
+# Returns non-zero if the docker exec fails.
+# ---------------------------------------------------------------------------
+query_target_state() {
+    local horizon_upper="$1"
+    docker exec sapphire-preprocessing-db psql \
+        -U postgres -d preprocessing_db -P pager=off -t -A -F $'\t' \
+        -c "SELECT COUNT(*), COALESCE(MIN(date)::text, '') FROM runoffs WHERE horizon_type='${horizon_upper}';"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    parse_args "$@"
+
+    print_banner
+    echo "| Running Runoff PENTAD/DECADE History Initialization (laptop-export -> API push)"
+
+    # Validate env file exists before loading.
+    if [[ ! -f "$ENV_FILE" ]]; then
+        echo -e "${RED}Error: env file not found: ${ENV_FILE}${NC}" >&2
+        exit 1
+    fi
+
+    # Validate the export CSV + manifest exist on disk BEFORE invoking docker.
+    if [[ ! -f "$FROM_EXPORT" ]]; then
+        echo -e "${RED}Error: --from-export CSV not found: ${FROM_EXPORT}${NC}" >&2
+        exit 1
+    fi
+    local MANIFEST_HOST="${FROM_EXPORT}.manifest"
+    if [[ ! -f "$MANIFEST_HOST" ]]; then
+        echo -e "${RED}Error: sidecar manifest not found: ${MANIFEST_HOST}${NC}" >&2
+        echo "       The laptop-side export script must emit BOTH files; transfer them together." >&2
+        exit 1
+    fi
+
+    # Manifest validation FIRST (Stage E #2 + brief §4.6). Fail loudly
+    # before doing any image work or psql probes.
+    umh_validate_export_manifest "$FROM_EXPORT" runoff_period
+
+    # Load .env vars and derive ieasyhydroforecast_* path variables.
+    read_configuration "${ENV_FILE}"
+
+    # Validate required env vars.
+    if [[ -z "${ieasyhydroforecast_data_root_dir:-}" ]]; then
+        echo -e "${RED}Error: Required environment variable ieasyhydroforecast_data_root_dir is not set.${NC}" >&2
+        exit 1
+    fi
+
+    # Resolve image via the P0 helper (CLI override -> configured tag -> :latest).
+    local IMAGE
+    IMAGE="$(umh_resolve_image "$IMAGE_OVERRIDE" "${ieasyhydroforecast_backend_docker_image_tag:-}")"
+
+    local horizon_upper
+    horizon_upper="$(echo "$HORIZON" | tr '[:lower:]' '[:upper:]')"
+
+    local LOG_DIR="${ieasyhydroforecast_data_root_dir}/logs/runoff_period_history_init"
+    mkdir -p "${LOG_DIR}"
+
+    local TIMESTAMP
+    TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+    log_file="${LOG_DIR}/runoff_period_history_init_${HORIZON}_${TIMESTAMP}.log"
+    export log_file
+
+    echo "| Log file: ${log_file}"
+    echo ""
+
+    umh_log_redacted "Starting runoff PENTAD/DECADE history initialization"
+    umh_log_redacted "  env_file:        ${ENV_FILE}"
+    umh_log_redacted "  from_export:     ${FROM_EXPORT}"
+    umh_log_redacted "  manifest:        ${MANIFEST_HOST} (validated OK)"
+    umh_log_redacted "  horizon:         ${HORIZON} (${horizon_upper})"
+    umh_log_redacted "  api_url:         ${API_URL}"
+    umh_log_redacted "  batch_size:      ${BATCH_SIZE}"
+    umh_log_redacted "  station_filter:  ${STATION_FILTER:-<none>}"
+    umh_log_redacted "  dry_run:         ${DRY_RUN}"
+    umh_print_image_resolution_line "${IMAGE}"
+
+    # -------------------------------------------------------------------------
+    # Pre-flight checks
+    # -------------------------------------------------------------------------
+
+    # 1. Docker must be running.
+    if ! docker info > /dev/null 2>&1; then
+        umh_log_redacted "ERROR: Docker is not running. Please start Docker and try again."
+        exit 1
+    fi
+    umh_log_redacted "Pre-flight: Docker daemon OK"
+
+    # 2. Pull image if not present locally.
+    if ! docker image inspect "$IMAGE" > /dev/null 2>&1; then
+        umh_log_redacted "Image ${IMAGE} not found locally, pulling..."
+        if ! docker pull "$IMAGE"; then
+            umh_log_redacted "ERROR: Failed to pull Docker image ${IMAGE}"
+            exit 1
+        fi
+        umh_log_redacted "Pull complete: ${IMAGE}"
+    else
+        umh_log_redacted "Pre-flight: image present locally (${IMAGE})"
+    fi
+
+    # -------------------------------------------------------------------------
+    # MODE detection — query target preprocessing-db.
+    # -------------------------------------------------------------------------
+    local MODE="full-import"
+    local CUTOFF=""
+    local TARGET_COUNT=0
+    local TARGET_MIN_DATE=""
+
+    if docker ps --filter "name=sapphire-preprocessing-db" --quiet | grep -q .; then
+        local query_out
+        if query_out="$(query_target_state "$horizon_upper" 2>&1)"; then
+            # query_out format: "<count>\t<min_date_or_empty>"
+            TARGET_COUNT="${query_out%%$'\t'*}"
+            TARGET_MIN_DATE="${query_out#*$'\t'}"
+            # Trim any trailing newline / whitespace.
+            TARGET_COUNT="${TARGET_COUNT//[$'\r\n ']/}"
+            TARGET_MIN_DATE="${TARGET_MIN_DATE//[$'\r\n ']/}"
+            umh_log_redacted "Target state: count=${TARGET_COUNT} min_date=${TARGET_MIN_DATE:-<null>} (horizon_type=${horizon_upper})"
+            if [[ "$TARGET_COUNT" != "0" && -n "$TARGET_MIN_DATE" ]]; then
+                MODE="pre-cutoff"
+                CUTOFF="$TARGET_MIN_DATE"
+            else
+                MODE="full-import"
+                CUTOFF=""
+            fi
+        else
+            umh_log_redacted "WARN: target query failed (${query_out}); assuming full-import"
+            MODE="full-import"
+            CUTOFF=""
+        fi
+    else
+        umh_log_redacted "WARN: sapphire-preprocessing-db not running; assuming full-import"
+        MODE="full-import"
+        CUTOFF=""
+    fi
+
+    umh_log_redacted "MODE=${MODE}$( [[ -n "$CUTOFF" ]] && echo " (cutoff=${CUTOFF})" || echo " (target empty)")"
+
+    # -------------------------------------------------------------------------
+    # Acquire a temp workspace (mode 0o700, trap-cleaned on EXIT INT TERM).
+    # -------------------------------------------------------------------------
+    local TMPDIR_RUNOFF
+    TMPDIR_RUNOFF="$(umh_acquire_temp_workspace runoff_period)"
+    umh_log_redacted "Temp workspace: ${TMPDIR_RUNOFF}"
+
+    # -------------------------------------------------------------------------
+    # Run the Python helper inside the prepgateway image.
+    # Mount migration_py/ read-only; mount the CSV + manifest read-only.
+    # -------------------------------------------------------------------------
+    local HELPER_DIR
+    HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/utils" && pwd)"
+
+    local DRY_RUN_FLAG=""
+    if [[ "$DRY_RUN" == true ]]; then
+        DRY_RUN_FLAG="--dry-run"
+    fi
+
+    local CUTOFF_ARGS=()
+    if [[ -n "$CUTOFF" ]]; then
+        CUTOFF_ARGS=("--cutoff" "$CUTOFF")
+    fi
+
+    local STATION_ARGS=()
+    if [[ -n "$STATION_FILTER" ]]; then
+        STATION_ARGS=("--station-filter" "$STATION_FILTER")
+    fi
+
+    umh_log_redacted "========================================"
+    umh_log_redacted "Running runoff PENTAD/DECADE push via docker"
+    umh_log_redacted "  image:        ${IMAGE}"
+    umh_log_redacted "  csv:          ${FROM_EXPORT} -> /runoff_period.csv (ro)"
+    umh_log_redacted "  manifest:     ${MANIFEST_HOST} -> /runoff_period.csv.manifest (ro)"
+    umh_log_redacted "  migration_py: ${HELPER_DIR}/migration_py -> /opt/migration_py (ro)"
+    umh_log_redacted "  horizon:      ${HORIZON}"
+    umh_log_redacted "  api_url:      ${API_URL}"
+    umh_log_redacted "  batch_size:   ${BATCH_SIZE}"
+    if [[ "$DRY_RUN" == true ]]; then
+        umh_log_redacted "  mode:         DRY RUN (no POSTs)"
+    else
+        umh_log_redacted "  mode:         REAL run"
+    fi
+    umh_log_redacted "========================================"
+
+    # shellcheck disable=SC2086  # DRY_RUN_FLAG intentionally unquoted: empty=no arg
+    docker run --rm --network host \
+        -v "${FROM_EXPORT}:/runoff_period.csv:ro" \
+        -v "${MANIFEST_HOST}:/runoff_period.csv.manifest:ro" \
+        -v "${HELPER_DIR}/migration_py:/opt/migration_py:ro" \
+        -e "PYTHONPATH=/opt" \
+        "$IMAGE" \
+        python3 -m migration_py.runoff_period \
+            --csv-path /runoff_period.csv \
+            --manifest-path /runoff_period.csv.manifest \
+            --horizon "${HORIZON}" \
+            --api-url "${API_URL}" \
+            --batch-size "${BATCH_SIZE}" \
+            "${CUTOFF_ARGS[@]}" \
+            "${STATION_ARGS[@]}" \
+            ${DRY_RUN_FLAG} \
+        2>&1 | tee -a "${log_file}"
+
+    local DOCKER_EXIT=${PIPESTATUS[0]}
+
+    # -------------------------------------------------------------------------
+    # Post-run summary.
+    # -------------------------------------------------------------------------
+    echo ""
+    echo -e "${BOLD}========================================"
+    echo -e " RUNOFF PENTAD/DECADE HISTORY INIT COMPLETE"
+    echo -e "========================================${NC}"
+    echo ""
+
+    if [[ "$DOCKER_EXIT" -ne 0 ]]; then
+        echo -e "${RED}Docker run exited with code ${DOCKER_EXIT}. Check the log above and:${NC}"
+        echo "  ${log_file}"
+        echo ""
+    else
+        if [[ "$DRY_RUN" == true ]]; then
+            echo -e "${YELLOW}DRY RUN complete — no records were POSTed.${NC}"
+            echo "  Re-run without --dry-run to push data."
+        else
+            echo -e "${GREEN}Push complete.${NC}"
+        fi
+        echo ""
+    fi
+
+    echo "Verify rows in the preprocessing DB:"
+    echo "  docker exec sapphire-preprocessing-db \\"
+    echo "    psql -U postgres -d preprocessing_db -c \\"
+    echo "    \"SELECT horizon_type, COUNT(*) AS rows, MIN(date), MAX(date) FROM runoffs WHERE horizon_type='${horizon_upper}' GROUP BY horizon_type;\""
+    echo ""
+    echo "Log file: ${log_file}"
+
+    exit "$DOCKER_EXIT"
+}
+
+main "$@"

--- a/bin/initialize_runoff_period_history.sh
+++ b/bin/initialize_runoff_period_history.sh
@@ -471,7 +471,6 @@ main() {
         "$IMAGE" \
         python3 -m migration_py.runoff_period \
             --csv-path /runoff_period.csv \
-            --manifest-path /runoff_period.csv.manifest \
             --horizon "${HORIZON}" \
             --api-url "${API_URL}" \
             --batch-size "${BATCH_SIZE}" \

--- a/bin/utils/migration_py/runoff_period.py
+++ b/bin/utils/migration_py/runoff_period.py
@@ -138,6 +138,11 @@ def _build_record(row: dict[str, str], horizon: str) -> dict | None:
     ``horizon_in_year``) are always included; ``discharge`` / ``predictor``
     are omitted when the source value is absent / unparseable.
 
+    Mixed-export guard (review feedback): if the CSV row carries its own
+    ``horizon_type`` column and it does not match the CLI ``horizon`` value
+    after case-normalization, the row is dropped (returns ``None``). Rows
+    without a ``horizon_type`` column fall through to trusting the CLI.
+
     Args:
         row: CSV row as ``{column_name: value_str}``.
         horizon: ``"pentad"`` or ``"decade"`` (lowercase payload form).
@@ -145,10 +150,20 @@ def _build_record(row: dict[str, str], horizon: str) -> dict | None:
     Returns:
         A payload dict matching ``RunoffCreate``, or ``None`` if the row
         cannot satisfy the required fields (caller treats this as a parse
-        skip).
+        skip) OR if the row's ``horizon_type`` column disagrees with
+        ``horizon`` (caller treats this as a horizon-mismatch skip).
     """
     if horizon not in _HORIZON_TO_PAYLOAD:
         return None
+
+    # Mixed-export defense: when the CSV row carries an explicit horizon_type
+    # column, it must match the CLI flag. A mismatch is treated as a drop
+    # rather than silently relabeling the payload from the CLI value.
+    row_horizon_raw = row.get("horizon_type")
+    if row_horizon_raw is not None:
+        row_horizon = row_horizon_raw.strip().lower()
+        if row_horizon and row_horizon != horizon:
+            return None
 
     code = (row.get("code") or "").strip()
     date_str = (row.get("date") or "").strip()[:10]
@@ -238,7 +253,9 @@ def _read_filtered_records_with_manifest(
         "skipped_parse": 0,
         "skipped_cutoff": 0,
         "skipped_station": 0,
+        "skipped_horizon_mismatch": 0,
     }
+    horizon_mismatch_logged = False
     records: list[dict] = []
     distinct_codes: set[str] = set()
     date_min: str | None = None
@@ -278,6 +295,26 @@ def _read_filtered_records_with_manifest(
             if cutoff is not None and date_str >= cutoff:
                 counters["skipped_cutoff"] += 1
                 continue
+
+            # Horizon-mismatch pre-check (mixed-export defense — review feedback):
+            # if the CSV row's horizon_type column disagrees with the CLI flag,
+            # drop the row under a distinct counter. First occurrence emits a
+            # WARNING line so the operator can investigate.
+            row_horizon_raw = row.get("horizon_type")
+            if row_horizon_raw is not None:
+                row_horizon = row_horizon_raw.strip().lower()
+                if row_horizon and row_horizon != horizon:
+                    counters["skipped_horizon_mismatch"] += 1
+                    if not horizon_mismatch_logged:
+                        print(
+                            f"WARNING: row code={code} date={date_str} carries "
+                            f"horizon_type={row_horizon!r} but --horizon={horizon!r}; "
+                            "dropping this row and any further mismatches "
+                            "(see SKIPPED_HORIZON_MISMATCH counter).",
+                            file=sys.stderr,
+                        )
+                        horizon_mismatch_logged = True
+                    continue
 
             record = _build_record(row, horizon)
             if record is None:
@@ -344,12 +381,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Path to the runoff_period export CSV inside the container.",
     )
-    p.add_argument(
-        "--manifest-path",
-        required=True,
-        type=Path,
-        help="Path to the sidecar ``<csv>.manifest`` file (for error clarity).",
-    )
+    # --manifest-path removed (review feedback): the actual validation
+    # derives the sidecar path from --csv-path via _common.validate_manifest,
+    # so a separate CLI arg was decorative. Operators always pass matching
+    # paths from the bash wrapper anyway.
     p.add_argument(
         "--horizon",
         required=True,
@@ -404,7 +439,9 @@ def _print_dry_run_inventory(
     """
     print(f"MODE={mode}" + (f" (cutoff={cutoff})" if cutoff else " (target empty)"))
     print("TARGET_TABLE=runoffs")
-    print(f"HORIZON_TYPE={horizon.upper()}")
+    # Lowercase per architecture §Q4 (review feedback): API/DB enum is
+    # lowercase 'pentad' / 'decade'; uppercase here misled operators.
+    print(f"HORIZON_TYPE={horizon.lower()}")
     print(f"CUTOFF={cutoff if cutoff else 'none'}")
     print(f"SOURCE_FILES=['{csv_path}']")
     print(f"SOURCE_ROW_COUNT={counters['source_row_count']}")
@@ -415,7 +452,8 @@ def _print_dry_run_inventory(
     print(
         f"SKIPPED_PARSE={counters['skipped_parse']} "
         f"SKIPPED_CUTOFF={counters['skipped_cutoff']} "
-        f"SKIPPED_STATION={counters['skipped_station']}"
+        f"SKIPPED_STATION={counters['skipped_station']} "
+        f"SKIPPED_HORIZON_MISMATCH={counters['skipped_horizon_mismatch']}"
     )
     # Safe-write policy line so operators see the active mode in the inventory.
     # P2a runs enrichment-only only; no --strict-merge sibling for this narrow
@@ -437,16 +475,13 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     csv_path: Path = args.csv_path
-    manifest_path: Path = args.manifest_path
     if not csv_path.is_file():
         print(f"ERROR: CSV not found: {csv_path}", file=sys.stderr)
         return 1
-    # The manifest path is allowed to be a hint; _common.validate_manifest
-    # derives the sidecar path from the CSV path. We still surface a clear
-    # error if the operator-supplied hint doesn't exist on disk.
-    if not manifest_path.is_file():
-        print(f"ERROR: manifest not found: {manifest_path}", file=sys.stderr)
-        return 1
+    # Manifest sidecar path is derived from the CSV path
+    # (--manifest-path arg was removed as decorative per review feedback).
+    # validate_manifest reads it directly.
+    manifest_path = csv_path.with_name(csv_path.name + ".manifest")
 
     # MODE is decided by the wrapper from the psql query; we just receive
     # the cutoff (or None) and pass it through.

--- a/bin/utils/migration_py/runoff_period.py
+++ b/bin/utils/migration_py/runoff_period.py
@@ -1,0 +1,519 @@
+"""Runoff PENTAD/DECADE laptop-export CSV-to-API push helper (P2a).
+
+Called from ``bin/initialize_runoff_period_history.sh`` as
+``python3 -m migration_py.runoff_period``. Reads a CSV produced by the
+laptop-side ``bin/export_runoff_period_history.sh`` script (a direct dump of
+the laptop's ``sapphire-preprocessing-db.runoffs`` rows filtered on
+``horizon_type IN ('PENTAD','DECADE')``) plus its sidecar ``.manifest`` file,
+validates the manifest (5 required keys per P0 contract), and POSTs the rows
+to the deployment server's preprocessing API.
+
+P2a sibling to P2b (hydrograph PENTAD/DECADE) — same shape (laptop-export →
+CSV + manifest → server-side import), different table (``runoffs`` instead of
+``hydrographs``) and different payload (narrow row with ``discharge`` +
+``predictor`` instead of a wide stat / quantile / year-mapped record).
+
+Column-name correction (vs the earlier sub-orch brief):
+    The DB column on ``runoffs`` is ``discharge`` (NOT ``discharge_avg`` —
+    that form is the CSV-source migrator's column name in
+    ``sapphire/services/preprocessing/app/data_migrator.py:210``). The API
+    payload key is also ``discharge``. This module reads ``discharge`` from
+    the export CSV (which the export script emits as the DB column name) and
+    forwards it under the same key. See file docstring of the export wrapper
+    for the matching SELECT column list.
+
+Universal safe-write rule (architecture §Q2 layer 2):
+    Runoff rows have two nullable float fields: ``discharge`` and
+    ``predictor``. By default the wrapper sends ONLY non-NULL source fields
+    (enrichment-only). The service-side ``_has_changes`` + ``setattr`` path
+    overwrites existing non-NULL targets with incoming NULL, so the wrapper
+    never injects null. The pentad/decade table is much narrower than
+    hydrograph's wide-stat row, so the stat-erasure risk is small here — but
+    we still follow the same rule for consistency with P2b.
+
+Manifest contract (per P0 ``_common.validate_manifest`` + brief §4.1):
+    Sidecar at ``<csv_path>.manifest`` must contain 5 keys:
+        export_type=runoff_period
+        row_count=<int>          # excluding header
+        station_count=<int>      # distinct ``code`` values in CSV
+        date_min=<YYYY-MM-DD>    # min(date) in CSV
+        date_max=<YYYY-MM-DD>    # max(date) in CSV
+
+Idempotency: the service upserts on ``(horizon_type, code, date)``; reruns
+are safe.
+
+Stdlib-only. Verified by ``migration_py._audit.audit_stdlib_only``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import csv
+import datetime
+import json
+import logging
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# Intra-package sibling import — relative form (level >= 1) is the explicit
+# pattern recognized by ``_audit.collect_imported_roots`` as intra-package and
+# skipped from the stdlib check.
+from . import _common
+
+logger = logging.getLogger("migration_py.runoff_period")
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Horizons this module supports. Service-side schema uses uppercase
+# ``HorizonType`` values ("PENTAD", "DECADE"); payloads serialize as the
+# lowercase enum value form ("pentad", "decade") for consistency with the
+# P1a / P2b wrappers (the FastAPI router accepts either case via the enum).
+_HORIZON_TO_PAYLOAD: dict[str, str] = {
+    "pentad": "pentad",
+    "decade": "decade",
+}
+
+# Required columns in every source CSV row (parse fails otherwise). These are
+# the minimum needed to construct the natural key + ``horizon_value`` +
+# ``horizon_in_year``.
+_REQUIRED_COLUMNS_BASE: frozenset[str] = frozenset(
+    {"code", "date", "horizon_value", "horizon_in_year"}
+)
+
+# Nullable float fields. The wrapper sends only non-NULL fields per the
+# safe-write rule. NOTE: ``discharge`` (NOT ``discharge_avg``).
+_FLOAT_FIELDS: tuple[str, ...] = ("discharge", "predictor")
+
+
+# ---------------------------------------------------------------------------
+# Value parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_float(raw: str | None) -> float | None:
+    """Return a float, or None if unparseable / null-like / non-finite."""
+    s = (raw or "").strip()
+    if not s or s.lower() in {"nan", "none", "null"}:
+        return None
+    try:
+        v = float(s)
+    except ValueError:
+        return None
+    # Reject NaN / +/-Inf — they cannot be JSON-serialized safely and the
+    # Pydantic schema would reject them.
+    if v != v or v == float("inf") or v == float("-inf"):
+        return None
+    return v
+
+
+def _parse_int(raw: str | None) -> int | None:
+    """Return an int, or None if unparseable / null-like."""
+    s = (raw or "").strip()
+    if not s or s.lower() in {"nan", "none", "null"}:
+        return None
+    try:
+        # Tolerate "10.0" style values (CSV exports sometimes coerce ints).
+        return int(float(s))
+    except (ValueError, OverflowError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Record building
+# ---------------------------------------------------------------------------
+
+
+def _build_record(row: dict[str, str], horizon: str) -> dict | None:
+    """Build the per-row API payload for a runoff PENTAD/DECADE record.
+
+    Implements the universal safe-write rule: only non-NULL fields are
+    included in the returned dict. Required fields per ``RunoffBase``
+    (``horizon_type``, ``code``, ``date``, ``horizon_value``,
+    ``horizon_in_year``) are always included; ``discharge`` / ``predictor``
+    are omitted when the source value is absent / unparseable.
+
+    Args:
+        row: CSV row as ``{column_name: value_str}``.
+        horizon: ``"pentad"`` or ``"decade"`` (lowercase payload form).
+
+    Returns:
+        A payload dict matching ``RunoffCreate``, or ``None`` if the row
+        cannot satisfy the required fields (caller treats this as a parse
+        skip).
+    """
+    if horizon not in _HORIZON_TO_PAYLOAD:
+        return None
+
+    code = (row.get("code") or "").strip()
+    date_str = (row.get("date") or "").strip()[:10]
+    if not code or not date_str:
+        return None
+    try:
+        datetime.date.fromisoformat(date_str)
+    except ValueError:
+        return None
+
+    horizon_value = _parse_int(row.get("horizon_value"))
+    horizon_in_year = _parse_int(row.get("horizon_in_year"))
+    if horizon_value is None or horizon_in_year is None:
+        return None
+
+    rec: dict = {
+        "horizon_type": _HORIZON_TO_PAYLOAD[horizon],
+        "code": code,
+        "date": date_str,
+        "horizon_value": horizon_value,
+        "horizon_in_year": horizon_in_year,
+    }
+
+    # --- Optional float fields (discharge, predictor) ---
+    for col in _FLOAT_FIELDS:
+        v = _parse_float(row.get(col))
+        if v is not None:
+            rec[col] = v
+
+    return rec
+
+
+def _read_filtered_records_with_manifest(
+    csv_path: Path,
+    manifest_path: Path,
+    horizon: str,
+    *,
+    cutoff: str | None,
+    station_filter: str | None,
+) -> tuple[
+    list[dict],
+    dict[str, int],
+    set[str],
+    str | None,
+    str | None,
+]:
+    """Read CSV (manifest-validated) and return per-record state.
+
+    Manifest validation is performed BEFORE record building so a stale or
+    cross-org CSV is rejected up front (catches the security-relevant leak
+    case described in P0 §Q5).
+
+    Args:
+        csv_path: path to the export CSV.
+        manifest_path: path to the sibling ``.manifest`` file (passed for
+            error message clarity; the actual validation reads
+            ``<csv_path>.manifest`` via ``_common.validate_manifest``).
+        horizon: ``"pentad"`` or ``"decade"``.
+        cutoff: optional ISO date; rows with ``date >= cutoff`` are dropped.
+            None means full-import (no date filter).
+        station_filter: optional single station code; rows whose ``code``
+            does not match are dropped. None means no station filter.
+
+    Returns:
+        Tuple ``(records, counters, distinct_codes, date_min, date_max)`` where:
+            - records: list of payload dicts (only non-NULL fields, post-filter).
+            - counters: dict with ``source_row_count``, ``filtered_row_count``,
+              ``skipped_parse``, ``skipped_cutoff``, ``skipped_station``.
+            - distinct_codes: set of codes that survived ALL filters.
+            - date_min / date_max: source CSV date range (pre-filter).
+
+    Raises:
+        ValueError: if required columns are missing.
+        _common.ManifestError (or subclass): if manifest validation fails.
+    """
+    # Validate manifest first; any failure raises an explicit subclass of
+    # ManifestError (caught by main() and reported with non-zero exit).
+    _common.validate_manifest(csv_path, "runoff_period")
+
+    # manifest_path is documented for the caller; we don't read it directly
+    # here because validate_manifest derives the sidecar path itself.
+    _ = manifest_path
+
+    counters = {
+        "source_row_count": 0,
+        "filtered_row_count": 0,
+        "skipped_parse": 0,
+        "skipped_cutoff": 0,
+        "skipped_station": 0,
+    }
+    records: list[dict] = []
+    distinct_codes: set[str] = set()
+    date_min: str | None = None
+    date_max: str | None = None
+
+    with csv_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        header = list(reader.fieldnames or [])
+        missing = _REQUIRED_COLUMNS_BASE - set(header)
+        if missing:
+            raise ValueError(
+                f"CSV {csv_path.name} is missing required column(s): {sorted(missing)}"
+            )
+
+        for row in reader:
+            counters["source_row_count"] += 1
+            code = (row.get("code") or "").strip()
+            date_str = (row.get("date") or "").strip()[:10]
+
+            # Track source date range pre-filter (for dry-run inventory).
+            if date_str:
+                if date_min is None or date_str < date_min:
+                    date_min = date_str
+                if date_max is None or date_str > date_max:
+                    date_max = date_str
+
+            if not code or not date_str:
+                counters["skipped_parse"] += 1
+                continue
+
+            # Station filter (applied before cutoff for clarity in counters).
+            if station_filter is not None and code != station_filter:
+                counters["skipped_station"] += 1
+                continue
+
+            # Cutoff filter (strictly less than cutoff).
+            if cutoff is not None and date_str >= cutoff:
+                counters["skipped_cutoff"] += 1
+                continue
+
+            record = _build_record(row, horizon)
+            if record is None:
+                counters["skipped_parse"] += 1
+                continue
+
+            records.append(record)
+            distinct_codes.add(code)
+            counters["filtered_row_count"] += 1
+
+    return records, counters, distinct_codes, date_min, date_max
+
+
+# ---------------------------------------------------------------------------
+# HTTP POST
+# ---------------------------------------------------------------------------
+
+
+def _post_batch(
+    batch: list[dict],
+    url: str,
+    *,
+    timeout: float = 120.0,
+) -> tuple[bool, str]:
+    """POST a single batch envelope to the API.
+
+    The preprocessing API expects ``{"data": [<record>, ...]}`` per the
+    ``RunoffBulkCreate`` schema. Returns ``(ok, message)``.
+    """
+    body = json.dumps({"data": batch}).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            return (200 <= resp.status < 300), f"HTTP {resp.status}"
+    except urllib.error.HTTPError as e:
+        body_txt = ""
+        with contextlib.suppress(Exception):
+            body_txt = e.read().decode("utf-8", errors="replace")[:200]
+        return False, f"HTTP {e.code}: {body_txt}"
+    except Exception as e:  # noqa: BLE001
+        return False, f"{type(e).__name__}: {e}"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python3 -m migration_py.runoff_period",
+        description=(
+            "Push runoff PENTAD/DECADE laptop-export CSV rows to the preprocessing API (P2a)."
+        ),
+    )
+    p.add_argument(
+        "--csv-path",
+        required=True,
+        type=Path,
+        help="Path to the runoff_period export CSV inside the container.",
+    )
+    p.add_argument(
+        "--manifest-path",
+        required=True,
+        type=Path,
+        help="Path to the sidecar ``<csv>.manifest`` file (for error clarity).",
+    )
+    p.add_argument(
+        "--horizon",
+        required=True,
+        choices=sorted(_HORIZON_TO_PAYLOAD.keys()),
+        help="Which horizon the CSV holds: 'pentad' or 'decade'.",
+    )
+    p.add_argument(
+        "--api-url",
+        required=True,
+        help="Preprocessing API endpoint URL (e.g. http://localhost:8002/runoff/).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,
+        help="Records per POST batch (default 500).",
+    )
+    p.add_argument(
+        "--cutoff",
+        default=None,
+        help="ISO date; rows with date >= cutoff are dropped (pre-cutoff mode).",
+    )
+    p.add_argument(
+        "--station-filter",
+        default=None,
+        help="Filter to a single station code.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Read + filter only; do NOT POST.",
+    )
+    return p
+
+
+def _print_dry_run_inventory(
+    *,
+    csv_path: Path,
+    horizon: str,
+    counters: dict[str, int],
+    distinct_codes: set[str],
+    date_min: str | None,
+    date_max: str | None,
+    mode: str,
+    cutoff: str | None,
+) -> None:
+    """Emit the §4.4 runbook dry-run inventory block.
+
+    Lines are printed on stdout (the wrapper tees them into its log file).
+    Station codes are NEVER printed individually — only the redacted count
+    via ``log_redacted_station_count``.
+    """
+    print(f"MODE={mode}" + (f" (cutoff={cutoff})" if cutoff else " (target empty)"))
+    print("TARGET_TABLE=runoffs")
+    print(f"HORIZON_TYPE={horizon.upper()}")
+    print(f"CUTOFF={cutoff if cutoff else 'none'}")
+    print(f"SOURCE_FILES=['{csv_path}']")
+    print(f"SOURCE_ROW_COUNT={counters['source_row_count']}")
+    print(f"FILTERED_ROW_COUNT={counters['filtered_row_count']}")
+    print(f"SOURCE_DATE_MIN={date_min if date_min else 'none'}")
+    print(f"SOURCE_DATE_MAX={date_max if date_max else 'none'}")
+    print(f"DISTINCT_STATION_COUNT_REDACTED={len(distinct_codes)}")
+    print(
+        f"SKIPPED_PARSE={counters['skipped_parse']} "
+        f"SKIPPED_CUTOFF={counters['skipped_cutoff']} "
+        f"SKIPPED_STATION={counters['skipped_station']}"
+    )
+    # Safe-write policy line so operators see the active mode in the inventory.
+    # P2a runs enrichment-only only; no --strict-merge sibling for this narrow
+    # table (the wide-stat-erasure risk that motivated --strict-merge in P2b
+    # does not apply to runoff_period, which has just two nullable fields).
+    print("SAFE_WRITE_POLICY=enrichment-only (default)")
+    # Redacted log line (count only, never the actual codes).
+    _common.log_redacted_station_count(
+        logger, sorted(distinct_codes), message_prefix="post_filter_stations"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    csv_path: Path = args.csv_path
+    manifest_path: Path = args.manifest_path
+    if not csv_path.is_file():
+        print(f"ERROR: CSV not found: {csv_path}", file=sys.stderr)
+        return 1
+    # The manifest path is allowed to be a hint; _common.validate_manifest
+    # derives the sidecar path from the CSV path. We still surface a clear
+    # error if the operator-supplied hint doesn't exist on disk.
+    if not manifest_path.is_file():
+        print(f"ERROR: manifest not found: {manifest_path}", file=sys.stderr)
+        return 1
+
+    # MODE is decided by the wrapper from the psql query; we just receive
+    # the cutoff (or None) and pass it through.
+    cutoff: str | None = args.cutoff
+    mode = "pre-cutoff" if cutoff else "full-import"
+
+    horizon: str = args.horizon
+
+    try:
+        records, counters, distinct_codes, date_min, date_max = (
+            _read_filtered_records_with_manifest(
+                csv_path,
+                manifest_path,
+                horizon,
+                cutoff=cutoff,
+                station_filter=args.station_filter,
+            )
+        )
+    except _common.ManifestError as exc:
+        print(f"ERROR: manifest validation failed: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    _print_dry_run_inventory(
+        csv_path=csv_path,
+        horizon=horizon,
+        counters=counters,
+        distinct_codes=distinct_codes,
+        date_min=date_min,
+        date_max=date_max,
+        mode=mode,
+        cutoff=cutoff,
+    )
+
+    if args.dry_run:
+        print("DRY RUN: no POSTs attempted.")
+        return 0
+
+    if not records:
+        print("No records to POST after filtering; exiting 0.")
+        return 0
+
+    n = len(records)
+    batch_size = max(1, args.batch_size)
+    n_batches = (n + batch_size - 1) // batch_size
+    sent = 0
+    failed = 0
+    for i in range(0, n, batch_size):
+        batch = records[i : i + batch_size]
+        batch_num = i // batch_size + 1
+        ok, msg = _post_batch(batch, args.api_url)
+        if ok:
+            sent += len(batch)
+        else:
+            failed += len(batch)
+            print(
+                f"  batch {batch_num}/{n_batches} FAILED: {msg}",
+                file=sys.stderr,
+            )
+        if batch_num % 20 == 0 or batch_num == n_batches:
+            print(f"  progress {batch_num}/{n_batches} ({sent}/{n} sent)")
+
+    print(f"GRAND TOTAL: sent={sent} failed={failed} (of {n} eligible records)")
+    return 0 if failed == 0 else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/doc/plans/issues/high_prio_gi_draft_update_migration_p2a_runoff_period.md
+++ b/doc/plans/issues/high_prio_gi_draft_update_migration_p2a_runoff_period.md
@@ -1,0 +1,303 @@
+# P2a: runoff PENTAD/DECADE laptop-export -> CSV -> API push
+
+## Summary
+
+Adds the laptop-export -> CSV+manifest -> server-import pipeline for the
+narrow `runoffs` PENTAD/DECADE table, completing the runoff family for the
+update-time migration toolkit (sibling to P1a which covers runoff DAY via
+the CSV-source path, and to P2b which covers hydrograph PENTAD/DECADE via
+the same DB-source shape but with a much wider payload).
+
+This is the **first DB-source phase to merge end-to-end on
+`develop_migration_toolkit`** with the P0 manifest contract exercised on
+both the emit side (export script writes `<csv>.manifest`) and the
+validate side (server-side wrapper rejects mismatches before any POST).
+
+## Scope
+
+Files added or modified:
+
+- `bin/export_runoff_period_history.sh` (NEW) — laptop-side export
+- `bin/initialize_runoff_period_history.sh` (NEW) — server-side import
+- `bin/utils/migration_py/runoff_period.py` (NEW) — stdlib-only POST helper
+- `apps/iEasyHydroForecast/tests/test_export_runoff_period.py` (NEW) — 18 tests
+- `apps/iEasyHydroForecast/tests/test_initialize_runoff_period.py` (NEW) — 32 tests
+- `apps/iEasyHydroForecast/tests/fixtures/migration_csv/runoff_period/` (NEW)
+  - `pentad_sample.csv` + `pentad_sample.csv.manifest`
+  - `decade_sample.csv` + `decade_sample.csv.manifest`
+- `doc/prod/update_data_migration_runbook.md` (MOD) — §6 preamble + §6.1
+- `doc/plans/issues/high_prio_gi_draft_update_migration_p2a_runoff_period.md` (NEW, this file)
+
+Out of scope (deliberately, per brief):
+
+- No edits under `sapphire/services/` — the API contract is fixed and
+  served by the existing `RunoffBulkCreate` endpoint.
+- No edits to §6.2 of the runbook — that section is P2b's territory and
+  lands on its own branch (PR #350).
+- No placeholders for §6.3+ siblings — P4a / P4b / P5 add their own
+  sections.
+
+## Load-bearing schema correction: `discharge`, not `discharge_avg`
+
+An earlier sub-orch brief mistakenly named the runoff value column
+`discharge_avg`. The actual DB column on the `runoffs` model is
+`discharge`:
+
+```python
+# sapphire/services/preprocessing/app/models.py:16-28
+class Runoff(Base):
+    __tablename__ = "runoffs"
+    ...
+    # Runoff values
+    discharge = Column(Float)
+    predictor = Column(Float)
+```
+
+The API payload key on `RunoffBase` is also `discharge`
+(`sapphire/services/preprocessing/app/schemas.py:7-14`). The
+`discharge_avg` name does appear in the codebase — but only as the
+CSV-source migrator's column name when ingesting the wide
+`intermediate_data/runoff_pentad.csv` shape:
+
+```python
+# sapphire/services/preprocessing/app/data_migrator.py:202-216
+def prepare_pentad_data(self, df: pd.DataFrame) -> List[Dict]:
+    ...
+    "discharge": float(row['discharge_avg']) if pd.notna(row['discharge_avg']) else None,
+    ...
+```
+
+The CSV column `discharge_avg` -> payload key `discharge` rename happens
+inside that migrator; the DB-source path that this PR adds reads the
+canonical DB column directly and forwards it under the same payload key.
+There is no rename anywhere in the P2a pipeline.
+
+The correction is enforced at three levels in this PR:
+
+1. **Export script** — the `COPY (SELECT ...)` lists `discharge` as a
+   column name. ShellCheck-clean, runs against the laptop's DB.
+2. **Python helper** — `_FLOAT_FIELDS = ("discharge", "predictor")`.
+   `_build_record()` reads `row.get("discharge")` and forwards under
+   the same key.
+3. **Test suite** — `test_build_record_uses_discharge_not_discharge_avg`
+   plus `test_pentad_csv_uses_discharge_not_discharge_avg` /
+   `test_decade_csv_uses_discharge_not_discharge_avg` lock in the
+   correct name at both the code and the fixture level, so a future
+   contributor cannot silently rename it back.
+
+## Design decisions
+
+### No `--strict-merge` follow-up
+
+P2b ships `--strict-merge` as a parsed-but-deferred CLI flag (logs a
+warning, falls back to enrichment-only) because the wide hydrograph
+PENTAD/DECADE row carries a real stat-erasure risk under the
+service-side `_has_changes` + `setattr` overwrite-with-NULL path
+(architecture §Q2 layer 2).
+
+P2a deliberately does NOT introduce a `--strict-merge` flag. The runoff
+PENTAD/DECADE row is narrow — only `discharge` and `predictor` are
+nullable, and neither is computed from quantiles or year-rotated source
+data. The wide-stat-erasure scenario does not apply. The enrichment-only
+default is sufficient and the dry-run inventory's
+`SAFE_WRITE_POLICY=enrichment-only (default)` line confirms it to the
+operator before any write.
+
+If a future need arises (e.g., a new wide `runoffs` schema variant), the
+P2b `--strict-merge` shape is the documented forward path; a follow-up
+PR can copy the flag verbatim.
+
+### Manifest contract validated end-to-end
+
+The P0 helper `migration_py._common.validate_manifest` enforces 5
+required keys on the sidecar: `export_type`, `row_count`,
+`station_count`, `date_min`, `date_max`. This PR is the first DB-source
+phase to wire both sides of the contract:
+
+- The export script computes `row_count`, `station_count`, `date_min`,
+  `date_max` from the CSV it just wrote (NOT from the stations-file
+  input count) so the contract catches mid-flight tampering.
+- The server-side wrapper calls `umh_validate_export_manifest` BEFORE
+  any image work or psql probes, so a stale or cross-org CSV is
+  rejected up front (the security-relevant leak case from P0 §Q5).
+
+The shipped fixture pair (pentad + decade) round-trips through the
+parser in the test suite — proof that the contract holds across the
+manifest write -> validate boundary.
+
+### Lowercase `horizon_type` on payload
+
+The DB row uses uppercase `'PENTAD'` / `'DECADE'` (SQLAlchemy enum
+storage), but the API accepts lowercase via the FastAPI Pydantic
+HorizonType enum (`pentad`, `decade`). The export script emits
+`lower(horizon_type::text)` in the `COPY (SELECT ...)` to keep the
+serialized form consistent across the Python helper and the wire
+payload — matching the convention established by P1a and P2b.
+
+### MODE detection per-horizon
+
+The wrapper queries the target preprocessing-db once via `docker exec
+psql`, filtered on `horizon_type='PENTAD'` or `'DECADE'`. This avoids
+the cross-horizon cutoff bug where a populated PENTAD table would
+suppress writes to an empty DECADE table (or vice versa). Each wrapper
+invocation handles one horizon and emits the corresponding MODE label
+to the dry-run inventory.
+
+### Stdlib-only Python helper
+
+`bin/utils/migration_py/runoff_period.py` imports only stdlib modules
+plus the intra-package `_common`. The `_audit.audit_stdlib_only` test
+enforces this rule across the whole `migration_py` package; the P2a
+test suite re-runs it as a regression guard. This keeps the helper
+self-contained for the prepgateway image without dragging a numpy /
+pandas dependency tree along.
+
+## CLI surface
+
+### Export (laptop side)
+
+```text
+bash bin/export_runoff_period_history.sh \
+    --horizon pentad|decade \
+    --stations-file PATH \
+    --out-dir PATH \
+    [--dry-run]
+```
+
+- `--horizon`: which subset of `runoffs` to export. Mandatory; rejects
+  any other value.
+- `--stations-file`: deployment's station-code list, one per line.
+  Empty lines + whitespace trimmed. SQL-injection guard rejects any
+  line containing an apostrophe.
+- `--out-dir`: created with mode `0700` if missing; CSV + manifest are
+  written with mode `0600`.
+- `--dry-run`: runs the COUNT(*) shape; emits nothing to disk.
+
+Location guard: if any
+`sapphire-{preprocessing,postprocessing,api-gateway}-...` container is
+visible via `docker ps`, the script refuses with a clear message
+pointing the operator at the server-side wrapper instead. Testing-only
+bypass via `_P2A_EXPORT_SKIP_LOCATION_GUARD=1`.
+
+### Import (server side)
+
+```text
+bash bin/initialize_runoff_period_history.sh <env_file_path> \
+    --from-export <csv_path> \
+    --horizon pentad|decade \
+    [--dry-run] [--api-url URL] [--batch-size N] [--image IMAGE] \
+    [--station-filter CODE]
+```
+
+- `env_file_path`: positional; the `.env_<org>` file.
+- `--from-export`: path to the transferred CSV. The sibling
+  `<PATH>.manifest` must exist.
+- `--horizon`: `pentad` or `decade`. Mandatory.
+- `--api-url`: default `http://localhost:8002/runoff/`.
+- `--batch-size`: default 500.
+- `--image`: docker image override; falls back to the P0 helper
+  resolution (CLI -> configured tag -> `:latest`).
+- `--station-filter`: P0 binding interface contract; honored
+  identically by P1a / P1b / P1c / P2b / P3.
+
+## Test coverage
+
+50 tests total across the two new test files (24 above the brief's
+18-minimum target). All pass with zero skips except the
+`test_location_guard_fires_when_sapphire_containers_present` predicate,
+which auto-skips when the SAPPHIRE stack is not running locally — a
+deterministic-skip permitted by the Zero Skips Policy because the guard
+physically cannot fire without the trigger condition.
+
+Highlights of the test surface:
+
+- CLI surface: `--help`, missing-arg rejection, invalid-horizon
+  rejection, station-filter contract documented in help text.
+- Record building: required-field enforcement, optional-field omission
+  when NULL/NaN/blank/garbage, legacy `discharge_avg` column ignored,
+  non-finite-float rejection.
+- Filtering: station-filter + cutoff combinations, distinct-code
+  counter, date-range tracking pre-filter.
+- Manifest validation: missing-manifest, row-count mismatch, wrong
+  `export_type`, missing-column CSV.
+- Dry-run inventory shape: every documented `KEY=value` line is
+  asserted, including `TARGET_TABLE=runoffs`, `HORIZON_TYPE=PENTAD`,
+  `MODE=pre-cutoff (cutoff=...)`, `DISTINCT_STATION_COUNT_REDACTED=N`,
+  `SAFE_WRITE_POLICY=enrichment-only (default)`.
+- Stdlib-only audit: re-runs the P0 `_audit.audit_stdlib_only` check on
+  the whole `migration_py` package.
+- Fixture round-trip: shipped pentad + decade CSV+manifest pairs parse
+  through `_read_filtered_records_with_manifest` and produce the
+  expected record + counter + date-range tuple.
+- Schema correction lock-ins: dedicated tests at both the code level
+  (payload key) and fixture level (CSV header) that fail loudly if
+  anyone renames `discharge` back to `discharge_avg`.
+
+Full `iEasyHydroForecast` suite at the end of the PR: 434 passed, 0
+failed, 0 unexpected skips.
+
+## Sentinel discipline
+
+Every fixture and test uses sentinel codes only (`19999` and the
+`00000`..`00009` HRU range). No real station codes appear in any
+committed artifact. The shipped fixture CSVs were grepped for any 5-digit
+sequence that isn't in the sentinel allowlist as part of the test suite
+(`test_pentad_sample_fixture_only_sentinel_codes` /
+`test_decade_sample_fixture_only_sentinel_codes`).
+
+## Operational guidance
+
+The runbook §6.1 walks the operator through the full pipeline:
+
+- `awk` recipe to derive the stations file from
+  `intermediate_data/runoff_day.csv` on the deployment server (then scp
+  to the laptop for the export).
+- Pre-flight `umask 077` / `~/.pgpass` setup.
+- Two-step laptop export (dry-run for COUNT(*); real run if counts
+  match).
+- scp transfer recipe.
+- Server-side dry-run with the full expected inventory shape and
+  enumerated common failure causes.
+- Single-station canary per §4.3 acceptance criterion.
+- Full population per horizon with all tunables documented.
+- Acceptance SQL block for runoff (per-horizon GROUP BY with
+  `discharge_rows` and `predictor_rows` non-null counts).
+- Rerun / idempotency notes pointing operators at
+  `--station-filter <code>` + lower `--batch-size` for narrow reruns.
+
+## Sibling coordination
+
+- P2b (hydrograph PENTAD/DECADE) is in flight on
+  `feature_p2b_hydrograph_period_history`. Both branches modify
+  `doc/prod/update_data_migration_runbook.md` (this PR adds §6
+  preamble + §6.1; P2b adds §6.2). A merge conflict is expected and is
+  trivial to resolve in either direction: the two §6.x subsections do
+  not overlap.
+- P4a (LR forecasts), P4b (ML forecasts), P5 (long forecasts) will add
+  §6.3 / §6.4 / §6.5 respectively. No placeholders are added in this
+  PR to avoid stale-section pollution.
+- No edits to shared P0 files (`bin/utils/update_migration_helpers.sh`,
+  `bin/utils/migration_py/_common.py`, `_audit.py`).
+
+## Verification checklist (pre-merge)
+
+- [x] `shellcheck` clean on both bash wrappers (verified via pre-commit
+  hook; second invocation in tests run subprocess against `bash`
+  successfully).
+- [x] Both `--help` flags return exit 0 with documented usage block.
+- [x] `iEasyHydroForecast` suite: 434 passed, 0 failed.
+- [x] All P2a payload keys use `discharge` (greppable: there is no
+  `discharge_avg` anywhere under `bin/` or in the runoff_period
+  fixtures).
+- [x] No real station codes anywhere; sentinel discipline enforced via
+  the fixture-only-sentinel-codes tests.
+- [x] No edits to `sapphire/services/`.
+- [x] Manifest validation exercised end-to-end (round-trip test on the
+  shipped fixtures).
+- [x] Runbook §6 preamble + §6.1 in place; §6.2 untouched (P2b
+  territory); §6.3+ not stubbed.
+
+## PR target
+
+`develop_migration_toolkit`. Branch `feature_p2a_runoff_period_history`
+already pushed.

--- a/doc/prod/update_data_migration_runbook.md
+++ b/doc/prod/update_data_migration_runbook.md
@@ -596,18 +596,269 @@ cutoff. For full-import mode, both should match the source date range.
 
 ## 6. Laptop local-export migrations
 
-[Filled by P2a (runoff PENTAD/DECADE), P2b (hydrograph PENTAD/DECADE), P4a
-(LR forecasts), P4b (ML forecasts), P5 (long forecasts). Each section gives:
-- Laptop side: `psql -X` COPY command with station filter and `umask 077`.
-- Manifest emission: `<export>.manifest` next to the CSV (the 5 required
-  keys validated by `migration_py._common.validate_manifest`: `export_type`,
-  `row_count`, `station_count`, `date_min`, `date_max`).
-- Transfer: scp both files together.
-- Server side: wrapper invocation with `--from-export` pointing at the
-  transferred CSV.
-- Location-guard verification: refuses to run on a host where deployment
-  containers are present (Stage E item #6 for export scripts).
-]
+Tables whose authoritative content lives in the laptop's source DB (rather
+than in a deployment-side CSV under `intermediate_data/`) follow a
+laptop-export -> CSV+manifest -> server-import shape:
+
+- **Laptop side:** `psql -X` `COPY (SELECT ...) TO STDOUT` filtered by the
+  deployment's station list, plus a manifest sidecar (`<export>.csv.manifest`)
+  with the 5 required keys validated by
+  `migration_py._common.validate_manifest`: `export_type`, `row_count`,
+  `station_count`, `date_min`, `date_max`. `umask 077` and tight perms
+  (`0600`) protect operationally-sensitive content while in transit.
+- **Transfer:** scp BOTH files together. The server-side wrapper refuses
+  to run if the manifest is missing or fails validation.
+- **Server side:** the corresponding `bin/initialize_*_history.sh`
+  wrapper invoked with `--from-export <csv_path>`. The wrapper validates
+  the manifest first, then runs the per-row push under the prepgateway
+  image (P0 helper toolkit).
+- **Location-guard verification:** every export script refuses to run on
+  a host where deployment containers are present (Stage E item #6); the
+  export is meant for the OPERATOR LAPTOP / jump host only.
+
+### 6.1 Runoff PENTAD/DECADE
+
+Source: laptop's local `sapphire-preprocessing-db.runoffs` table,
+filtered on `horizon_type IN ('PENTAD','DECADE')` and on the deployment's
+station list. Target: `runoffs` rows with `horizon_type='PENTAD'` or
+`horizon_type='DECADE'` (one wrapper run per horizon). MODE branches on
+target state per-horizon — empty target = `full-import`; populated
+target = `pre-cutoff (cutoff=MIN(date))`. Reruns are idempotent
+(service-side upsert on `(horizon_type, code, date)`).
+
+#### Background
+
+The `runoffs` PENTAD/DECADE rows are the period-aggregated discharge
+record used by linear-regression and ML forecasters as predictor input.
+Each row carries two nullable floats — `discharge` and `predictor` — and
+the natural-key trio `(horizon_type, code, date)` plus
+`horizon_value` / `horizon_in_year`. The intermediate-data CSV
+(`runoff_*.csv` under `intermediate_data/`) is the operational write
+path but does not preserve the full historical record consistently
+across deployments — for the update-time migration we therefore go
+through the laptop's preprocessing DB instead.
+
+**Column-name correction (load-bearing).** The DB column on `runoffs`
+is `discharge` — **not** `discharge_avg`. The `discharge_avg` form is
+the CSV-source migrator column name in
+`sapphire/services/preprocessing/app/data_migrator.py:210`, used when
+ingesting the wide intermediate CSV. The DB column, the API payload
+key, the export CSV header, and the server-side helper all use
+`discharge` throughout. There is no rename anywhere in the P2a
+pipeline.
+
+**Safe-write policy (architecture §Q2 layer 2).** The wrapper sends
+only non-NULL source fields per the universal safe-write rule. Unlike
+hydrograph PENTAD/DECADE (§6.2), the runoff row is narrow: only
+`discharge` and `predictor` are nullable, so the wide stat-erasure risk
+that motivated `--strict-merge` for hydrograph does not apply here. The
+dry-run inventory prints `SAFE_WRITE_POLICY=enrichment-only (default)`
+so the operator confirms the active policy before any write. No
+`--strict-merge` opt-in is implemented or planned for this wrapper.
+
+**End-to-end manifest contract.** P2a is the first DB-source phase to
+land on `develop_migration_toolkit` end-to-end with the P0 manifest
+contract exercised in both the export emit-side and the import
+validate-side. The contract is verified by
+`migration_py._common.validate_manifest` (5 required keys) plus an
+intentional fixture-level lock-in (the test suite asserts that the
+shipped CSV header uses `discharge` and not `discharge_avg`).
+
+#### 6.1.1 Laptop side — export
+
+Run on the OPERATOR LAPTOP / jump host. The export script refuses to run
+on the deployment server (a `sapphire-{preprocessing,postprocessing,
+api-gateway}-...` container detected via `docker ps` triggers an
+explicit error — Stage E #6).
+
+Pre-requisites (per §3):
+
+- `~/.pgpass` mode `0600` with credentials for the laptop's
+  preprocessing DB.
+- `PGHOST` / `PGPORT` / `PGUSER` / `PGDATABASE` env vars set (no
+  password in CLI).
+- `<stations_file>` listing the deployment's station codes, one per
+  line. Generate from the deployment's `intermediate_data/runoff_day.csv`
+  (e.g. `awk -F, 'NR>1 {print $1}' /data/<org>_data/intermediate_data/runoff_day.csv | sort -u > /tmp/stations.txt`).
+- `<out_dir>` writable; will be created with mode `0o700` if missing.
+
+```bash
+# PENTAD export (do BOTH if migrating both horizons).
+bash bin/export_runoff_period_history.sh \
+    --horizon pentad \
+    --stations-file /tmp/stations.txt \
+    --out-dir /tmp/runoff_period_export \
+    --dry-run
+
+# Inspect the COUNT(*) output. If it matches expectations, run without --dry-run:
+bash bin/export_runoff_period_history.sh \
+    --horizon pentad \
+    --stations-file /tmp/stations.txt \
+    --out-dir /tmp/runoff_period_export
+
+# DECADE export (same flags; different --horizon).
+bash bin/export_runoff_period_history.sh \
+    --horizon decade \
+    --stations-file /tmp/stations.txt \
+    --out-dir /tmp/runoff_period_export
+```
+
+Each export emits TWO files in `<out_dir>`:
+
+```
+runoff_period_<horizon>_<UTC_timestamp>.csv
+runoff_period_<horizon>_<UTC_timestamp>.csv.manifest
+```
+
+Both files have mode `0600`. The manifest contains the 5 P0-required
+keys plus a `horizon=<pentad|decade>` annotation and a generation
+timestamp comment.
+
+Transfer BOTH files together to the deployment server's data root logs
+directory (or wherever the operator chooses):
+
+```bash
+scp /tmp/runoff_period_export/runoff_period_pentad_*.csv* \
+    <user>@<server>:/data/<org>_data/logs/
+scp /tmp/runoff_period_export/runoff_period_decade_*.csv* \
+    <user>@<server>:/data/<org>_data/logs/
+```
+
+If only one file lands on the server, the server-side wrapper will
+refuse (`sidecar manifest not found`).
+
+#### 6.1.2 Server side — dry-run
+
+Validate the manifest, MODE, and filtered row count BEFORE any write:
+
+```bash
+bash bin/initialize_runoff_period_history.sh "$ENV_FILE" \
+    --from-export /data/<org>_data/logs/runoff_period_pentad_<UTC_timestamp>.csv \
+    --horizon pentad \
+    --dry-run
+```
+
+Expected inventory shape (per §4.4):
+
+```text
+MODE=<full-import (target empty) | pre-cutoff (cutoff=YYYY-MM-DD)>
+TARGET_TABLE=runoffs
+HORIZON_TYPE=PENTAD
+CUTOFF=<date or none>
+SOURCE_FILES=['/runoff_period.csv']
+SOURCE_ROW_COUNT=<n>
+FILTERED_ROW_COUNT=<n>
+SOURCE_DATE_MIN=<date>
+SOURCE_DATE_MAX=<date>
+DISTINCT_STATION_COUNT_REDACTED=<n>
+SKIPPED_PARSE=<n> SKIPPED_CUTOFF=<n> SKIPPED_STATION=<n>
+SAFE_WRITE_POLICY=enrichment-only (default)
+post_filter_stations: count=<n> (all redacted)
+IMAGE=mabesa/sapphire-prepgateway:<tag> source=<cli|configured|fallback>
+```
+
+If `HORIZON_TYPE`, `MODE`, source counts, or `SAFE_WRITE_POLICY` look
+unexpected — STOP and investigate. Do NOT proceed to write.
+
+Common dry-run failure causes:
+
+- **Manifest validation error.** A typo in the stations file or a stale
+  CSV. The error names the failing key (`row_count`, `station_count`,
+  `date_min`, `date_max`, or `export_type`). Re-run the laptop export to
+  regenerate the manifest.
+- **`CSV ... is missing required column(s)`.** If the CSV header is
+  truncated or modified mid-flight, the helper rejects it before any
+  write. The required minimum columns are `code`, `date`,
+  `horizon_value`, `horizon_in_year`.
+- **Empty `FILTERED_ROW_COUNT`.** Either the cutoff is later than the
+  source's `date_max`, the station-filter was set to a code not in the
+  CSV, or the stations file didn't include any codes that the laptop DB
+  has runoff period rows for. Inspect `SOURCE_ROW_COUNT`,
+  `SOURCE_DATE_MAX`, and `SKIPPED_*` to diagnose.
+
+#### 6.1.3 Canary (single station, per §4.3 acceptance criterion)
+
+Run with a single sentinel / low-risk station code before full
+population. Substitute `<code>` with the canary code (`19999` sentinel
+when available, otherwise a single low-risk operational code):
+
+```bash
+# Canary dry-run
+bash bin/initialize_runoff_period_history.sh "$ENV_FILE" \
+    --from-export /data/<org>_data/logs/runoff_period_pentad_<UTC_timestamp>.csv \
+    --horizon pentad \
+    --dry-run --station-filter <code>
+
+# Canary write (one station only)
+bash bin/initialize_runoff_period_history.sh "$ENV_FILE" \
+    --from-export /data/<org>_data/logs/runoff_period_pentad_<UTC_timestamp>.csv \
+    --horizon pentad \
+    --station-filter <code>
+```
+
+Verify the canary row count via the §8 acceptance SQL (filtered on the
+same `code`). Then proceed to full population.
+
+#### 6.1.4 Full population (per horizon)
+
+```bash
+# Pentad
+bash bin/initialize_runoff_period_history.sh "$ENV_FILE" \
+    --from-export /data/<org>_data/logs/runoff_period_pentad_<UTC_timestamp>.csv \
+    --horizon pentad
+
+# Decade
+bash bin/initialize_runoff_period_history.sh "$ENV_FILE" \
+    --from-export /data/<org>_data/logs/runoff_period_decade_<UTC_timestamp>.csv \
+    --horizon decade
+```
+
+Tunables:
+
+- `--batch-size <N>` — records per POST batch (default `500`). Lower to
+  diagnose API-side timeouts; raise if the API tolerates larger
+  envelopes.
+- `--api-url <URL>` — override target endpoint (default
+  `http://localhost:8002/runoff/`).
+- `--image <IMAGE>` — pin a specific Docker image (overrides resolution
+  via env file's `ieasyhydroforecast_backend_docker_image_tag`).
+
+#### 6.1.5 Acceptance SQL pointer
+
+After completion (per horizon), run the §8 acceptance block. For a
+quick local check:
+
+```bash
+docker exec -i sapphire-preprocessing-db \
+  psql -U postgres -d preprocessing_db -P pager=off <<SQL
+SELECT horizon_type, COUNT(*) AS rows,
+       COUNT(discharge) AS discharge_rows,
+       COUNT(predictor) AS predictor_rows,
+       MIN(date), MAX(date)
+FROM runoffs
+WHERE horizon_type IN ('PENTAD','DECADE')
+GROUP BY horizon_type
+ORDER BY horizon_type;
+SQL
+```
+
+Compare `rows` and `MAX(date)` against the dry-run's
+`FILTERED_ROW_COUNT` and `SOURCE_DATE_MAX`. `discharge_rows` and
+`predictor_rows` reflect the enrichment-only safe-write policy: an
+existing row whose `discharge` was already populated stays populated
+even if a new source row has the field absent. For pre-cutoff mode,
+expect `MIN(date)` to be the earliest source date AND `MAX(date)` to be
+one day before the prior cutoff. For full-import mode, both should
+match the source date range.
+
+#### 6.1.6 Idempotency and rerun
+
+The natural key `(horizon_type, code, date)` is upserted service-side,
+so rerunning the same wrapper with the same args is safe. To narrow a
+rerun on failure, combine `--station-filter <code>` with a smaller
+`--batch-size` (e.g. `--batch-size 200`). On the laptop side, re-export
+into a fresh `--out-dir` if the source DB has changed since the last
+export.
 
 ## 7. Regenerate / gap-backfill hooks
 


### PR DESCRIPTION
## Summary

Adds the laptop-export → CSV+manifest → server-import pipeline for runoff
PENTAD/DECADE (`runoffs` table, `horizon_type IN ('PENTAD','DECADE')`).
Sibling to P1a (runoff DAY, CSV-source) and P2b (hydrograph PENTAD/DECADE,
same DB-source shape but wide payload). **First DB-source phase to land
end-to-end exercise of the P0 manifest contract.**

## Highlights

- **Schema correction (load-bearing):** the DB column is `discharge`, NOT
  `discharge_avg`. The `discharge_avg` form is the CSV-source migrator's
  column name in `data_migrator.py:210` — different code path. This PR
  uses `discharge` everywhere (export SELECT, payload key, fixtures) and
  lock-in tests at both code level and fixture level prevent regression.
- **End-to-end manifest contract:** both export emit-side and server
  validate-side wire up the 5-key sidecar
  (`migration_py._common.validate_manifest`); shipped fixtures round-trip
  through the parser as a regression guard.
- **No `--strict-merge` follow-up:** narrow runoff row carries no
  wide-stat-erasure risk that motivated the deferred flag in P2b.

## Files

- `bin/export_runoff_period_history.sh` (NEW, 437 lines)
- `bin/initialize_runoff_period_history.sh` (NEW, 518 lines)
- `bin/utils/migration_py/runoff_period.py` (NEW, 519 lines, stdlib-only)
- `apps/iEasyHydroForecast/tests/test_export_runoff_period.py` (NEW, 18 tests)
- `apps/iEasyHydroForecast/tests/test_initialize_runoff_period.py` (NEW, 32 tests)
- `apps/iEasyHydroForecast/tests/fixtures/migration_csv/runoff_period/` (NEW)
- `doc/prod/update_data_migration_runbook.md` (MOD — §6 preamble + §6.1; §6.2 untouched)
- `doc/plans/issues/high_prio_gi_draft_update_migration_p2a_runoff_period.md` (NEW)

## Test plan

- [x] shellcheck clean on both bash wrappers (verified via pre-commit hook)
- [x] Both `--help` flags return exit 0 (covered by tests)
- [x] `iEasyHydroForecast` suite: **434 passed, 0 failed, 0 unexpected skips**
- [x] 50 new P2a tests across both test files (target was 18+)
- [x] All payload keys use `discharge`, not `discharge_avg` (greppable; no leaks)
- [x] No real station codes anywhere; sentinel discipline enforced via tests
- [x] No edits to `sapphire/services/`
- [x] Manifest validation exercised end-to-end (round-trip on shipped fixtures)
- [x] Runbook §6.2 not touched (P2b territory); §6.3+ not stubbed for siblings

## Sibling coordination

P2b (PR #350, `feature_p2b_hydrograph_period_history`) lands §6.2 of the
runbook on its own branch. Both PRs add §6.x subsections to the same
file — a trivial merge conflict is expected and the two subsections do
not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)