### PR TITLE
fix(image-resolver/runbook): remove v1.0.0 advice + add arm64 + .env prereqs (P2)

### DIFF
--- a/apps/iEasyHydroForecast/tests/test_migration_helpers.py
+++ b/apps/iEasyHydroForecast/tests/test_migration_helpers.py
@@ -46,8 +46,11 @@ def test_resolve_image_cli_override_wins():
 
 
 def test_resolve_image_configured_tag_used():
-    image, source = _common.resolve_image(None, "v1.0.0")
-    assert image == "mabesa/sapphire-prepgateway:v1.0.0"
+    # Use a dated-tag form (YYYY-MM) — the canonical operator-pin shape after
+    # Finding 4 (Tajik walkthrough): v1.0.0 was never published to Docker Hub,
+    # so test fixtures no longer enshrine it.
+    image, source = _common.resolve_image(None, "2026-06")
+    assert image == "mabesa/sapphire-prepgateway:2026-06"
     assert source == "configured"
 
 

--- a/apps/iEasyHydroForecast/tests/test_migration_image_resolver.py
+++ b/apps/iEasyHydroForecast/tests/test_migration_image_resolver.py
@@ -44,11 +44,31 @@ def test_resolve_image_warns_on_local_tag(caplog):
     assert "local" in caplog.text
 
 
-def test_resolve_image_no_warning_on_release_tag(caplog):
+def test_resolve_image_no_warning_on_dated_tag(caplog):
+    # Dated YYYY-MM tags (e.g. 2026-06) are the canonical operator-pin form
+    # after Finding 4 — v1.0.0 was never published to Docker Hub.
     caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
-    _common.resolve_image(None, "v1.0.0")
+    _common.resolve_image(None, "2026-06")
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert warnings == []
+
+
+def test_resolve_image_warning_does_not_advise_v1_0_0(caplog):
+    """Regression proof for Finding 4 (Tajik walkthrough, 2026-06-08).
+
+    The operator-facing warning previously recommended pinning to
+    ``mabesa/sapphire-prepgateway:v1.0.0``. That tag does not exist on
+    Docker Hub; operators following the advice hit a pull failure. The
+    abstract dated-tag guidance replaces it and must not regress.
+    """
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    _common.resolve_image(None, "latest")
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected at least one WARNING for unpinned :latest tag"
+    combined = " ".join(r.getMessage() for r in warnings)
+    assert "v1.0.0" not in combined, (
+        f"warning text must not advise v1.0.0 (Finding 4 regression); got: {combined!r}"
+    )
 
 
 def test_resolve_image_warn_on_unpinned_can_be_disabled(caplog):

--- a/apps/iEasyHydroForecast/tests/test_shell_image_resolver.py
+++ b/apps/iEasyHydroForecast/tests/test_shell_image_resolver.py
@@ -1,0 +1,116 @@
+"""Subprocess-driven tests for the bash umh_check_arch_platform seam.
+
+Covers Finding 5 from the Tajik runbook walkthrough (2026-06-08): the
+mabesa/sapphire-prepgateway image tags are amd64-only, so Apple Silicon
+operators must set DOCKER_DEFAULT_PLATFORM=linux/amd64 before invoking any
+wrapper. The wrappers inherit an arm64 detection check by calling
+umh_resolve_image, which in turn calls umh_check_arch_platform.
+
+These tests source bin/utils/update_migration_helpers.sh in a child bash
+process and assert on stderr. The architecture string is injected via the
+UMH_ARCH_OVERRIDE env var seam (intentional test hook in the helper) so the
+test does NOT stub `uname` on PATH.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Repo root: apps/iEasyHydroForecast/tests/test_*.py -> parents[3]
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_HELPER = _REPO_ROOT / "bin" / "utils" / "update_migration_helpers.sh"
+
+_ARM64_WARNING_SUBSTRING = "arm64/Apple Silicon host detected"
+
+
+def _run_arch_check(
+    *,
+    arch_override: str,
+    docker_default_platform: str | None,
+) -> subprocess.CompletedProcess[str]:
+    """Source the helper in a child bash and run umh_check_arch_platform.
+
+    Args:
+        arch_override: value to inject as UMH_ARCH_OVERRIDE.
+        docker_default_platform: value for DOCKER_DEFAULT_PLATFORM, or None
+            to leave it unset in the child environment.
+
+    Returns:
+        The completed process (stderr captured for assertion).
+    """
+    # Build a minimal child env. Start from PATH only so we don't inherit a
+    # stale DOCKER_DEFAULT_PLATFORM from the test runner's environment.
+    env: dict[str, str] = {
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+        "UMH_ARCH_OVERRIDE": arch_override,
+    }
+    if docker_default_platform is not None:
+        env["DOCKER_DEFAULT_PLATFORM"] = docker_default_platform
+
+    script = f'set -eo pipefail; source "{_HELPER}"; umh_check_arch_platform'
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_arm64_host_without_platform_emits_warning():
+    """Case A: arm64 host + no DOCKER_DEFAULT_PLATFORM -> warning on stderr."""
+    result = _run_arch_check(arch_override="aarch64", docker_default_platform=None)
+    assert result.returncode == 0, (
+        f"helper sourcing failed: stderr={result.stderr!r} stdout={result.stdout!r}"
+    )
+    assert _ARM64_WARNING_SUBSTRING in result.stderr, (
+        f"expected arm64 warning on stderr, got: {result.stderr!r}"
+    )
+    # The warning must direct operators to the specific env var fix.
+    assert "DOCKER_DEFAULT_PLATFORM=linux/amd64" in result.stderr
+
+
+def test_arm64_host_with_platform_set_is_silent():
+    """Case B: arm64 host + DOCKER_DEFAULT_PLATFORM=linux/amd64 -> no warning."""
+    result = _run_arch_check(
+        arch_override="aarch64",
+        docker_default_platform="linux/amd64",
+    )
+    assert result.returncode == 0, (
+        f"helper sourcing failed: stderr={result.stderr!r} stdout={result.stdout!r}"
+    )
+    assert _ARM64_WARNING_SUBSTRING not in result.stderr, (
+        f"arm64 warning must be suppressed when DOCKER_DEFAULT_PLATFORM is "
+        f"set; got stderr={result.stderr!r}"
+    )
+
+
+def test_amd64_host_never_warns():
+    """Case C: x86_64 host (no DOCKER_DEFAULT_PLATFORM) -> no warning."""
+    result = _run_arch_check(arch_override="x86_64", docker_default_platform=None)
+    assert result.returncode == 0, (
+        f"helper sourcing failed: stderr={result.stderr!r} stdout={result.stdout!r}"
+    )
+    assert _ARM64_WARNING_SUBSTRING not in result.stderr, (
+        f"amd64 hosts must not see the arm64 warning; got stderr={result.stderr!r}"
+    )
+
+
+def test_arm64_alias_also_warns():
+    """`uname -m` returns 'arm64' on macOS and 'aarch64' on Linux ARM. Both fire."""
+    result = _run_arch_check(arch_override="arm64", docker_default_platform=None)
+    assert result.returncode == 0
+    assert _ARM64_WARNING_SUBSTRING in result.stderr, (
+        f"both arm64 and aarch64 must trigger the warning; got: {result.stderr!r}"
+    )
+
+
+if __name__ == "__main__":
+    # Manual smoke run helper: `python test_shell_image_resolver.py`.
+    sys.exit(
+        subprocess.call(
+            ["pytest", "-v", __file__],
+        )
+    )

--- a/bin/utils/migration_py/_common.py
+++ b/bin/utils/migration_py/_common.py
@@ -118,8 +118,10 @@ def _warn_if_unpinned_tag(image: str) -> None:
         logger = logging.getLogger(__name__)
         logger.warning(
             "Resolved Docker image '%s' uses an unpinned tag. "
-            "Operational deployments must pin to the release tag "
-            "(e.g. mabesa/sapphire-prepgateway:v1.0.0).",
+            "Operational deployments must pin to a current dated tag "
+            "published on Docker Hub (format YYYY-MM, e.g. the latest "
+            "available). Verify available tags at "
+            "https://hub.docker.com/r/mabesa/sapphire-prepgateway/tags.",
             image,
         )
 

--- a/bin/utils/update_migration_helpers.sh
+++ b/bin/utils/update_migration_helpers.sh
@@ -77,11 +77,33 @@ umh_log_redacted() {
 }
 
 # ---------------------------------------------------------------------------
+# umh_check_arch_platform: warn Apple Silicon / arm64 operators if
+# DOCKER_DEFAULT_PLATFORM is unset. The published mabesa/sapphire-prepgateway
+# tags are currently amd64-only; without the override, docker pull fails on
+# arm64 with a "no matching manifest for linux/arm64/v8 in the manifest list"
+# error.
+#
+# Testability seam:
+#   The architecture string is taken from $UMH_ARCH_OVERRIDE when set, else
+#   `uname -m`. The override env var lets the shell test suite simulate an
+#   arm64 host without stubbing `uname` on PATH. It is an internal test hook
+#   and is intentionally NOT documented in operator-facing material.
+# ---------------------------------------------------------------------------
+umh_check_arch_platform() {
+    local _arch
+    _arch="${UMH_ARCH_OVERRIDE:-$(uname -m)}"
+    if [[ "$_arch" =~ ^(arm64|aarch64)$ && -z "${DOCKER_DEFAULT_PLATFORM:-}" ]]; then
+        echo "WARNING: arm64/Apple Silicon host detected. The mabesa/sapphire-prepgateway images are amd64-only. Set DOCKER_DEFAULT_PLATFORM=linux/amd64 before invoking the wrapper, or the docker pull will fail." >&2
+    fi
+}
+
+# ---------------------------------------------------------------------------
 # umh_resolve_image: pick CLI override > configured tag > FALLBACK.
 # Inputs:  $1 = CLI override (may be empty), $2 = configured tag (may be empty)
 # Stdout:  resolved image string
 # Stderr:  WARNING line if resolved tag is :local or :latest AND a deployment
-#          container is detected on this host.
+#          container is detected on this host. Also emits an arm64 platform
+#          warning (via umh_check_arch_platform) so every wrapper inherits it.
 #
 # NOTE: docker ps (no -a) misses stopped containers; maintenance-stopped
 # deployments fall through to Python-only warning (not elevated). Override
@@ -92,6 +114,11 @@ umh_resolve_image() {
     local configured_tag="${2:-}"
     local image=""
     local source=""
+
+    # Arm64 preflight: warn on Apple Silicon hosts without
+    # DOCKER_DEFAULT_PLATFORM=linux/amd64. Wrappers inherit this automatically
+    # by calling umh_resolve_image during their image-resolution step.
+    umh_check_arch_platform
 
     if [[ -n "$cli_override" ]]; then
         image="$cli_override"
@@ -106,11 +133,13 @@ umh_resolve_image() {
 
     # Elevated warning when an unpinned tag is resolved on a deployment host.
     # (S1 limitation comment above describes the maintenance-stopped gap.)
+    # Guidance is abstract (no literal month) because dated tags rotate
+    # month-by-month; operators verify currently-available tags on Docker Hub.
     case "$image" in
         *:local|*:latest)
             if command -v docker >/dev/null 2>&1; then
                 if [[ -n "$(docker ps --filter 'name=sapphire-preprocessing-db' --quiet 2>/dev/null)" ]]; then
-                    echo "WARNING: resolved image '${image}' uses an unpinned tag on a deployment host. Pin to a release tag (e.g. mabesa/sapphire-prepgateway:v1.0.0)." >&2
+                    echo "WARNING: resolved image '${image}' uses an unpinned tag on a deployment host. Pin to a current dated tag published on Docker Hub (format YYYY-MM, e.g. the latest available). Verify available tags at https://hub.docker.com/r/mabesa/sapphire-prepgateway/tags." >&2
                 fi
             fi
             ;;

--- a/doc/prod/update_data_migration_runbook.md
+++ b/doc/prod/update_data_migration_runbook.md
@@ -69,6 +69,8 @@ The deployment server must have:
 - The deployment's `.env_<org>` file present (positional arg to every wrapper).
 - The deployment data root with `intermediate_data/` populated for the station-list extraction.
 - Write access to `<data_root>/logs/` for the wrapper's temp workspace and log files.
+- `sapphire/.env` populated with `POSTGRES_USER`, `POSTGRES_PASSWORD`, `PREPROCESSING_DB`, `POSTPROCESSING_DB`, `USER_DB`, and `AUTH_DB`. These are the keys consumed by `bin/backup_sapphire_db.sh` (per its header comment) at §4.1. Use `sapphire/.env.example` as a template. The same populated `sapphire/.env` (full key set per `.env.example`) is what §3 uses to start services; if you started the services on this host, this file is already in place.
+- **Apple Silicon / arm64 hosts**: the `mabesa/sapphire-prepgateway` images are currently amd64-only. Set `DOCKER_DEFAULT_PLATFORM=linux/amd64` in the operator's shell before invoking any migration wrapper, or the docker pull will fail with `no matching manifest for linux/arm64/v8`. The wrappers will emit a warning on stderr if this is missing on an arm64 host.
 
 ### Laptop prerequisites (for PENTAD/DECADE/forecast exports only)
 


### PR DESCRIPTION
## Summary

Three coordinated fixes from the Tajik SAPPHIRE 2 runbook walkthrough on 2026-06-08. **P2 of a 3-phase hardening batch** (P1: ML enum SQL fix, runs in parallel; P3: integrated verification, follows).

### Findings addressed

- **Finding 4**: The wrapper warning advised operators to pin `mabesa/sapphire-prepgateway:v1.0.0`. That tag does not exist on Docker Hub — available tags are `latest`, `2026-06`, `local`, `2026-05`, `2026-04`, `py312`, `py311`, `v0.2.0`. Operators following the warning verbatim hit a `manifest not found` pull failure. Both the shell helper and the Python `_common.py` warnings now use abstract `YYYY-MM` guidance with a Docker Hub link, no literal month, no `v1.0.0`.
- **Finding 5**: All published image tags are amd64-only. Apple Silicon operators must set `DOCKER_DEFAULT_PLATFORM=linux/amd64` before invoking any wrapper, or `docker pull` fails with `no matching manifest for linux/arm64/v8`. The wrappers now emit a stderr warning via a new `umh_check_arch_platform` helper, called from `umh_resolve_image` (so every wrapper inherits it automatically). Architecture detection is testable via the `UMH_ARCH_OVERRIDE` env-var seam so CI can simulate arm64 without stubbing `uname`.
- **Finding 37**: `bin/backup_sapphire_db.sh` (invoked at runbook §4.1) requires `sapphire/.env` populated with `POSTGRES_USER`, `POSTGRES_PASSWORD`, `PREPROCESSING_DB`, `POSTPROCESSING_DB`, `USER_DB`, and `AUTH_DB`. Runbook §2 listed running containers but not the .env file — operators following §2 verbatim hit a missing-file error at §4.1. §2 now lists the file and required keys, with a pointer to `sapphire/.env.example`.

### Scope choice

This PR is **option A** (doc/wrapper hardening) — not **option B** (multi-arch image releases). No changes under `.github/workflows/`.

## Files changed (6)

- `bin/utils/update_migration_helpers.sh` — abstract warning string, new `umh_check_arch_platform` function, call site in `umh_resolve_image`
- `bin/utils/migration_py/_common.py` — abstract warning string in `_warn_if_unpinned_tag` (matches the shell helper)
- `apps/iEasyHydroForecast/tests/test_migration_helpers.py` — replace `v1.0.0` canonical pin with dated-tag form (`2026-06`)
- `apps/iEasyHydroForecast/tests/test_migration_image_resolver.py` — rename `test_resolve_image_no_warning_on_release_tag` to `_on_dated_tag`; add `test_resolve_image_warning_does_not_advise_v1_0_0` regression-proof test
- `apps/iEasyHydroForecast/tests/test_shell_image_resolver.py` — **NEW**, four subprocess-driven tests for `umh_check_arch_platform` (arm64 warns, arm64+platform-set silent, amd64 silent, `arm64`/`aarch64` aliases both fire)
- `doc/prod/update_data_migration_runbook.md` — §2 only, two new bullets (`sapphire/.env` + arm64 `DOCKER_DEFAULT_PLATFORM`)

## Off-limits paths (confirmed untouched)

- `sapphire/services/` — colleague-managed
- `.github/workflows/` — option A chosen over option B
- Other `bin/utils/migration_py/*.py` files (`ml_forecast.py`, `runoff_day.py`, `hydrograph_day.py`, `_audit.py`, `__init__.py`)
- Runbook §6.4 (P1's territory) and §10 (PR #359's territory)
- No real station codes anywhere

## Test plan

- [x] `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh iEasyHydroForecast` → **698 passed**, zero failures, zero unexpected skips
- [x] Targeted runs of `test_shell_image_resolver.py`, `test_migration_helpers.py`, `test_migration_image_resolver.py` → 20/20 passed
- [x] `git grep -nE "v1\.0\.0" bin/ doc/prod/update_data_migration_runbook.md` returns nothing
- [x] `ruff format` + `ruff check` + `shellcheck` pre-commit hooks all pass
- [ ] Server-side manual smoke (deferred to P3 integrated verification)

## Coordination

- **P1** (ML enum SQL fix) runs in parallel in a sibling worktree; P1 touches runbook §6.4 (ML forecast section). This PR touches §2 only. Line-disjoint, no expected conflict.
- **PR #359** (MIG-002 runbook §10 rollback glob fix) is open and edits §10 of the same runbook. Soft-rebase if #359 lands first; the §2 changes here do not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)