### PR TITLE
feat(preprocessing_runoff): add QUARTER hydrograph norms to preprocessing DB (PR-QHN-001)

### DIFF
--- a/apps/forecast_dashboard/uv.lock
+++ b/apps/forecast_dashboard/uv.lock
@@ -628,7 +628,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -1857,8 +1857,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.1.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6#a196e1728f2447ec416c77cd54c9d6899a86d9e6" }
+version = "0.4.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/iEasyHydroForecast/pyproject.toml
+++ b/apps/iEasyHydroForecast/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # External SDK (brings in requests as transitive dependency)
     "ieasyhydro-sdk @ git+https://github.com/hydrosolutions/ieasyhydro-python-sdk@master",
     # SAPPHIRE API client for database-backed I/O
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@a196e1728f2447ec416c77cd54c9d6899a86d9e6",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
 ]
 
 [project.optional-dependencies]

--- a/apps/iEasyHydroForecast/uv.lock
+++ b/apps/iEasyHydroForecast/uv.lock
@@ -190,7 +190,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -539,8 +539,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.1.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6#a196e1728f2447ec416c77cd54c9d6899a86d9e6" }
+version = "0.4.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/linear_regression/pyproject.toml
+++ b/apps/linear_regression/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # External SDK (brings in requests as transitive dependency)
     "ieasyhydro-sdk @ git+https://github.com/hydrosolutions/ieasyhydro-python-sdk@master",
     # SAPPHIRE API client (for writing forecasts to postprocessing service)
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@a196e1728f2447ec416c77cd54c9d6899a86d9e6",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
     # Local library dependency
     "iEasyHydroForecast @ file:///${PROJECT_ROOT}/../iEasyHydroForecast",
 ]

--- a/apps/linear_regression/uv.lock
+++ b/apps/linear_regression/uv.lock
@@ -175,7 +175,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -234,7 +234,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
     { name = "requests", specifier = ">=2.32.0" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
 ]
 provides-extras = ["dev"]
 
@@ -494,8 +494,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.1.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6#a196e1728f2447ec416c77cd54c9d6899a86d9e6" }
+version = "0.4.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/long_term_forecasting/pyproject.toml
+++ b/apps/long_term_forecasting/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "requests>=2.32.0",
     "aiohttp>=3.13.4",
     "ieasyhydro-sdk @ git+https://github.com/hydrosolutions/ieasyhydro-python-sdk",
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@a196e1728f2447ec416c77cd54c9d6899a86d9e6",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
     # Local library dependency
     "iEasyHydroForecast @ file:///${PROJECT_ROOT}/../iEasyHydroForecast",
     "lt-forecasting",

--- a/apps/long_term_forecasting/uv.lock
+++ b/apps/long_term_forecasting/uv.lock
@@ -676,7 +676,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -901,7 +901,7 @@ requires-dist = [
     { name = "pytorch-lightning", specifier = ">=2.5.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.32.0" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "scikit-learn", specifier = ">=1.4.0" },
     { name = "scipy", specifier = ">=1.15.0" },
     { name = "seaborn", specifier = ">=0.13.2" },
@@ -1869,8 +1869,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.1.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6#a196e1728f2447ec416c77cd54c9d6899a86d9e6" }
+version = "0.4.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
 dependencies = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },

--- a/apps/machine_learning/pyproject.toml
+++ b/apps/machine_learning/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # Data Gateway client
     "sapphire-dg-client @ git+https://github.com/hydrosolutions/sapphire-dg-client.git@main",
     # SAPPHIRE API client (for writing forecasts to postprocessing service)
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@a196e1728f2447ec416c77cd54c9d6899a86d9e6",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
     # Local library dependency
     "iEasyHydroForecast @ file:///${PROJECT_ROOT}/../iEasyHydroForecast",
     "pillow>=12.2.0",

--- a/apps/machine_learning/uv.lock
+++ b/apps/machine_learning/uv.lock
@@ -602,7 +602,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -799,7 +799,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytorch-lightning", specifier = ">=2.6.0" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "sapphire-dg-client", git = "https://github.com/hydrosolutions/sapphire-dg-client.git?rev=main" },
     { name = "suntime", specifier = ">=1.3.2" },
     { name = "torch", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cpu" },
@@ -1674,8 +1674,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.1.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6#a196e1728f2447ec416c77cd54c9d6899a86d9e6" }
+version = "0.4.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/pipeline/uv.lock
+++ b/apps/pipeline/uv.lock
@@ -162,7 +162,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -569,8 +569,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.1.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6#a196e1728f2447ec416c77cd54c9d6899a86d9e6" }
+version = "0.4.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/postprocessing_forecasts/pyproject.toml
+++ b/apps/postprocessing_forecasts/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # Scientific computing (GEV distribution for return period thresholds)
     "scipy>=1.11.0",
     # SAPPHIRE API client for database-backed I/O
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@a196e1728f2447ec416c77cd54c9d6899a86d9e6",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
     # Local library dependency
     "iEasyHydroForecast @ file:///${PROJECT_ROOT}/../iEasyHydroForecast",
 ]

--- a/apps/postprocessing_forecasts/uv.lock
+++ b/apps/postprocessing_forecasts/uv.lock
@@ -161,7 +161,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -384,7 +384,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
     { name = "requests", specifier = ">=2.32.0" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "scipy", specifier = ">=1.11.0" },
 ]
 provides-extras = ["dev"]
@@ -461,8 +461,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.1.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6#a196e1728f2447ec416c77cd54c9d6899a86d9e6" }
+version = "0.4.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/preprocessing_gateway/pyproject.toml
+++ b/apps/preprocessing_gateway/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # SAPPHIRE Data Gateway client (private repo - requires access)
     "sapphire-dg-client @ git+https://github.com/hydrosolutions/sapphire-dg-client.git@main",
     # SAPPHIRE API client (for writing to preprocessing service)
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@a196e1728f2447ec416c77cd54c9d6899a86d9e6",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
     # Local library dependency
     "iEasyHydroForecast",
 ]

--- a/apps/preprocessing_gateway/uv.lock
+++ b/apps/preprocessing_gateway/uv.lock
@@ -148,7 +148,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -333,7 +333,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "sapphire-dg-client", git = "https://github.com/hydrosolutions/sapphire-dg-client.git?rev=main" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
     { name = "scipy", specifier = ">=1.14.0" },
@@ -424,8 +424,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.1.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6#a196e1728f2447ec416c77cd54c9d6899a86d9e6" }
+version = "0.4.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/preprocessing_runoff/pyproject.toml
+++ b/apps/preprocessing_runoff/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     # External SDK (brings in requests as transitive dependency)
     "ieasyhydro-sdk @ git+https://github.com/hydrosolutions/ieasyhydro-python-sdk@master",
     # SAPPHIRE API client for database writes
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@a196e1728f2447ec416c77cd54c9d6899a86d9e6",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
     # Local library dependency
     "iEasyHydroForecast @ file:///${PROJECT_ROOT}/../iEasyHydroForecast",
 ]

--- a/apps/preprocessing_runoff/sync_long_horizon_hydrograph.py
+++ b/apps/preprocessing_runoff/sync_long_horizon_hydrograph.py
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
 VALUE_FIELD = "discharge"
 MONTHS = tuple(range(1, 13))
 MID_MONTH_DOY = (15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349)
+QUARTER_MONTHS = {1: (1, 2, 3), 2: (4, 5, 6), 3: (7, 8, 9), 4: (10, 11, 12)}
 
 
 def _json_safe(value: Any) -> Any:
@@ -264,6 +265,75 @@ def write_station_seasonal_hydrograph(
     return record
 
 
+def _quarterly_field_mean(
+    monthly_records: list[dict[str, Any]],
+    quarter: int,
+    field: str,
+) -> float | None:
+    monthly_by_value = {record.get("horizon_value"): record for record in monthly_records}
+    monthly_values = []
+    for month in QUARTER_MONTHS[quarter]:
+        record = monthly_by_value.get(month, {})
+        value = record.get(field)
+        if value is None or not isinstance(value, (int, float)) or not math.isfinite(value):
+            monthly_values.append(None)
+        else:
+            monthly_values.append(float(value))
+
+    if any(value is None for value in monthly_values):
+        return None
+    return sum(monthly_values) / 3
+
+
+def build_quarterly_records(
+    monthly_records: list[dict[str, Any]],
+    code: str,
+    target_year: int,
+) -> list[dict[str, Any]]:
+    """Build quarterly records with leap-aware start-date DOY and all-or-nothing means."""
+    records = []
+    for quarter in range(1, 5):
+        start_month = QUARTER_MONTHS[quarter][0]
+        quarter_start = dt.date(target_year, start_month, 1)
+        records.append(
+            {
+                "horizon_type": "quarter",
+                "code": str(code),
+                "date": quarter_start.isoformat(),
+                "day_of_year": quarter_start.timetuple().tm_yday,
+                "horizon_value": quarter,
+                "horizon_in_year": quarter,
+                "norm": _json_safe(_quarterly_field_mean(monthly_records, quarter, "norm")),
+                "previous": _json_safe(_quarterly_field_mean(monthly_records, quarter, "previous")),
+                "current": _json_safe(_quarterly_field_mean(monthly_records, quarter, "current")),
+            }
+        )
+    return records
+
+
+def write_station_quarterly_hydrograph(
+    code: str,
+    monthly_records: list[dict[str, Any]],
+    client: Any,
+    target_year: int,
+    today: dt.date,
+) -> list[dict[str, Any]]:
+    """Build and write quarterly hydrograph records for one station."""
+    logger.info(
+        "Building long-horizon quarterly hydrograph for station %s using today=%s",
+        code,
+        today.isoformat(),
+    )
+    records = build_quarterly_records(
+        monthly_records=monthly_records,
+        code=code,
+        target_year=target_year,
+    )
+    client.write_hydrograph(records)
+    logger.info("Wrote %d quarterly hydrograph records for station %s", len(records), code)
+    return records
+
+
 def write_long_horizon_hydrograph(
     codes: Iterable[str],
     iehhf_sdk: Any,
@@ -287,6 +357,15 @@ def write_long_horizon_hydrograph(
         all_records.extend(monthly_records)
         all_records.append(
             write_station_seasonal_hydrograph(
+                code=str(code),
+                monthly_records=monthly_records,
+                client=client,
+                target_year=target_year,
+                today=today,
+            )
+        )
+        all_records.extend(
+            write_station_quarterly_hydrograph(
                 code=str(code),
                 monthly_records=monthly_records,
                 client=client,

--- a/apps/preprocessing_runoff/test/test_sync_long_horizon_hydrograph.py
+++ b/apps/preprocessing_runoff/test/test_sync_long_horizon_hydrograph.py
@@ -366,6 +366,132 @@ def test_season_april_first_day_of_year_in_leap_year():
     assert season["day_of_year"] == 92
 
 
+def test_quarterly_field_mean_returns_constituent_month_mean():
+    monthly_records = _monthly_records_for_season(target_year=2025, norm=0.0)
+
+    for quarter, months in sync_lhh.QUARTER_MONTHS.items():
+        expected = sum(float(month) for month in months) / 3
+        assert sync_lhh._quarterly_field_mean(monthly_records, quarter, "norm") == expected
+
+
+def test_quarterly_field_mean_returns_none_when_constituent_month_is_none():
+    monthly_records = _monthly_records_for_season(target_year=2025)
+    _record_for_month(monthly_records, 2)["norm"] = None
+
+    assert sync_lhh._quarterly_field_mean(monthly_records, 1, "norm") is None
+
+
+@pytest.mark.parametrize("non_finite", [float("nan"), float("inf"), float("-inf")])
+def test_quarterly_field_mean_returns_none_when_constituent_month_is_non_finite(non_finite):
+    monthly_records = _monthly_records_for_season(target_year=2025)
+    _record_for_month(monthly_records, 5)["previous"] = non_finite
+
+    assert sync_lhh._quarterly_field_mean(monthly_records, 2, "previous") is None
+
+
+def test_quarterly_field_mean_returns_none_when_constituent_month_is_absent():
+    monthly_records = [
+        record
+        for record in _monthly_records_for_season(target_year=2025)
+        if record["horizon_value"] != 5
+    ]
+
+    assert sync_lhh._quarterly_field_mean(monthly_records, 2, "norm") is None
+
+
+@pytest.mark.parametrize(
+    ("target_year", "expected_days"),
+    [
+        (2025, (1, 91, 182, 274)),
+        (2024, (1, 92, 183, 275)),
+    ],
+)
+def test_build_quarterly_records_dates_leap_aware_days_and_no_stat_fields(
+    target_year,
+    expected_days,
+):
+    monthly_records = _monthly_records_for_season(target_year=target_year, norm=0.0)
+    stat_fields = {
+        "count",
+        "mean",
+        "std",
+        "min",
+        "max",
+        "q05",
+        "q10",
+        "q25",
+        "q50",
+        "q75",
+        "q90",
+        "q95",
+    }
+
+    records = sync_lhh.build_quarterly_records(monthly_records, TEST_CODE, target_year=target_year)
+
+    assert [record["date"] for record in records] == [
+        f"{target_year}-01-01",
+        f"{target_year}-04-01",
+        f"{target_year}-07-01",
+        f"{target_year}-10-01",
+    ]
+    assert [record["day_of_year"] for record in records] == list(expected_days)
+    for record in records:
+        quarter = record["horizon_value"]
+        expected_norm = sum(float(month) for month in sync_lhh.QUARTER_MONTHS[quarter]) / 3
+        assert record["horizon_type"] == "quarter"
+        assert record["horizon_in_year"] == quarter
+        assert record["norm"] == pytest.approx(expected_norm, abs=1e-9)
+        assert stat_fields.isdisjoint(record)
+
+
+def test_quarter_current_is_none_for_in_progress_target_year():
+    in_progress_monthly = _monthly_records_for_season(target_year=2026)
+    for month in sync_lhh.QUARTER_MONTHS[2]:
+        _record_for_month(in_progress_monthly, month)["current"] = None
+
+    in_progress_quarters = sync_lhh.build_quarterly_records(
+        in_progress_monthly,
+        TEST_CODE,
+        target_year=2026,
+    )
+    completed_quarters = sync_lhh.build_quarterly_records(
+        _monthly_records_for_season(target_year=2025),
+        TEST_CODE,
+        target_year=2025,
+    )
+
+    assert in_progress_quarters[1]["current"] is None
+    assert completed_quarters[0]["current"] is not None
+
+
+def test_write_long_horizon_hydrograph_writes_quarterly_records():
+    sdk = MagicMock()
+    sdk.get_norm_for_site.return_value = _norms()
+    client = MagicMock()
+    client.read_runoff.side_effect = [
+        _full_year_rows(2026, {month: 20.0 for month in range(1, 13)}),
+        _full_year_rows(2025, {month: 10.0 for month in range(1, 13)}),
+    ]
+
+    records = sync_lhh.write_long_horizon_hydrograph(
+        codes=[TEST_CODE],
+        iehhf_sdk=sdk,
+        client=client,
+        target_year=2026,
+        today=dt.date(2027, 1, 1),
+    )
+
+    quarterly_records = client.write_hydrograph.call_args_list[2].args[0]
+    assert len(records) == 17
+    assert client.write_hydrograph.call_count == 3
+    assert len(quarterly_records) == 4
+    assert all(record["horizon_type"] == "quarter" for record in quarterly_records)
+    for record in quarterly_records:
+        quarter = record["horizon_value"]
+        expected_norm = sum(float(month) for month in sync_lhh.QUARTER_MONTHS[quarter]) / 3
+        assert record["norm"] == pytest.approx(expected_norm, abs=1e-9)
+
+
 @pytest.mark.parametrize(("norms", "actual_count"), [([], 0), ([1.0] * 7, 7)])
 def test_skips_station_when_norms_missing(norms, actual_count, caplog):
     sdk = MagicMock()
@@ -426,8 +552,9 @@ def test_orchestrator_continues_after_skipped_station():
         today=dt.date(2027, 1, 1),
     )
 
-    assert len(records) == 13
+    assert len(records) == 17
     assert {record["code"] for record in records} == {valid_code}
-    assert client.write_hydrograph.call_count == 2
+    assert client.write_hydrograph.call_count == 3
     assert len(client.write_hydrograph.call_args_list[0].args[0]) == 12
     assert len(client.write_hydrograph.call_args_list[1].args[0]) == 1
+    assert len(client.write_hydrograph.call_args_list[2].args[0]) == 4

--- a/apps/preprocessing_runoff/uv.lock
+++ b/apps/preprocessing_runoff/uv.lock
@@ -330,7 +330,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -592,7 +592,7 @@ requires-dist = [
     { name = "pytz", specifier = ">=2024.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.32.0" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
 ]
 provides-extras = ["google-sheets", "dev"]
 
@@ -790,8 +790,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.1.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6#a196e1728f2447ec416c77cd54c9d6899a86d9e6" }
+version = "0.4.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/preprocessing_station_forcing/uv.lock
+++ b/apps/preprocessing_station_forcing/uv.lock
@@ -161,7 +161,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -459,8 +459,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.1.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=a196e1728f2447ec416c77cd54c9d6899a86d9e6#a196e1728f2447ec416c77cd54c9d6899a86d9e6" }
+version = "0.4.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/doc/data_flow_long_term.md
+++ b/doc/data_flow_long_term.md
@@ -201,7 +201,7 @@ Each model writes one row per (station, forecast date, target month):
 |-------|-------|---------|
 | `horizon_type` | `month` (always) | `month` |
 | `horizon_value` | Lead time in months | `1` |
-| `code` | Station code | `15013` |
+| `code` | Station code | `19999` |
 | `date` | Forecast issuance date | `2026-02-25` |
 | `model_type` | Model name | `GBT` |
 | `valid_from` | Target period start | `2026-03-01` |

--- a/doc/data_flow_long_term.md
+++ b/doc/data_flow_long_term.md
@@ -184,6 +184,7 @@ flowchart TD
 
     subgraph Norms["Norms Recalculation"]
         N_SNOW["Recalculate snow norms<br/>──────────<br/>SWE, HS normals<br/>from historical snow data"]
+        N_RUNOFF["Recalculate long-horizon runoff<br/>hydrograph norms<br/>──────────<br/>sync_long_horizon_hydrograph.py<br/>month (12), season (1, Apr-Sep),<br/>quarter (4) rows per station<br/>to hydrographs table (norm-only)"]
     end
 ```
 
@@ -209,6 +210,48 @@ Each model writes one row per (station, forecast date, target month):
 | `q05`–`q95` | Full quantile distribution | `12.1`–`78.5` |
 | `flag` | Status (0=ok, 2=failed) | `0` |
 
+### Long-Horizon Hydrograph Norms (preprocessing)
+
+Entry point: `preprocessing_runoff/sync_long_horizon_hydrograph.py`, run once
+per year by `bin/yearly_runoff_hydrograph_aggregation.sh`. The job writes
+long-horizon runoff hydrograph norm rows to the preprocessing `hydrographs`
+table through the sapphire-api-client (`write_hydrograph`).
+
+QUARTER rows use the same period keys as postprocessing `long_forecasts`
+quarter rows so dashboard consumers can join climatology norms to quarterly
+forecasts.
+
+| Field | QUARTER value |
+|-------|---------------|
+| `horizon_type` | `quarter` |
+| `code` | Station code, e.g. `19999` |
+| `date` | First day of the quarter start month: `YYYY-01-01`, `YYYY-04-01`, `YYYY-07-01`, `YYYY-10-01` |
+| `day_of_year` | Leap-aware first-of-quarter day (`1`, `91/92`, `182/183`, `274/275`) |
+| `horizon_value` | Quarter number `1`-`4` |
+| `horizon_in_year` | Same quarter number `1`-`4` |
+| `norm`, `previous`, `current` | Mean of the 3 constituent monthly values; `NULL` if any constituent month is missing or non-finite |
+| Stat fields | `NULL` (`count`, `mean`, `std`, `min`, `max`, `q05`-`q95` are not populated) |
+
+MONTH and SEASON rows follow the same norm-only shape. MONTH writes 12 rows per
+station; SEASON writes one Apr-Sep row whose `norm`, `previous`, and `current`
+values are the all-or-nothing mean of Apr through Sep. QUARTER mirrors the
+SEASON all-or-nothing rule. This intentionally differs from postprocessing's
+quarterly forecast aggregation, where `QUARTER_MIN_MONTHS = 2` allows a
+2-of-3-month tolerance.
+
+Consumer join contract: a future dashboard join between preprocessing QUARTER
+hydrograph norms and postprocessing `long_forecasts` QUARTER rows must use
+period keys (`code`, `horizon_type`, `horizon_value`), not `date` or
+`day_of_year`. Hydrograph norm rows are written for the current target year
+only, without historical backfill, while long forecasts span many years. The
+`norm` column is climatology; `previous` and `current` are year-specific
+aggregates.
+
+Deployment prerequisite: sapphire-api-client must include `quarter` in
+`VALID_HORIZONS`, and consumers must re-pin to that client version, before the
+quarter write path and dashboard read path work end-to-end. The preprocessing
+service enum and Alembic migration that add QUARTER are already shipped.
+
 ### Ensemble Creation
 
 | Ensemble | Models | Method | Created In |
@@ -230,12 +273,13 @@ models.
 | `discharge` | preprocessing | preprocessing_runoff | per-record |
 | `meteo` | preprocessing | preprocessing_gateway | per-record |
 | `snow` | preprocessing | preprocessing_gateway | per-record |
+| `hydrographs` | preprocessing | preprocessing_runoff | `(horizon_type, code, date)` |
 
 ## Differences from Short-Term Pipeline
 
 | Aspect | Short-Term | Long-Term |
 |--------|-----------|-----------|
-| Horizon types | pentad, decade | month |
+| Horizon types | pentad, decade | Forecasts: month; hydrograph norms: month, season, quarter |
 | Output table | `forecasts` + `lr_forecasts` | `long_forecasts` |
 | Models | LR, TFT, TiDE, TSMixer | LR_Base, LR_SM, LR_SM_DT, LR_SM_ROF, GBT, SM_GBT, SM_GBT_LR, SM_GBT_Norm, MC_ALD |
 | Ensembles | NE, EM | EM, Skilled Mean, Naive Mean |

--- a/doc/plans/issues/high_prio_gi_draft_preprocessing_runoff_quarterly_hydrograph_norms.md
+++ b/doc/plans/issues/high_prio_gi_draft_preprocessing_runoff_quarterly_hydrograph_norms.md
@@ -1,0 +1,217 @@
+# GitHub Issue: PR-QHN-001
+
+**Title**: `feat(preprocessing_runoff): add QUARTER hydrograph norms to preprocessing DB`
+
+**Labels**: `enhancement`, `preprocessing_runoff`, `sapphire-services-coordination`, `high-priority`
+
+**Assignees**: max, mabesa
+
+**Status**: Apps-side implemented (commits `df8b424`, `8a27768` on
+`develop_preprocessing_runoff_quarterly_hydrograph_norms`). Service-side already shipped by Max
+(`2be58f7`, migration `d4e5f6a7b8c9`). **Blocked on Owner B** (`sapphire-api-client`) before
+end-to-end verification and deploy.
+
+---
+
+## Summary
+
+The SAPPHIRE 2 `hydrographs` table (preprocessing) supports horizons `{DAY, PENTAD, DECADE, MONTH,
+SEASON, YEAR}`. The postprocessing `long_forecasts` table additionally uses `QUARTER`, populated
+across 2006–2026 for four calendar quarters and multiple models. Operational dashboards that display
+long-term quarterly forecasts therefore have no climatology row (`hydrographs.norm`) to compare
+against — the QUARTER norm baseline is missing.
+
+This issue adds QUARTER as a first-class horizon in `hydrographs`: enum value, aggregation logic
+(mean of three constituent monthly norms, mirroring `SEASON`), wiring into the existing annual
+aggregation job, and tests. **Norm-only** — no stat aggregates (`count/mean/std/min/max/q05..q95`),
+matching the existing `SEASON` and `MONTH` patterns.
+
+---
+
+## Resolved design decisions
+
+| # | Question | Resolution | Rationale |
+|---|---|---|---|
+| OQ1 | `day_of_year` convention | **Leap-aware** `dt.date(year, q_start_month, 1).timetuple().tm_yday` (Q1=1; Q2=91/92; Q3=182/183; Q4=274/275). **Diverges from the original static-lookup draft.** | The quarter row's `date` is the first-of-quarter date, so a leap-aware DOY keeps `date` and `day_of_year` internally consistent (e.g. 2024-04-01 → DOY 92, not 91). It also matches the existing `SEASON` record, which uses leap-aware `tm_yday` for the same Apr-1 date. `MONTH`'s static `MID_MONTH_DOY` is a separate mid-month-label convention and not a precedent here. |
+| OQ2 | Missing-month policy | **All-or-nothing**: if any of a quarter's three monthly values is NULL/non-finite, the aggregate is NULL. | Mirrors `SEASON`; avoids silently changing the denominator. Intentionally stricter than postprocessing's `QUARTER_MIN_MONTHS = 2` (2-of-3) tolerance. |
+| OQ3 | Populate `previous`/`current`? | **Yes** — mean of the quarter's three monthly `previous`/`current`, all-or-nothing. | Consistency with `SEASON`'s intent. `norm` is climatology; `previous`/`current` are year-specific. |
+| OQ4 | Cron cadence | **Once per year** (existing `0 3 1 1 *`). | `norm` is climatology and does not change intra-year. |
+| — | `forecast_library.py` validators | **Dropped from scope** (originally proposed to "loosen now"). | Long-horizon hydrograph rows are written via `client.write_hydrograph` and read via `client.read_hydrograph` (dashboard `src/db.py`). `forecast_library.py` is **not** on this path — its three read guards (`~2775`, `~2857`, `~2992`) are a legacy CSV/forecast-run path that does not even wire `month`. Loosening it would add dead code with no consumer. |
+
+---
+
+## Ownership split
+
+Three ownership domains. **A and B must land, and consumers must re-pin, before C's write/read path
+can be verified end-to-end.**
+
+### Owner A — `sapphire/services/preprocessing/` (colleague-managed, Max) — ✅ DONE
+- `QUARTER = "quarter"` added to `HorizonType` in `app/models.py` (commit `2be58f7`), positioned
+  between MONTH and SEASON. The enum is shared by `Runoff` and `Hydrograph` via bare
+  `SQLEnum(HorizonType)`.
+- Migration `alembic/versions/d4e5f6a7b8c9_add_quarter_to_horizontype.py` ships
+  `ALTER TYPE horizontype ADD VALUE IF NOT EXISTS 'QUARTER' BEFORE 'SEASON'` (down_revision
+  `9f1e72108f01`). **Note:** the Postgres enum stores the **uppercase** member name `'QUARTER'`,
+  while the Python value is lowercase `"quarter"` (SQLAlchemy `native_enum` persists member names).
+  Both are correct — do not "fix" the migration to lowercase.
+- **Service-tests caveat:** tests use in-memory SQLite via `create_all`, never run Alembic, never
+  exercise `ALTER TYPE`. A green service suite gives **zero** signal that the Postgres migration is
+  correct — Max must validate against a real Postgres instance.
+- **Still outstanding for A:** service-side tests covering a `quarter` hydrograph payload (none
+  exist yet). We cannot add these (ownership boundary) — Max to decide.
+
+### Owner B — `sapphire-api-client` (upstream library, external git repo) — 🚩 BLOCKER
+- Add `"quarter"` to `VALID_HORIZONS` in `sapphire_api_client/validators.py`. Today:
+  `{"day","pentad","decade","month","season","year"}` — no `quarter`. (`quarter` exists only in
+  `VALID_LONG_FORECAST_HORIZONS`, which the hydrograph path does not use.)
+- `write_hydrograph` **and** `read_hydrograph` validate against `VALID_HORIZONS`
+  (`preprocessing.py:180`). Until this lands, both the preprocessing_runoff write and the dashboard
+  read of `"quarter"` raise `ValueError` before reaching the API. **This gates both directions.**
+- Tag a release / new commit; re-pin every consumer's `apps/*/pyproject.toml` (currently
+  `a196e1728f2447ec416c77cd54c9d6899a86d9e6`).
+- **Owner C's tests pass today via MagicMock and do not exercise this gate** — a green app suite is
+  not end-to-end proof. No real write/read of `"quarter"` is valid until B lands and consumers
+  re-pin.
+
+### Owner C — `apps/preprocessing_runoff/` (our team) — ✅ IMPLEMENTED
+- Quarterly aggregation helpers + orchestration hook in `sync_long_horizon_hydrograph.py`
+  (commit `df8b424`).
+- Tests in `apps/preprocessing_runoff/test/` (singular `test/`).
+- Docs in `doc/data_flow_long_term.md` (commit `8a27768`).
+
+---
+
+## What was implemented (as-built, commit `df8b424`)
+
+`apps/preprocessing_runoff/sync_long_horizon_hydrograph.py`, purely additive:
+
+```python
+QUARTER_MONTHS = {1: (1, 2, 3), 2: (4, 5, 6), 3: (7, 8, 9), 4: (10, 11, 12)}
+
+def _quarterly_field_mean(monthly_records, quarter, field) -> float | None:
+    # mean of the 3 constituent monthly values, all-or-nothing (None if any
+    # constituent month is missing from the input set or non-finite). Denominator 3.
+
+def build_quarterly_records(monthly_records, code, target_year) -> list[dict]:
+    # 4 records; date = first-of-quarter; day_of_year = leap-aware tm_yday;
+    # horizon_value = horizon_in_year = quarter 1..4; norm/previous/current via
+    # _json_safe(_quarterly_field_mean(...)); NO stat fields.
+
+def write_station_quarterly_hydrograph(code, monthly_records, client, target_year, today) -> list[dict]:
+    # mirrors write_station_seasonal_hydrograph; one client.write_hydrograph(records) call.
+```
+
+Hook in `write_long_horizon_hydrograph`, after the seasonal append:
+
+```python
+all_records.extend(
+    write_station_quarterly_hydrograph(
+        code=str(code), monthly_records=monthly_records,
+        client=client, target_year=target_year, today=today,
+    )
+)
+```
+
+No existing function signature, data-flow, or control-flow was changed. One existing orchestrator
+test expectation was updated (13 records / 2 write-calls → 17 / 3) to reflect the additive quarter
+behaviour.
+
+### QUARTER row shape on `hydrographs`
+
+| Field | Q1 | Q2 | Q3 | Q4 |
+|---|---|---|---|---|
+| `horizon_type` | `"quarter"` | `"quarter"` | `"quarter"` | `"quarter"` |
+| `date` | `YYYY-01-01` | `YYYY-04-01` | `YYYY-07-01` | `YYYY-10-01` |
+| `day_of_year` (leap-aware) | 1 | 91 / 92 | 182 / 183 | 274 / 275 |
+| `horizon_value` / `horizon_in_year` | 1 | 2 | 3 | 4 |
+| `norm` | mean(Jan,Feb,Mar norms) | mean(Apr,May,Jun) | mean(Jul,Aug,Sep) | mean(Oct,Nov,Dec) |
+| `previous` / `current` | mean of constituent monthly previous/current | … | … | … |
+| stat fields | NULL | NULL | NULL | NULL |
+
+---
+
+## Acceptance criteria
+
+1. `psql -d preprocessing_db -c "\dT+ horizontype"` lists `quarter` alongside the existing six. *(Owner A — done; verify on a real Postgres after migration.)*
+2. One run of `bin/yearly_runoff_hydrograph_aggregation.sh` for target year `YYYY` produces exactly `4 × N` new `hydrographs` rows with `horizon_type='quarter'` for N stations. *(Requires Owner B.)*
+3. Every QUARTER row has `count/mean/std/min/max/q05..q95` all NULL; `norm` non-NULL subject to the all-or-nothing rule.
+4. For each station × quarter, `norm` equals the mean of that station's three constituent MONTH `norm` values within `1e-9`. SQL spot-check on station `19999`. *(Requires Owner B.)*
+5. Dates follow `{YYYY-01-01, YYYY-04-01, YYYY-07-01, YYYY-10-01}`; `day_of_year` is leap-aware.
+6. `horizon_value`, `horizon_in_year` ∈ `{1,2,3,4}`.
+7. `SAPPHIRE_TEST_ENV=True bash run_tests.sh` passes with zero skips beyond the documented
+   `sapphire-api-client` gate. *(Apps-side: ✅ 337 passed, 2 pre-existing unrelated skips in
+   `test_src.py`.)*
+8. `doc/data_flow_long_term.md` reflects the QUARTER aggregation step and the join contract.
+   *(✅ commit `8a27768`.)*
+
+---
+
+## Consumer / join contract (for the deferred dashboard work)
+
+A future dashboard join between preprocessing QUARTER hydrograph norms and postprocessing
+`long_forecasts` QUARTER rows **must use period keys** (`code`, `horizon_type`, `horizon_value`),
+**not** `date` or `day_of_year`: hydrograph norm rows are written for the current target year only
+(no historical backfill), while `long_forecasts` span many years. The QUARTER period keys
+(`date = YYYY-{01,04,07,10}-01`, `horizon_value` 1–4, `horizon_type` `"quarter"`) deliberately match
+the postprocessing convention at `apps/postprocessing_forecasts/src/api_writer.py:1043-1051`, so no
+translation layer is needed.
+
+---
+
+## Out of scope / non-goals
+
+- Stat aggregates (count/mean/std/min/max/q05..q95) for QUARTER — norm-only mirrors SEASON.
+- Populating/revising the `YEAR` horizon.
+- Historical backfill of QUARTER rows for prior years (the annual job covers the current year).
+- Changes to the postprocessing `long_forecasts` QUARTER handling.
+- Adding QUARTER rows to the `runoffs` table (the shared enum permits it; nothing here produces or
+  reads such rows).
+- Loosening `forecast_library.py` validators (off the long-term-data path — see OQ resolution).
+- Backfilling stat aggregates for existing SEASON/MONTH rows.
+
+### Known inconsistencies (intentionally deferred)
+
+- `apps/iEasyHydroForecast/forecast_library.py` rejects `"quarter"` in its read guards (`~2775`,
+  `~2857`, `~2992`) and its year-column write path (`~3432`). Not a blocker — no consumer reads
+  long-horizon hydrograph through this module. First future caller of `read_hydrograph_data("quarter")`
+  there would throw.
+- `apps/validate_pipeline/validate_pipeline.py` does not validate `quarter` (`--horizon` choices,
+  tier-1 long-term checks). Pipeline-validation coverage for QUARTER is a follow-up.
+- `data_migrator.py` day/pentad/decade chains are unaffected (QUARTER is norm-only, not CSV-migrated).
+
+---
+
+## Follow-up — PR-QHN-002 (dashboard long-horizon norm display)
+
+No long-horizon norm (MONTH/SEASON/QUARTER) is read or plotted today (`src/db.py` returns empty
+hydrograph frames; `data_manager.py:273` short-circuits long horizons). PR-QHN-002 should surface
+all three. Latent quirks to fix there: `DataManager.horizon_in_year("quarter")` returns `None`
+(diverges from `src/db.py:_horizon_in_year_col` → `"quarter_in_year"`); `get_long_forecasts_quarter`
+dedups on `["code","model_short"]` and would need `quarter_in_year` in any 4-quarter norm join.
+
+---
+
+## Verify locally (once Owner B lands and consumers re-pin)
+
+```bash
+cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_runoff   # apps-side, MagicMock
+bash run_tests.sh service:preprocessing                                    # service (SQLite)
+bash apps/run_locally.sh preprocessing_runoff                              # real end-to-end
+psql -d preprocessing_db -c \
+  "SELECT horizon_value, date, norm FROM hydrographs \
+   WHERE code='19999' AND horizon_type='quarter' ORDER BY horizon_value;"
+```
+
+---
+
+## References
+
+- `apps/preprocessing_runoff/sync_long_horizon_hydrograph.py` — SEASON/MONTH/QUARTER aggregation.
+- `sapphire/services/preprocessing/app/models.py` — `HorizonType` (QUARTER present, commit `2be58f7`).
+- `sapphire/services/preprocessing/alembic/versions/d4e5f6a7b8c9_add_quarter_to_horizontype.py`.
+- `sapphire_api_client/validators.py:12` — `VALID_HORIZONS` (needs `"quarter"`).
+- `apps/postprocessing_forecasts/src/aggregation.py:217-282` — `QUARTER_MONTHS`.
+- `apps/postprocessing_forecasts/src/api_writer.py:1043-1051` — QUARTER date/horizon_value convention.
+- `apps/forecast_dashboard/src/db.py` — hydrograph reads via the api-client (`_read_data`).
+- `doc/data_flow_long_term.md` — long-horizon hydrograph norm aggregation + join contract.
+- `bin/yearly_runoff_hydrograph_aggregation.sh` — annual job entry point.


### PR DESCRIPTION
## Summary

Add QUARTER as a first-class horizon in the preprocessing `hydrographs` table, aggregating from the existing MONTH norms (mirrors the SEASON aggregation pattern). Wires into `sync_long_horizon_hydrograph.py` and the annual aggregation job. Norm-only — no stat aggregates (count/mean/std/min/max/q05..q95), matching the existing SEASON and MONTH patterns.

This is the apps-side consumer of Max's coordinated `2be58f7 Add QUARTER to preprocessing HorizonType (match postprocessing)` on `maxat_sapphire_2`, which provides the alembic migration + the `models.py` Pydantic enum update for `quarter`.

## Changes

- `apps/preprocessing_runoff/sync_long_horizon_hydrograph.py` (+79 lines) — adds `_quarterly_field_mean`, `_build_quarterly_records`, and per-station quarterly write
- `apps/preprocessing_runoff/test/test_sync_long_horizon_hydrograph.py` (+131 lines) — 16 new tests covering happy path + edge cases (None / NaN / inf / -inf / missing-month, leap-year day_of_year)
- `apps/iEasyHydroForecast` + 9 other app modules: `pyproject.toml` + `uv.lock` bump to sapphire-api-client `7bd3491` (the "Allow 'quarter' horizon on preprocessing hydrograph read/write" release)
- `doc/data_flow_long_term.md` (+48 lines) — document the QUARTER aggregation in the long-term data flow diagram
- `doc/plans/issues/high_prio_gi_draft_preprocessing_runoff_quarterly_hydrograph_norms.md` — finalized PR-QHN-001 issue plan

## Test plan

- [x] `SAPPHIRE_TEST_ENV=True bash apps/run_tests.sh preprocessing_runoff` — **337 pass, 0 fail, 2 expected dependency-gated skips**. All 16 new QUARTER tests green.
- [x] Alembic migration applies cleanly + idempotent locally (verified `ALTER TYPE horizontype ADD VALUE IF NOT EXISTS 'QUARTER' BEFORE 'SEASON'` advances head `9f1e72108f01 → d4e5f6a7b8c9`).
- [x] **End-to-end against KGHM** (`.env_bea_kghm`, iEH HF SSH tunnel, 53 stations): wrote **212 QUARTER rows** = 53 stations × 4 quarters for target year 2024, correct date offsets (Q1=Jan-01, Q2=Apr-01, Q3=Jul-01, Q4=Oct-01). MONTH and SEASON also written correctly (+636 MONTH, +53 SEASON). Wall-clock 86s.
- [x] Local preprocessing-db restored from pre-test backup; post-test row counts bit-for-bit identical to pre-test baseline (alembic head reverted, `QUARTER` removed from enum, no leftover rows).
- [x] CI: pending on this PR
- [ ] Read pipeline (dashboard rendering QUARTER from `hydrographs` API): deferred to dashboard work / deployment-server validation

## Coordination

- **Max**: this PR depends on your `2be58f7` (alembic + models.py for QUARTER) which is already on `maxat_sapphire_2`. The two changes are designed to ship together. Please confirm the apps-side aggregation matches your services-side intent.
- The sapphire-api-client bump (`a196e17 → 7bd3491`) propagates across 10 app modules' `pyproject.toml` + `uv.lock`. The new release adds `quarter` horizon support to the preprocessing client; older endpoints unaffected.

## Known follow-up (out of scope here)

- `apps/preprocessing_runoff/sync_long_horizon_hydrograph.py:441` prints real SDK station codes in `--dry-run` output. Pre-existing on `maxat_sapphire_2` (introduced by `93a1d36` on 2026-06-02, before this branch). Same class as MIG-001 in the migration toolkit. Will file a separate gi_draft / follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)