### PR TITLE
fix(ml-export/import): use uppercase PG enum labels in SQL (Finding 11, P1)

### DIFF
--- a/apps/iEasyHydroForecast/tests/test_export_ml_forecast.py
+++ b/apps/iEasyHydroForecast/tests/test_export_ml_forecast.py
@@ -241,3 +241,126 @@ def test_export_rejects_zero_row_behaviorally(tmp_path):
     # The manifest sidecar must NOT exist (the guard runs BEFORE manifest write).
     manifests = list(out_dir.glob("*.manifest")) if out_dir.exists() else []
     assert manifests == [], f"manifest should not exist after zero-row reject, got {manifests}"
+
+
+# ---------------------------------------------------------------------------
+# Finding 11 (Tajik live test): PG enum-label SQL regression guard
+# ---------------------------------------------------------------------------
+
+
+def _capture_dry_run_sql(tmp_path, *extra_args):
+    """Run the export wrapper in --dry-run mode with a PATH-injected fake
+    ``psql`` that records its ``-c`` argument (the emitted SQL) to a file,
+    then returns ``(result, captured_sql_text)``.
+
+    The fake psql is sufficient for behavioral SQL capture: the wrapper's
+    dry-run path runs exactly one ``psql -c "$count_sql"`` invocation
+    (lines 388-407 of ``bin/export_ml_forecast_history.sh``) and exits 0
+    on success. The location guard is bypassed via ``--i-am-on-laptop``
+    so this test does not depend on a running docker daemon.
+    """
+    import os
+    import stat
+
+    fake_bin = tmp_path / "fake_bin"
+    fake_bin.mkdir()
+    sql_capture = tmp_path / "captured.sql"
+    fake_psql = fake_bin / "psql"
+    # The wrapper invokes psql like:
+    #   psql -X -P pager=off -A -F $'\t' -h ... -p ... -U ... -d ... -c <sql>
+    # We walk the argv looking for ``-c`` and dump the following arg.
+    fake_psql.write_text(
+        f"""#!/usr/bin/env bash
+prev=""
+for arg in "$@"; do
+    if [[ "$prev" == "-c" ]]; then
+        printf '%s' "$arg" > {sql_capture!s}
+    fi
+    prev="$arg"
+done
+# Emit a placeholder COUNT response so the wrapper's dry-run prints it.
+echo "0	0		"
+exit 0
+"""
+    )
+    fake_psql.chmod(fake_psql.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    out_dir = tmp_path / "out"
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(_WRAPPER),
+            str(out_dir),
+            "--i-am-on-laptop",
+            "--dry-run",
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    captured = sql_capture.read_text(encoding="utf-8") if sql_capture.is_file() else ""
+    return result, captured
+
+
+def test_export_dry_run_sql_uses_uppercase_pg_enum_labels(tmp_path):
+    """Finding 11 regression: the dry-run COUNT query must filter
+    ``model_type`` against the PG enum LABELS in UPPERCASE
+    (``TFT``/``TIDE``/``TSMIXER``) via a ``::text`` cast, NOT the API
+    mixed-case wire values that the upstream wrapper used to ship.
+
+    Reverting the SQL to the old form
+    (``model_type IN ('TFT','TiDE','TSMixer')``) must make this test FAIL.
+
+    Authority for the two-representation rule:
+    ``sapphire/services/postprocessing/app/models.py:23-24`` (inline comment
+    documents PG enum LABEL = ``TSMIXER``, API wire value = ``TSMixer``).
+    """
+    result, captured = _capture_dry_run_sql(tmp_path)
+    assert result.returncode == 0, (
+        f"expected dry-run to exit 0, got {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert captured, (
+        "fake psql did not capture any SQL; wrapper dry-run path may have "
+        f"changed.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    # Required: uppercase PG enum labels are present.
+    assert "'TFT'" in captured, f"missing 'TFT' literal in SQL: {captured!r}"
+    assert "'TIDE'" in captured, f"missing 'TIDE' literal in SQL: {captured!r}"
+    assert "'TSMIXER'" in captured, f"missing 'TSMIXER' literal in SQL: {captured!r}"
+
+    # Required: ``::text`` cast (the chosen fix form per Finding 11).
+    assert "model_type::text" in captured, f"missing ``model_type::text`` cast in SQL: {captured!r}"
+
+    # Forbidden: mixed-case API wire spellings must not appear as SQL
+    # literals (they would 422 against real deployments).
+    assert "'TiDE'" not in captured, f"mixed-case 'TiDE' SQL literal slipped back in: {captured!r}"
+    assert "'TSMixer'" not in captured, (
+        f"mixed-case 'TSMixer' SQL literal slipped back in: {captured!r}"
+    )
+
+
+def test_export_dry_run_sql_model_filter_uses_uppercase_label(tmp_path):
+    """When ``--model TiDE`` is given (API wire spelling), the wrapper
+    must normalize to the PG enum LABEL ``TIDE`` in the SQL.
+
+    Regression guard: ``normalize_model_filter`` previously returned the
+    mixed-case API form which made the WHERE clause hit the same enum
+    coercion error this PR fixes."""
+    result, captured = _capture_dry_run_sql(tmp_path, "--model", "TiDE")
+    assert result.returncode == 0, (
+        f"expected dry-run to exit 0, got {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert captured, "no SQL captured"
+    # The model-filter clause must use the PG enum LABEL via ``::text`` cast.
+    assert "model_type::text = 'TIDE'" in captured, (
+        f"model-filter clause must use uppercase PG label via ::text cast, got: {captured!r}"
+    )
+    assert "'TiDE'" not in captured, f"mixed-case 'TiDE' literal must not appear; got: {captured!r}"

--- a/apps/iEasyHydroForecast/tests/test_initialize_ml_forecast.py
+++ b/apps/iEasyHydroForecast/tests/test_initialize_ml_forecast.py
@@ -930,3 +930,127 @@ def test_shipped_TFT_fixture_round_trips(tmp_path):
     for rec in records:
         assert rec["horizon_type"] == "day"
         assert rec["model_type"] == "TFT"
+
+
+# ===========================================================================
+# 9. Finding 11 (Tajik live test): PG enum-label SQL regression guard
+# ===========================================================================
+
+
+def _capture_query_target_state_sql(tmp_path):
+    """Behaviorally exercise the wrapper's ``query_target_state`` shell
+    function with a fake ``docker`` shell function that records the
+    ``-c`` argument (the SQL the wrapper would send to psql).
+
+    Approach:
+      1. Copy the wrapper to ``tmp_path`` with its trailing ``main "$@"``
+         line removed — sourcing the file then defines all functions
+         (including ``query_target_state``) without invoking ``main``.
+      2. Spawn a bash subshell that pre-defines ``docker`` as a function
+         capturing its ``-c`` argument, then sources the stripped wrapper
+         and calls ``query_target_state`` directly.
+
+    Returns the SQL string the wrapper would have sent (or ``""`` if the
+    helper failed to capture).
+    """
+    capture_file = tmp_path / "captured.sql"
+    stripped_wrapper = tmp_path / "init_nomain.sh"
+
+    # Strip the final ``main "$@"`` line so sourcing only defines functions.
+    src = _WRAPPER.read_text(encoding="utf-8")
+    src_lines = src.rstrip("\n").splitlines()
+    while src_lines and not src_lines[-1].strip().startswith("main "):
+        src_lines.pop()
+    if src_lines and src_lines[-1].strip().startswith("main "):
+        src_lines.pop()
+    stripped_wrapper.write_text("\n".join(src_lines) + "\n", encoding="utf-8")
+
+    driver = f"""
+docker() {{
+    local prev=""
+    local got_sql=""
+    for arg in "$@"; do
+        if [[ "$prev" == "-c" ]]; then
+            got_sql="$arg"
+        fi
+        prev="$arg"
+    done
+    if [[ -n "$got_sql" ]]; then
+        printf '%s' "$got_sql" > {capture_file!s}
+    fi
+    # Emit a fake "count<TAB>min_date" line so the caller's parsing succeeds.
+    printf '0\\t\\n'
+    return 0
+}}
+# Set $0 to the ORIGINAL wrapper path so the wrapper's
+# ``source "$(dirname "$0")/utils/update_migration_helpers.sh"`` resolves
+# to the real helpers library.
+source "{stripped_wrapper!s}"
+query_target_state
+"""
+    result = subprocess.run(
+        ["bash", "-c", driver, str(_WRAPPER)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    captured = capture_file.read_text(encoding="utf-8") if capture_file.is_file() else ""
+    return result, captured
+
+
+def test_query_target_state_sql_uses_uppercase_pg_enum_labels(tmp_path):
+    """Finding 11 regression: ``query_target_state`` (the MODE-detection
+    helper in ``bin/initialize_ml_forecast_history.sh``) must send SQL
+    that compares ``model_type`` against the PG enum LABELS in UPPERCASE
+    (``TFT``/``TIDE``/``TSMIXER``) via ``::text`` — never the mixed-case
+    API wire values.
+
+    Reverting to the old form
+    (``model_type IN ('TFT','TiDE','TSMixer')``) MUST make this test FAIL.
+
+    Authority for the two-representation rule:
+    ``sapphire/services/postprocessing/app/models.py:23-24``.
+    """
+    result, captured = _capture_query_target_state_sql(tmp_path)
+    assert result.returncode == 0, (
+        f"driver exited non-zero: {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert captured, (
+        "fake docker did not capture any SQL from query_target_state\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    # Required: uppercase PG enum labels.
+    assert "'TFT'" in captured, f"missing 'TFT' literal in SQL: {captured!r}"
+    assert "'TIDE'" in captured, f"missing 'TIDE' literal in SQL: {captured!r}"
+    assert "'TSMIXER'" in captured, f"missing 'TSMIXER' literal in SQL: {captured!r}"
+    # Required: ``::text`` cast.
+    assert "model_type::text" in captured, f"missing ``model_type::text`` cast in SQL: {captured!r}"
+    # Forbidden: mixed-case API spellings as SQL literals.
+    assert "'TiDE'" not in captured, f"mixed-case 'TiDE' SQL literal slipped back in: {captured!r}"
+    assert "'TSMixer'" not in captured, (
+        f"mixed-case 'TSMixer' SQL literal slipped back in: {captured!r}"
+    )
+
+
+def test_verify_sql_tip_uses_uppercase_pg_enum_labels():
+    """The post-completion verify SQL the wrapper PRINTS to the operator
+    must also use PG enum LABELS (uppercase + ``::text``) so the operator
+    can paste the snippet straight into psql against the live DB without
+    hitting ``invalid input value for enum modeltype: "TiDE"``.
+
+    This is a source-text check because the echo lines are unconditional
+    output after the docker-run step — exercising the full path would
+    require a stack of stubs (docker, helpers, env file, manifest)
+    disproportionate to the contract under test."""
+    src = _WRAPPER.read_text(encoding="utf-8")
+    assert "model_type::text IN ('TFT','TIDE','TSMIXER')" in src, (
+        "post-run verify SQL tip must use uppercase PG enum labels with "
+        "``::text`` cast (Finding 11)"
+    )
+    # The mixed-case literals must NOT appear in the verify tip.
+    assert "'TiDE'" not in src or src.count("'TiDE'") == 0, (
+        "mixed-case 'TiDE' literal must not appear in wrapper SQL"
+    )
+    assert "'TSMixer'" not in src, "mixed-case 'TSMixer' literal must not appear in wrapper SQL"

--- a/bin/export_ml_forecast_history.sh
+++ b/bin/export_ml_forecast_history.sh
@@ -5,7 +5,8 @@
 # Laptop-side export wrapper for the ML forecast migration toolkit (P4b).
 # Pulls historical ML forecast rows from a laptop's
 # ``sapphire-postprocessing-db`` table ``forecasts``, filtered to the three
-# ML model variants (``model_type IN ('TFT','TiDE','TSMixer')``), and writes:
+# ML model variants (``model_type::text IN ('TFT','TIDE','TSMIXER')``), and
+# writes:
 #
 #   1. ``<out_dir>/ml_forecast_<timestamp>.csv`` — header + rows
 #   2. ``<out_dir>/ml_forecast_<timestamp>.csv.manifest`` — sidecar with the
@@ -27,10 +28,21 @@
 #   pass ``--include-legacy-horizons``. The exported CSV preserves the
 #   source ``horizon_type`` cell so the server wrapper can filter as needed.
 #
-# Enum case (Stage A §E):
-#   The exported ``model_type`` column uses MIXED-CASE values exactly as
-#   stored in PostgreSQL: ``TFT``, ``TiDE``, ``TSMixer``. Downstream
-#   ``migration_py.ml_forecast.MODEL_DIR_TO_API`` accepts both forms.
+# Enum case (Stage A §E; Finding 11 — Tajik live test):
+#   Two representations of ``model_type`` are in play:
+#     - PG enum LABELS (used in raw SQL WHERE / model-filter clauses):
+#       UPPERCASE — ``TFT`` / ``TIDE`` / ``TSMIXER`` — compared via
+#       ``model_type::text`` to sidestep the enum-literal coercion error
+#       that bites mixed-case literals (``invalid input value for enum
+#       modeltype: "TiDE"``).
+#     - API wire values (the ``model_type`` cell of the exported CSV, and
+#       the JSON payload posted by the server-side helper): MIXED-CASE —
+#       ``TFT`` / ``TiDE`` / ``TSMixer`` — exactly as ``ModelType`` is
+#       declared in
+#       ``sapphire/services/postprocessing/app/models.py:23-24`` (see the
+#       inline comment there).
+#   Downstream ``migration_py.ml_forecast.MODEL_DIR_TO_API`` accepts both
+#   spellings on read.
 #
 # Usage:
 #   bash bin/export_ml_forecast_history.sh <out_dir> [OPTIONS]
@@ -99,6 +111,9 @@ Usage: bash bin/export_ml_forecast_history.sh <out_dir> [OPTIONS]
 
 Export ML forecast history rows (TFT, TiDE, TSMixer) from the laptop's
 sapphire-postprocessing-db.forecasts table to a CSV + manifest pair.
+The DB filter compares ``model_type::text`` against the PG enum LABELS
+(``TFT``/``TIDE``/``TSMIXER``); the exported CSV preserves the mixed-case
+API spelling (``TFT``/``TiDE``/``TSMixer``).
 
 Arguments:
   out_dir              Destination directory for the CSV + manifest pair.
@@ -266,14 +281,17 @@ validate_model_filter() {
 }
 
 # ---------------------------------------------------------------------------
-# Normalize the model filter to the canonical API value (mixed case).
+# Normalize the model filter to the canonical PG enum LABEL (uppercase).
+# Used ONLY in the raw SQL WHERE clause (compared via ``model_type::text``).
+# The API wire spelling (mixed case ``TFT`` / ``TiDE`` / ``TSMixer``) is
+# resolved server-side by ``migration_py.ml_forecast.MODEL_DIR_TO_API``.
 # Echoes the normalized form on stdout.
 # ---------------------------------------------------------------------------
 normalize_model_filter() {
     case "$1" in
         TFT) echo "TFT" ;;
-        TIDE|TiDE) echo "TiDE" ;;
-        TSMIXER|TSMixer) echo "TSMixer" ;;
+        TIDE|TiDE) echo "TIDE" ;;
+        TSMIXER|TSMixer) echo "TSMIXER" ;;
         *) echo "" ;;
     esac
 }
@@ -283,7 +301,11 @@ normalize_model_filter() {
 # Echoes the clause on stdout.
 # ---------------------------------------------------------------------------
 build_where_clause() {
-    local where="model_type IN ('TFT','TiDE','TSMixer')"
+    # Finding 11 (Tajik live test): compare PG enum LABELS via ``::text``
+    # to sidestep the enum-literal coercion error against real deployments
+    # (``invalid input value for enum modeltype: "TiDE"``). The CSV export
+    # below still emits the API mixed-case spelling.
+    local where="model_type::text IN ('TFT','TIDE','TSMIXER')"
 
     if [[ "$INCLUDE_LEGACY_HORIZONS" == true ]]; then
         # Accept both 'day' (modern) AND 'pentad'/'decade' (legacy).
@@ -298,7 +320,7 @@ build_where_clause() {
     if [[ -n "$MODEL_FILTER" ]]; then
         local m
         m="$(normalize_model_filter "$MODEL_FILTER")"
-        where+=" AND model_type = '${m}'"
+        where+=" AND model_type::text = '${m}'"
     fi
     if [[ -n "$START_DATE" ]]; then
         where+=" AND date >= '${START_DATE//\'/\'\'}'"

--- a/bin/initialize_ml_forecast_history.sh
+++ b/bin/initialize_ml_forecast_history.sh
@@ -6,8 +6,10 @@
 # migration toolkit). Reads a CSV that was produced by
 # ``bin/export_ml_forecast_history.sh`` on the laptop's
 # ``sapphire-postprocessing-db`` (table ``forecasts``, filtered to
-# ``model_type IN ('TFT','TiDE','TSMixer')``) and POSTs the rows to the
-# deployment postprocessing API ``/forecast/`` endpoint.
+# ``model_type::text IN ('TFT','TIDE','TSMIXER')`` — PG enum LABELS, see
+# Finding 11 below) and POSTs the rows to the deployment postprocessing
+# API ``/forecast/`` endpoint as mixed-case ``TFT`` / ``TiDE`` / ``TSMixer``
+# wire values.
 #
 # Uses the P0 helper (bin/utils/update_migration_helpers.sh) for image
 # resolution, temp workspace, redacted logging, manifest validation, and the
@@ -18,10 +20,21 @@
 # Two architectural quirks (see also bin/utils/migration_py/ml_forecast.py
 # docstring):
 #
-# 1. Enum case (Stage A §E): the API ``ModelType`` enum values are
-#    MIXED-CASE — ``TFT``, ``TiDE``, ``TSMixer`` — not the legacy uppercase
-#    on-disk dir spellings. ``MODEL_DIR_TO_API`` in the Python helper maps
-#    both forms to the canonical spelling.
+# 1. Enum case (Stage A §E; Finding 11 — Tajik live test):
+#    Two ``model_type`` representations are in play, and BOTH must stay
+#    correct in this wrapper:
+#      - PG enum LABELS (this script's raw SQL only): UPPERCASE
+#        ``TFT`` / ``TIDE`` / ``TSMIXER``, compared via ``::text`` to
+#        sidestep the enum-literal coercion error
+#        (``invalid input value for enum modeltype: "TiDE"``) that bit
+#        the live Tajik DB on real-data walkthrough.
+#      - API wire values (JSON payload POSTed by the Python helper):
+#        MIXED-CASE ``TFT`` / ``TiDE`` / ``TSMixer`` per
+#        ``sapphire/services/postprocessing/app/models.py:23-24`` (see
+#        the inline ``# TSMIXER(how it is stored in PostgreSQL),
+#        TSMixer(how it is passed in API)`` comment).
+#    ``MODEL_DIR_TO_API`` in the Python helper maps both spellings to the
+#    mixed-case API form.
 #
 # 2. Default horizon = ``day`` (user-lock L6): modern ML CSV-derived writes
 #    store as ``horizon_type='day'`` regardless of pentad / decade workflow.
@@ -262,10 +275,18 @@ parse_args() {
 
 # Query the postprocessing-db for MODE detection (ML rows only).
 # Echoes "count<TAB>min_date_or_empty" on stdout.
+#
+# Finding 11 (Tajik live test): ``model_type`` is a PostgreSQL enum whose
+# LABELS are UPPERCASE — ``TFT`` / ``TIDE`` / ``TSMIXER`` — per the comment
+# at ``sapphire/services/postprocessing/app/models.py:23-24``. We compare
+# via ``::text`` to sidestep the enum-literal coercion error
+# (``invalid input value for enum modeltype: "TiDE"``) that bit the live
+# Tajik DB before this fix. The Python helper still POSTs the API
+# mixed-case wire values; the two representations are intentional.
 query_target_state() {
     docker exec sapphire-postprocessing-db psql \
         -U postgres -d postprocessing_db -P pager=off -t -A -F $'\t' \
-        -c "SELECT COUNT(*), COALESCE(MIN(date)::text, '') FROM forecasts WHERE model_type IN ('TFT','TiDE','TSMixer');"
+        -c "SELECT COUNT(*), COALESCE(MIN(date)::text, '') FROM forecasts WHERE model_type::text IN ('TFT','TIDE','TSMIXER');"
 }
 
 main() {
@@ -495,7 +516,7 @@ main() {
     echo "  docker exec sapphire-postprocessing-db \\"
     echo "    psql -U postgres -d postprocessing_db -c \\"
     echo "    \"SELECT horizon_type, model_type, COUNT(*) AS rows, MIN(date), MAX(date)"
-    echo "       FROM forecasts WHERE model_type IN ('TFT','TiDE','TSMixer')"
+    echo "       FROM forecasts WHERE model_type::text IN ('TFT','TIDE','TSMIXER')"
     echo "       GROUP BY horizon_type, model_type ORDER BY model_type, horizon_type;\""
     echo ""
     echo "Log file: ${log_file}"

--- a/bin/utils/migration_py/ml_forecast.py
+++ b/bin/utils/migration_py/ml_forecast.py
@@ -2,19 +2,34 @@
 
 Called from ``bin/initialize_ml_forecast_history.sh`` as
 ``python3 -m migration_py.ml_forecast``. Reads a CSV exported from the
-laptop's ``sapphire-postprocessing-db`` (table ``forecasts``) filtered to
-ML model rows (``model_type IN ('TFT','TiDE','TSMixer')``) and POSTs the
-records to the postprocessing API ``/forecast/`` endpoint.
+laptop's ``sapphire-postprocessing-db`` (filtered upstream via
+``model_type::text IN ('TFT','TIDE','TSMIXER')`` — the PG enum LABELS;
+see Finding 11 below) and POSTs the records to the postprocessing API
+``/forecast/`` endpoint as MIXED-CASE ``TFT`` / ``TiDE`` / ``TSMixer``
+API wire values.
 
 Two architectural quirks documented in the P4b gi_draft:
 
-1. **Enum case sensitivity (Stage A §E live test):** the API ``ModelType``
-   enum values are MIXED-CASE — ``TFT``, ``TiDE``, ``TSMixer`` — not all
-   uppercase. The legacy on-disk directory naming uses uppercase
+1. **Enum case sensitivity (Stage A §E; Finding 11 — Tajik live test):**
+   ``model_type`` has TWO representations, and BOTH must remain correct
+   end-to-end:
+
+   - PG enum LABELS (raw SQL only, in the wrapper ``.sh`` scripts):
+     UPPERCASE ``TFT`` / ``TIDE`` / ``TSMIXER``. Real deployments fail with
+     ``invalid input value for enum modeltype: "TiDE"`` if mixed-case
+     literals are used in a WHERE clause.
+   - API wire values (the JSON payload assembled HERE and POSTed): the
+     MIXED-CASE form ``TFT`` / ``TiDE`` / ``TSMixer``, exactly as declared
+     in ``sapphire/services/postprocessing/app/models.py:23-24``
+     (see the inline ``# TSMIXER(how it is stored in PostgreSQL),
+     TSMixer(how it is passed in API)`` comment).
+
+   The legacy on-disk directory naming uses uppercase
    (``predictions/TFT/``, ``predictions/TIDE/``, ``predictions/TSMIXER/``).
-   This module exposes ``MODEL_DIR_TO_API`` to map between them. Any source
-   string outside the three known dir / API spellings is rejected with
-   ``UnknownMLModelTypeError``.
+   ``MODEL_DIR_TO_API`` / ``resolve_model_type`` map every accepted
+   spelling to the mixed-case API form (NEVER the uppercase PG label —
+   uppercase is for SQL only). Any source string outside the known dir /
+   API spellings is rejected with ``UnknownMLModelTypeError``.
 
 2. **Default horizon storage = ``day`` (user-lock L6):** modern ML CSV-derived
    writes go in as ``horizon_type='day'`` regardless of the caller's pentad /
@@ -70,10 +85,13 @@ logger = logging.getLogger("migration_py.ml_forecast")
 # Enum case mapping (Stage A §E live-test result)
 # ---------------------------------------------------------------------------
 
-# Maps a source spelling (whether the upstream uses the legacy on-disk
-# uppercase ``TIDE``/``TSMIXER`` dir convention, or the API mixed-case form)
-# to the canonical API enum value as defined in
-# ``sapphire/services/postprocessing/app/models.py::ModelType``.
+# Two model_type representations are in play (Finding 11 — Tajik live test):
+#   - PG enum LABELS (raw SQL only, used in the wrapper ``.sh`` scripts):
+#     UPPERCASE ``TFT`` / ``TIDE`` / ``TSMIXER``.
+#   - API wire values (JSON POST payload built here): MIXED-CASE
+#     ``TFT`` / ``TiDE`` / ``TSMixer``.
+# This map normalizes every accepted source spelling to the API wire form.
+# Authority: ``sapphire/services/postprocessing/app/models.py:23-24``.
 MODEL_DIR_TO_API: dict[str, str] = {
     "TFT": "TFT",
     "TIDE": "TiDE",

--- a/doc/prod/update_data_migration_runbook.md
+++ b/doc/prod/update_data_migration_runbook.md
@@ -1537,8 +1537,9 @@ last export.
 ### 6.4 ML forecasts (TFT / TiDE / TSMixer)
 
 Source: laptop `sapphire-postprocessing-db`, table `forecasts`, filtered to
-`model_type IN ('TFT','TiDE','TSMixer')`. Target: deployment-server
-`forecasts` rows with the same three model_types. Default storage shape is
+`model_type::text IN ('TFT','TIDE','TSMIXER')` (PG enum LABELS; see the
+"Representation note" below). Target: deployment-server `forecasts` rows
+with the same three model_types. Default storage shape is
 `horizon_type='day'` per user-lock L6 — modern ML writes (operational pipeline
 post commit `1cb3495`) only emit `day` rows. Pre-cutoff vs full-import is
 decided by the deployment-side `forecasts` table state, filtered to the three
@@ -1593,6 +1594,29 @@ API spelling. Any source string outside the six known spellings raises
 The export CSV preserves the canonical API spelling (mixed case) — the
 mapping table above documents the historical mismatch so operators
 investigating older on-disk artifacts know what to expect.
+
+##### Representation note: PG enum LABEL vs API wire value (Finding 11)
+
+`model_type` has TWO representations and both must stay correct end-to-end.
+The Tajik live-deployment walkthrough hit a hard failure
+(`ERROR: invalid input value for enum modeltype: "TiDE"`) because the
+wrappers' raw SQL used the API wire spellings as enum literals. The fix
+splits the two boundaries explicitly:
+
+| Boundary | Spelling | Where used |
+|---|---|---|
+| PG enum LABELS | UPPERCASE: `TFT` / `TIDE` / `TSMIXER` | Raw SQL in `bin/export_ml_forecast_history.sh` and `bin/initialize_ml_forecast_history.sh`, compared via `model_type::text IN (...)` |
+| API wire values | MIXED-CASE: `TFT` / `TiDE` / `TSMixer` | Exported CSV `model_type` column AND JSON body POSTed by `migration_py.ml_forecast` to `/forecast/` |
+
+Authority: the `ModelType` enum in
+`sapphire/services/postprocessing/app/models.py:23-24` carries the
+inline comment `# TSMIXER(how it is stored in PostgreSQL), TSMixer(how
+it is passed in API)`. SQLAlchemy uses Python enum NAMES (uppercase) as
+the PG enum labels; `.value` is the API JSON form.
+
+If you write an ad-hoc acceptance SQL against the live `forecasts` table,
+ALWAYS use the uppercase labels with `::text` (see §6.4.6 below). Mixed-case
+literals will hard-fail the query.
 
 ##### WARNING: default horizon='day' vs `--preserve-legacy-ml-horizons`
 
@@ -1796,10 +1820,13 @@ on the deployment server:
 ```bash
 docker exec -i sapphire-postprocessing-db \
   psql -U postgres -d postprocessing_db -P pager=off <<SQL
+-- Finding 11 (Tajik live test): compare against PG enum LABELS
+-- (UPPERCASE) via ``::text``; mixed-case literals fail with
+-- ``invalid input value for enum modeltype: "TiDE"`` on real DBs.
 SELECT horizon_type, model_type, COUNT(*) AS rows,
        MIN(date) AS first_date, MAX(date) AS last_date
 FROM forecasts
-WHERE model_type IN ('TFT','TiDE','TSMixer')
+WHERE model_type::text IN ('TFT','TIDE','TSMIXER')
 GROUP BY horizon_type, model_type
 ORDER BY model_type, horizon_type;
 SQL


### PR DESCRIPTION
## Summary

Phase 1 of the Tajik SAPPHIRE 2 live-deployment hardening batch. Fixes
**Finding 11** from the Tajik runbook walkthrough: both ML forecast
wrappers were embedding mixed-case enum literals (`'TiDE'`, `'TSMixer'`)
in their raw SQL, which hard-fails any real deployment with:

```
ERROR: invalid input value for enum modeltype: "TiDE"
```

This blocks ML backfill on the Tajik live server (and any future
deployment).

## The two-representation rule

`model_type` has **two** representations and the wrappers were
collapsing them. Authority:
[`sapphire/services/postprocessing/app/models.py:23-24`](https://github.com/hydrosolutions/SAPPHIRE_Forecast_Tools/blob/maxat_sapphire_2/sapphire/services/postprocessing/app/models.py#L23-L24)
carries the inline comment
`# TSMIXER(how it is stored in PostgreSQL), TSMixer(how it is passed in API)`:

| Boundary | Spelling | Where |
|---|---|---|
| **PG enum LABELS** (raw SQL only) | UPPERCASE: `TFT` / `TIDE` / `TSMIXER` | Wrapper `.sh` SQL queries — fixed in this PR |
| **API wire values** (JSON POST body) | MIXED-CASE: `TFT` / `TiDE` / `TSMixer` | `migration_py.ml_forecast` payload — **unchanged**, was already correct |

The fix compares via `model_type::text IN ('TFT','TIDE','TSMIXER')` —
sidesteps the enum-literal coercion error without a function wrapper
(non-sargable `UPPER(model_type::text)` rejected). The Python helper's
`resolve_model_type` / `MODEL_DIR_TO_API` are untouched — the API wire
output still emits mixed-case, as the postprocessing service expects.

## Files changed

- `bin/export_ml_forecast_history.sh` — `build_where_clause` and
  `normalize_model_filter` now use PG enum LABELS via `::text` cast.
- `bin/initialize_ml_forecast_history.sh` — `query_target_state`
  MODE-detection SQL and the post-run verify SQL echoed to the operator
  switched to the same form.
- `bin/utils/migration_py/ml_forecast.py` — docstring + 7-line
  clarifying comment on the two-representation rule. **No logic changes.**
  `MODEL_DIR_TO_API`, `resolve_model_type`, `_API_ML_MODELS`, and the
  payload construction at `:252` are untouched.
- `apps/iEasyHydroForecast/tests/test_export_ml_forecast.py` and
  `tests/test_initialize_ml_forecast.py` — behavioral regression
  tests that capture the emitted SQL via PATH-injected `psql` /
  `docker` stubs and assert the uppercase + `::text` contract.
  Verified to FAIL when the SQL is reverted to the mixed-case form.
- `doc/prod/update_data_migration_runbook.md` §6.4 only — added a
  "Representation note" callout citing `models.py:23-24`; updated the
  §6.4.6 acceptance SQL example to use the PG enum LABEL form. **§10
  (rollback section, PR #359 territory) is intentionally untouched.**

## Test plan

- [x] `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh iEasyHydroForecast`
  → 697 passed (was 693 + 4 new behavioral regressions).
- [x] Verified new tests FAIL when the SQL is temporarily reverted to
  the mixed-case form, then PASS once the fix is restored — confirms
  the tests catch the regression.
- [x] `git grep -nE "'TiDE'|'TSMixer'" bin/` returns 0 matches.
- [x] Existing canonical-API-form tests (`test_model_enum_case_*`,
  `test_build_record_default_horizon_is_day`) pass unmodified, proving
  the JSON POST payload still emits mixed-case wire values.
- [x] Pre-commit hooks (ruff check, ruff format, shellcheck) all pass.
- [ ] **Server-side verification (deferred to P3):** rerun the ML
  forecast canary against the Tajik live `postprocessing-db` and
  confirm `query_target_state` succeeds + the verify SQL paste works.

## Phase context

This is **P1** of a 3-phase hardening batch:

- **P1 (this PR)** — Finding 11 ML enum SQL fix.
- **P2** — image / prerequisite hardening (runs in parallel).
- **P3** — integrated verification against Tajik live (follows P1 + P2).

## Notes for reviewer

- Sentinel station code `19999` only — no real codes touched in tests,
  docs, or commit messages.
- Out-of-scope observation (file under P2/P3): `HorizonType` is also a
  PG enum whose LABELS differ from `.value` (NAMES `DAY`/`PENTAD`/`DECADE`
  vs values `day`/`pentad`/`decade`). The wrappers currently use the
  value form (`horizon_type = 'day'`) which by SQLAlchemy default would
  also raise enum coercion errors — but Finding 11 walkthrough only
  flagged `model_type`. If the Tajik DB stores `HorizonType` with VALUES
  as labels, the wrappers are fine; if NAMES, this is the next bug to
  surface. Intentionally not scoped into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)