### PR TITLE
fix(migration-toolkit): use uppercase PG enum labels in horizon_type SQL (MIG-003)

### DIFF
--- a/apps/iEasyHydroForecast/tests/test_export_ml_forecast.py
+++ b/apps/iEasyHydroForecast/tests/test_export_ml_forecast.py
@@ -364,3 +364,91 @@ def test_export_dry_run_sql_model_filter_uses_uppercase_label(tmp_path):
         f"model-filter clause must use uppercase PG label via ::text cast, got: {captured!r}"
     )
     assert "'TiDE'" not in captured, f"mixed-case 'TiDE' literal must not appear; got: {captured!r}"
+
+
+# ---------------------------------------------------------------------------
+# MIG-003: horizon_type PG enum-label SQL regression guard
+# ---------------------------------------------------------------------------
+
+
+def test_export_dry_run_sql_horizon_type_uses_uppercase_pg_enum_label(tmp_path):
+    """MIG-003 regression: the default-mode dry-run COUNT query must filter
+    ``horizon_type`` against the PG enum LABEL in UPPERCASE (``DAY``) via
+    a ``::text`` cast, NOT the API wire value ``'day'`` that the wrapper
+    used to ship.
+
+    Reverting the SQL to the old form (``horizon_type = 'day'``) must
+    make this test FAIL with
+    ``ERROR: invalid input value for enum horizontype: "day"`` on
+    real deployments.
+
+    Authority for the two-representation rule:
+    ``sapphire/services/postprocessing/app/models.py:9-17`` — the
+    ``HorizonType`` Python enum where NAMES (uppercase ``DAY``/``PENTAD``/
+    ``DECADE``/``MONTH``/``QUARTER``/``SEASON``) become the PG enum
+    labels, and ``.value`` strings (lowercase ``'day'``/...) are the API
+    JSON wire form.
+    """
+    import re
+
+    result, captured = _capture_dry_run_sql(tmp_path)
+    assert result.returncode == 0, (
+        f"expected dry-run to exit 0, got {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert captured, "no SQL captured"
+
+    # Required: uppercase PG enum label + ``::text`` cast (the chosen fix
+    # form per MIG-003, mirrors Finding 11 / model_type pattern).
+    assert "horizon_type::text" in captured, (
+        f"missing ``horizon_type::text`` cast in SQL: {captured!r}"
+    )
+    assert "'DAY'" in captured, f"missing uppercase 'DAY' literal in SQL: {captured!r}"
+
+    # Forbidden: bare lowercase ``horizon_type`` equality / IN with
+    # lowercase enum-label literal would hard-fail on real deployments.
+    # Use a regex anchored to the column to avoid false positives from
+    # column names like ``horizon_in_year`` or fragments of words.
+    # Case-sensitive: we explicitly forbid lowercase, allow uppercase.
+    forbidden = re.compile(r"horizon_type\s*=\s*'day'")
+    assert not forbidden.search(captured), (
+        f"lowercase ``horizon_type = 'day'`` slipped back into SQL: {captured!r}"
+    )
+
+
+def test_export_dry_run_sql_horizon_type_legacy_uses_uppercase_pg_enum_labels(tmp_path):
+    """MIG-003 regression: with ``--include-legacy-horizons`` the IN-list
+    must contain UPPERCASE PG enum labels (``'DAY'``/``'PENTAD'``/
+    ``'DECADE'``) via a ``::text`` cast.
+
+    Reverting the SQL to the old form
+    (``horizon_type IN ('day','pentad','decade')``) must make this
+    test FAIL on real deployments.
+    """
+    import re
+
+    result, captured = _capture_dry_run_sql(tmp_path, "--include-legacy-horizons")
+    assert result.returncode == 0, (
+        f"expected dry-run to exit 0, got {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert captured, "no SQL captured"
+
+    # Required: uppercase PG enum labels are present.
+    assert "'DAY'" in captured, f"missing 'DAY' literal in SQL: {captured!r}"
+    assert "'PENTAD'" in captured, f"missing 'PENTAD' literal in SQL: {captured!r}"
+    assert "'DECADE'" in captured, f"missing 'DECADE' literal in SQL: {captured!r}"
+    assert "horizon_type::text" in captured, (
+        f"missing ``horizon_type::text`` cast in SQL: {captured!r}"
+    )
+
+    # Forbidden: lowercase PG enum-label literals inside an IN-list
+    # against ``horizon_type``. Scope the regex to the WHERE-clause
+    # column to avoid matching e.g. ``horizon_in_year``. Case-sensitive:
+    # we forbid lowercase, allow uppercase (the fix form).
+    forbidden = re.compile(
+        r"horizon_type[^,)]*IN\s*\([^)]*'(day|pentad|decade)'",
+    )
+    assert not forbidden.search(captured), (
+        f"lowercase horizon_type IN-list literal slipped back into SQL: {captured!r}"
+    )

--- a/apps/iEasyHydroForecast/tests/test_initialize_long_forecast.py
+++ b/apps/iEasyHydroForecast/tests/test_initialize_long_forecast.py
@@ -785,24 +785,33 @@ def test_main_dry_run_reports_missing_hindcast(tmp_path, capsys):
 
 
 # ---------------------------------------------------------------------------
-# 19a. SQL enum case in MODE detection uses lowercase 'month'
+# 19a. SQL enum case in MODE detection uses ::text cast + UPPERCASE 'MONTH'
 # ---------------------------------------------------------------------------
 
 
-def test_mode_detection_query_uses_lowercase_month_enum():
-    """The query_target_state SQL must use horizon_type='month' (lowercase).
+def test_mode_detection_query_uses_uppercase_month_pg_enum_label():
+    """MIG-003 regression: query_target_state SQL must use
+    ``horizon_type::text='MONTH'`` (PG enum LABEL, UPPERCASE).
 
-    The DB/API enum stores the value as lowercase 'month'. If the query
-    used 'MONTH', it would return 0 rows on a populated table, causing
-    the wrapper to enter full-import mode and re-POST existing records.
+    Authority: ``sapphire/services/postprocessing/app/models.py:9-17``
+    (``HorizonType`` Python enum). SQLAlchemy stores the Python NAME
+    (``MONTH``) as the PG enum label; ``.value`` (``'month'``) is the
+    API wire form only. Comparing against lowercase ``'month'`` literals
+    hard-fails with ``invalid input value for enum horizontype: "month"``
+    on real deployments.
+
+    Reverting the SQL to the old form
+    (``horizon_type='month'``) must make this test FAIL.
     """
     src = _WRAPPER.read_text(encoding="utf-8")
-    assert "horizon_type='month'" in src, (
-        "query_target_state must use horizon_type='month' (lowercase); "
-        "found uppercase or missing reference in the script"
+    assert "horizon_type::text='MONTH'" in src, (
+        "query_target_state must use horizon_type::text='MONTH' "
+        "(PG enum LABEL uppercase via ::text cast)"
     )
-    assert "horizon_type='MONTH'" not in src, (
-        "uppercase 'MONTH' found in script; must be lowercase 'month'"
+    # The bare lowercase form was the original bug — must not reappear in
+    # executable SQL (allowed in comments/docstrings).
+    assert "horizon_type='month'" not in src, (
+        "lowercase 'horizon_type=\\'month\\'' found; must be horizon_type::text='MONTH' per MIG-003"
     )
 
 
@@ -1040,14 +1049,20 @@ def test_wrapper_per_mode_query_uses_horizon_value_filter():
     """Round-3 review feedback: --mode runs must use a per-mode psql query
     scoped to the selected mode's horizon_value, not the global query.
     String-level regression guard on the wrapper source confirms the
-    per-mode query exists and references both horizon_type='month' AND
-    horizon_value=${MODE_HORIZON_VALUE}."""
+    per-mode query exists and references both
+    ``horizon_type::text='MONTH'`` (MIG-003: PG enum LABEL UPPERCASE via
+    ``::text`` cast) AND ``horizon_value=${MODE_HORIZON_VALUE}``."""
     src = _WRAPPER.read_text(encoding="utf-8")
     # The per-mode branch must guard on MODE_FILTER being set...
     assert 'if [[ -n "$MODE_FILTER" ]]' in src
     # ...and execute a scoped query that filters on the mode's horizon_value.
     assert "MODE_HORIZON_VALUE" in src
     assert "horizon_value=${MODE_HORIZON_VALUE}" in src
+    # MIG-003: the per-mode query MUST use the PG enum LABEL via ::text cast.
+    assert "horizon_type::text='MONTH'" in src, (
+        "per-mode query must filter horizon_type::text='MONTH' (PG enum "
+        "LABEL uppercase); lowercase literals hard-fail on real deployments"
+    )
     # The per-mode branch must parse horizon_value from the mode's config JSON.
     assert "operational_month_lead_time" in src
 
@@ -1108,3 +1123,69 @@ def test_per_mode_parser_documents_sync_with_python_helper():
     src = _WRAPPER.read_text(encoding="utf-8")
     assert "migration_py.long_forecast" in src
     assert "_load_mode_config" in src
+
+
+# ---------------------------------------------------------------------------
+# MIG-003: horizon_type PG enum-label SQL regression guard (behavioral)
+# ---------------------------------------------------------------------------
+
+
+def test_wrapper_psql_sql_uses_uppercase_horizon_type_pg_enum_labels():
+    """MIG-003 behavioral regression: every ``psql -c <SQL>`` call in the
+    wrapper must reference ``horizon_type`` only via the PG enum LABEL
+    UPPERCASE through a ``::text`` cast.
+
+    The wrapper invokes psql twice — once in ``query_target_state`` for
+    the global-mode MODE detection and once in the per-mode branch
+    (``--mode <name>``). Both queries hit the live
+    ``sapphire-postprocessing-db.long_forecasts`` table whose
+    ``horizon_type`` column is a PG enum with UPPERCASE labels
+    (``DAY``/``PENTAD``/``DECADE``/``MONTH``/...).
+
+    This test extracts every ``-c "..."`` string passed to ``psql`` from
+    the wrapper source and asserts the WHERE clause uses
+    ``horizon_type::text='MONTH'``. Reverting either SQL site to the old
+    lowercase form (``horizon_type='month'``) makes this test FAIL — and
+    the live query hard-fails with
+    ``ERROR: invalid input value for enum horizontype: "month"``.
+
+    Authority for the two-representation rule:
+    ``sapphire/services/postprocessing/app/models.py:9-17`` — the
+    ``HorizonType`` Python enum where NAMES (uppercase) become the PG
+    enum labels and ``.value`` strings (lowercase) are the API JSON form.
+    """
+    src = _WRAPPER.read_text(encoding="utf-8")
+
+    # Extract every psql -c "<SQL>" invocation. The wrapper formats them
+    # across multiple lines with backslash continuations, so allow any
+    # whitespace between ``-c`` and the opening quote.
+    sql_blocks = re.findall(
+        r'\bpsql\b[\s\S]*?-c\s+"([^"]+)"',
+        src,
+    )
+    assert sql_blocks, (
+        'expected at least one ``psql -c "..."`` invocation in the '
+        "wrapper source; regex extraction returned no matches — has the "
+        "wrapper layout changed?"
+    )
+
+    horizon_blocks = [s for s in sql_blocks if "horizon_type" in s]
+    assert horizon_blocks, (
+        "expected at least one psql SQL block to reference "
+        f"horizon_type; regex returned only: {sql_blocks!r}"
+    )
+
+    for block in horizon_blocks:
+        # Required: PG enum LABEL UPPERCASE via ``::text`` cast.
+        assert "horizon_type::text='MONTH'" in block, (
+            f"psql SQL block missing horizon_type::text='MONTH' "
+            f"(PG enum LABEL uppercase via ::text cast): {block!r}"
+        )
+        # Forbidden: bare lowercase ``horizon_type='month'`` literal in
+        # an equality predicate (anchored to the column, so column names
+        # like ``horizon_in_year`` are not matched). Case-sensitive:
+        # forbid lowercase, allow uppercase (the fix form).
+        forbidden = re.compile(r"horizon_type\s*=\s*'month'")
+        assert not forbidden.search(block), (
+            f"lowercase ``horizon_type = 'month'`` predicate slipped back into psql SQL: {block!r}"
+        )

--- a/bin/export_ml_forecast_history.sh
+++ b/bin/export_ml_forecast_history.sh
@@ -308,10 +308,13 @@ build_where_clause() {
     local where="model_type::text IN ('TFT','TIDE','TSMIXER')"
 
     if [[ "$INCLUDE_LEGACY_HORIZONS" == true ]]; then
-        # Accept both 'day' (modern) AND 'pentad'/'decade' (legacy).
-        where+=" AND horizon_type IN ('day','pentad','decade')"
+        # Accept both 'DAY' (modern) AND 'PENTAD'/'DECADE' (legacy).
+        # MIG-003: compare PG enum LABELS via ``::text`` (same pattern as
+        # model_type above) — lowercase literals hard-fail the
+        # ``horizontype`` enum coercion on real deployments.
+        where+=" AND horizon_type::text IN ('DAY','PENTAD','DECADE')"
     else
-        where+=" AND horizon_type = 'day'"
+        where+=" AND horizon_type::text = 'DAY'"
     fi
 
     if [[ -n "$STATION_FILTER" ]]; then

--- a/bin/initialize_long_forecast_history.sh
+++ b/bin/initialize_long_forecast_history.sh
@@ -317,7 +317,7 @@ parse_args() {
 query_target_state() {
     docker exec sapphire-postprocessing-db psql \
         -U postgres -d postprocessing_db -P pager=off -t -A -F $'\t' \
-        -c "SELECT COUNT(*), COALESCE(MIN(date)::text, '') FROM long_forecasts WHERE horizon_type='month';"
+        -c "SELECT COUNT(*), COALESCE(MIN(date)::text, '') FROM long_forecasts WHERE horizon_type::text='MONTH';"
 }
 
 # ---------------------------------------------------------------------------
@@ -466,7 +466,7 @@ PYEOF
             local query_out
             if query_out="$(docker exec sapphire-postprocessing-db psql \
                 -U postgres -d postprocessing_db -P pager=off -t -A -F $'\t' \
-                -c "SELECT COUNT(*), COALESCE(MIN(date)::text, '') FROM long_forecasts WHERE horizon_type='month' AND horizon_value=${MODE_HORIZON_VALUE};" 2>&1)"; then
+                -c "SELECT COUNT(*), COALESCE(MIN(date)::text, '') FROM long_forecasts WHERE horizon_type::text='MONTH' AND horizon_value=${MODE_HORIZON_VALUE};" 2>&1)"; then
                 TARGET_COUNT="${query_out%%$'\t'*}"
                 TARGET_MIN_DATE="${query_out#*$'\t'}"
                 TARGET_COUNT="${TARGET_COUNT//[$'\r\n ']/}"

--- a/doc/plans/issues/high_prio_gi_draft_migration_horizon_type_case_coercion.md
+++ b/doc/plans/issues/high_prio_gi_draft_migration_horizon_type_case_coercion.md
@@ -1,0 +1,154 @@
+## Wrapper SQL uses lowercase horizon_type literals against UPPERCASE PG enum (MIG-003)
+
+**Status**: Draft (2026-06-10)
+**Module**: `bin/` (migration toolkit — ML export wrapper + long-term initialize wrapper)
+**Priority**: **High** (deployment-blocking — every affected query hard-fails against any operational deployment, same severity class as MIG-001/Finding 11)
+**Labels**: `migration-toolkit`, `sql`, `enum-coercion`, `deployment-blocker`, `audit-fix`
+**Discovered**: 2026-06-10 during P3 verification of the hardening batch (PR #360 + #361 merged earlier today). Flagged in advance by the P1 agent (task #56) and confirmed live during the same session.
+**Related**:
+- Finding 11 / PR #361 — same bug class for `model_type`. The fix pattern + tests there are the model for this one.
+- Authority: `sapphire/services/postprocessing/app/models.py:9-17` — `HorizonType` Python enum where NAMES (`DAY`/`PENTAD`/`DECADE`/...) differ from `.value` strings (`day`/`pentad`/`decade`/...). SQLAlchemy stores the NAME as the PG enum label.
+
+---
+
+## Summary
+
+Four executable SQL queries in the migration toolkit's `.sh` wrappers compare `horizon_type` against lowercase string literals (`'day'`, `'pentad'`, `'decade'`, `'month'`). The live `sapphire-postprocessing-db` `horizontype` PG enum stores UPPERCASE labels (`DAY`, `PENTAD`, `DECADE`, `MONTH`, `QUARTER`, `SEASON`). Every affected query hard-fails on any operational deployment with:
+
+```
+ERROR: invalid input value for enum horizontype: "day"
+```
+
+This blocks both the ML laptop export and the long-term forecast import wrappers on any real deployment. Same bug class as Finding 11 (which P1 fixed for `model_type`); the same `::text` cast pattern is the right fix here.
+
+---
+
+## Live evidence (reproduced 2026-06-10)
+
+```bash
+$ POSTGRES_USER=$(docker exec sapphire-postprocessing-db printenv POSTGRES_USER)
+
+# Probe the enum:
+$ docker exec sapphire-postprocessing-db psql -U "$POSTGRES_USER" -d postprocessing_db -tAc \
+    "SELECT enumlabel FROM pg_enum WHERE enumtypid='horizontype'::regtype ORDER BY enumsortorder"
+DAY
+PENTAD
+DECADE
+MONTH
+QUARTER
+SEASON
+
+# Reproduce the bug:
+$ docker exec sapphire-postprocessing-db psql -U "$POSTGRES_USER" -d postprocessing_db -tAc \
+    "SELECT COUNT(*) FROM forecasts WHERE horizon_type = 'day'"
+ERROR:  invalid input value for enum horizontype: "day"
+LINE 1: SELECT COUNT(*) FROM forecasts WHERE horizon_type = 'day'
+                                                            ^
+
+# Confirm fix pattern works (model_type::text cast — same as Finding 11 fix):
+$ docker exec sapphire-postprocessing-db psql -U "$POSTGRES_USER" -d postprocessing_db -tAc \
+    "SELECT COUNT(*) FROM forecasts WHERE horizon_type::text = 'DAY'"
+1144764
+```
+
+The existing live row already stores `horizon_type='PENTAD'` (uppercase). Confirmed by:
+```
+$ ... -tAc "SELECT model_type::text, horizon_type::text FROM forecasts LIMIT 1"
+TSMIXER|PENTAD
+```
+
+---
+
+## Audit — exact bug sites (file:line)
+
+`grep -rnE "horizon_type[ =]*[=]?[ ]*'(day|pentad|decade|month|quarter|season|year)'" bin/ apps/`
+filtered to executable SQL contexts (excluding docstrings, comments, and tests):
+
+| File | Line | Wrong | Correct |
+|---|---|---|---|
+| `bin/export_ml_forecast_history.sh` | :312 | `where+=" AND horizon_type IN ('day','pentad','decade')"` | `where+=" AND horizon_type::text IN ('DAY','PENTAD','DECADE')"` |
+| `bin/export_ml_forecast_history.sh` | :314 | `where+=" AND horizon_type = 'day'"` | `where+=" AND horizon_type::text = 'DAY'"` |
+| `bin/initialize_long_forecast_history.sh` | :320 | `... WHERE horizon_type='month'` | `... WHERE horizon_type::text='MONTH'` |
+| `bin/initialize_long_forecast_history.sh` | :469 | `... WHERE horizon_type='month' AND horizon_value=${MODE_HORIZON_VALUE}` | `... WHERE horizon_type::text='MONTH' AND horizon_value=${MODE_HORIZON_VALUE}` |
+
+**Authority** for the case mismatch: `sapphire/services/postprocessing/app/models.py:9-17` — `HorizonType` Python enum class where the Python NAMES (`DAY`/`PENTAD`/...) become the PG enum labels and the `.value` strings (`'day'`/`'pentad'`/...) are the API wire format. Compare to `ModelType` at `:23` which has the same pattern and is explicitly documented in the comment.
+
+---
+
+## Audit — what's NOT in scope (not a bug)
+
+The `grep` also surfaced lots of non-bug mentions of `horizon_type='day'` etc. These should NOT be changed:
+
+- **Docstrings + comments** (`bin/export_ml_forecast_history.sh:25,58,124`; `bin/initialize_ml_forecast_history.sh:40,346`; `bin/utils/migration_py/ml_forecast.py:35,645`; `apps/machine_learning/scr/utils_ml_forecast.py:762`; `apps/iEasyHydroForecast/forecast_library.py:5368`). Comments are not executed.
+- **API wire format references** (any Python code that passes `'day'` to a Pydantic model or REST API). Pydantic's `HorizonType` enum maps the `.value` string to the enum member, then SQLAlchemy stores the NAME — same dual-representation rule as `model_type`. **Do NOT change these**.
+- **Tests asserting the wire form** (e.g. `apps/iEasyHydroForecast/tests/test_forecast_library.py:3498,3539,3794,3870` — these check the API call uses lowercase `'decade'`/`'month'`; correct, do not change). Same for `apps/postprocessing_forecasts/tests/test_quarterly_api_writer.py` etc.
+- **Test that asserts the buggy SQL pattern**: `apps/iEasyHydroForecast/tests/test_initialize_long_forecast.py:800` literally asserts `"horizon_type='month'" in src`. This test was wrong — it was enshrining the bug. **Update it** to assert the new pattern `"horizon_type::text='MONTH'"`.
+
+The dual-representation rule (PG enum NAMES uppercase vs API wire VALUES lowercase) is the same rule P1 documented for `model_type`. The runbook §6.4 representation note from PR #361 already explains the pattern — extend it to cover `horizon_type`.
+
+---
+
+## Fix
+
+Single-PR fix following the P1 pattern:
+
+### 1. SQL changes (4 sites)
+
+Apply the table above. Use `horizon_type::text` cast (NOT `UPPER(horizon_type::text)`) — same rationale as P1 Revision #8: the cast sidesteps enum-literal coercion without the non-sargable function wrapper.
+
+### 2. Test changes
+
+- Update `apps/iEasyHydroForecast/tests/test_initialize_long_forecast.py:800`: change the assertion from `"horizon_type='month'"` to `"horizon_type::text='MONTH'"`. The neighbouring docstring at `:793` should also be updated.
+- Similar assertion at `:1043` ("per-mode query exists and references both horizon_type='month' AND ...") should be updated.
+- Add a behavioral regression test (mirror the P1 pattern at `apps/iEasyHydroForecast/tests/test_export_ml_forecast.py::test_export_dry_run_sql_uses_uppercase_pg_enum_labels`): capture the dry-run SQL emitted by the affected wrappers, assert the WHERE clause contains uppercase `'DAY'`/`'MONTH'` and does NOT contain lowercase `'day'`/`'month'`.
+
+### 3. Runbook §6 representation note
+
+Extend the §6.4 "Representation note" callout (added by PR #361) to also cover `horizon_type`. Same two-representation rule: PG enum NAMES uppercase for SQL; API wire VALUES lowercase for JSON payloads. Cite `models.py:9-17`.
+
+### 4. Audit (no change expected)
+
+Confirm no other wrapper or helper has the same pattern:
+- `git grep -nE "horizon_type[ =]*=[ ]*'(day|pentad|decade|month|quarter|season|year)'" bin/` should return zero matches after the fix
+- `git grep -nE "horizon_type IN \('(day|pentad|decade)" bin/` should also return zero
+
+If new matches appear, fix them in the same PR.
+
+---
+
+## Acceptance criteria
+
+- [ ] All four bug sites use `horizon_type::text` with UPPERCASE literals.
+- [ ] `git grep -nE "horizon_type[ =]*=[ ]*'(day|pentad|decade|month|quarter|season|year)'" bin/` returns no matches in executable SQL.
+- [ ] `git grep -nE "horizon_type IN \('(day|pentad|decade|month|quarter|season|year)" bin/` returns no matches.
+- [ ] `test_initialize_long_forecast.py` assertions updated to the new pattern; tests pass.
+- [ ] Behavioral regression test captures dry-run SQL and would FAIL on the old form.
+- [ ] Existing tests asserting API wire format (`apps/iEasyHydroForecast/tests/test_forecast_library.py:3498-3539,3794-3870` etc.) remain UNCHANGED and green — they validate the Pydantic side which still uses lowercase.
+- [ ] Runbook §6.4 representation note extended to cover `horizon_type` with `models.py:9-17` authority.
+- [ ] `SAPPHIRE_TEST_ENV=True bash apps/run_tests.sh iEasyHydroForecast` passes, zero failures, no unexpected skips.
+- [ ] Manual live-DB verification: run `psql -c "SELECT COUNT(*) FROM forecasts WHERE horizon_type::text = 'DAY'"` against the local stack, confirm returns a count (not enum error).
+
+---
+
+## Rollout
+
+1. Single PR off `maxat_sapphire_2`. Branch: `fix_horizon_type_enum_sql`. Doc + 2 wrappers + 1 test file + 1 runbook section. Roughly 15-20 lines of executable code change.
+2. **No image rebuild required** — the wrappers are read fresh from the operator's checkout on each invocation. Sapphire-services not affected.
+3. **No DB migration required** — DB schema already has uppercase enum labels; this PR aligns the wrappers to the schema.
+4. **Operators with existing log files from prior runs**: if they ran the ML export or long-term initialize wrappers before this fix, those runs would have hard-errored — there's no silent-corruption risk. They should re-run after merge.
+
+---
+
+## Process note
+
+This bug was flagged in advance by the P1 implementing agent (logged as task #56 from the 2026-06-08 walkthrough) and confirmed live during the P3 verification on 2026-06-10. The pattern is identical to Finding 11 (model_type) and was visible in `models.py:9-17` for anyone reading the schema, but slipped through the original migration-toolkit sprint because the test suite stubs psql and doesn't validate against a real enum at integration time.
+
+**Recommended follow-up for future migration-toolkit work**: any wrapper that constructs SQL against a column of PG enum type MUST either (a) use the `::text` cast pattern, or (b) include an integration test that runs the constructed SQL against an actual enum. Without one of those, this class of bug is invisible until live deployment.
+
+---
+
+## Out of scope
+
+- Other case-sensitivity audits beyond `horizon_type` (e.g. `meteo_type`, `snow_type`). Worth a separate audit but not blocking this PR.
+- Restructuring the Pydantic dual-representation pattern at the services layer (`sapphire/services/` — colleague-managed).
+- Adding integration tests that stand up a real Postgres instance with the enum (process improvement; separate scope).

--- a/doc/plans/module_issues.md
+++ b/doc/plans/module_issues.md
@@ -61,6 +61,7 @@ These are blocking decisions — work downstream cannot advance until they are r
 | **INFRA-014** | Add deployment initialization workflow | infra | **High** | Review | [`review_gi_draft_infra_new_deployment_initialization.md`](issues/review_gi_draft_infra_new_deployment_initialization.md) | FD-001 (partial) |
 | **P-004** | Fix silent timeout failure in `execute_with_retries` — timed-out tasks marked DONE | pipeline | **High** | Review | [`high_prio_gi_draft_pipeline_disable_unfulfilled_deps_check.md`](issues/high_prio_gi_draft_pipeline_disable_unfulfilled_deps_check.md) |
 | **MIG-002** | Runbook §10 rollback uses wrong dump filename glob — silent data destruction on operator rollback | migration-toolkit | **High** | Draft | [`high_prio_gi_draft_runbook_rollback_dump_glob_bug.md`](issues/high_prio_gi_draft_runbook_rollback_dump_glob_bug.md) | Discovered during Tajik runbook walkthrough 2026-06-08; data-loss class. Reviewer round-1 APPROVE WITH REVISIONS applied. |
+| **MIG-003** | Wrapper SQL uses lowercase horizon_type literals against UPPERCASE PG enum — deployment-blocking | migration-toolkit | **High** | Draft | [`high_prio_gi_draft_migration_horizon_type_case_coercion.md`](issues/high_prio_gi_draft_migration_horizon_type_case_coercion.md) | Discovered during P3 verification 2026-06-10; same class as Finding 11. 4 SQL fix sites in ML export + long-term initialize wrappers. |
 
 ---
 

--- a/doc/prod/update_data_migration_runbook.md
+++ b/doc/prod/update_data_migration_runbook.md
@@ -1620,6 +1620,17 @@ If you write an ad-hoc acceptance SQL against the live `forecasts` table,
 ALWAYS use the uppercase labels with `::text` (see §6.4.6 below). Mixed-case
 literals will hard-fail the query.
 
+The **same dual-representation rule applies to `horizon_type`** (MIG-003,
+discovered 2026-06-10). The `HorizonType` enum in
+`sapphire/services/postprocessing/app/models.py:9-17` carries PG enum
+LABELS in UPPERCASE (`DAY` / `PENTAD` / `DECADE` / `MONTH` / `QUARTER` /
+`SEASON`) while `.value` strings (`'day'` / `'pentad'` / ...) are the
+API JSON wire form. Raw SQL in `bin/export_ml_forecast_history.sh` and
+`bin/initialize_long_forecast_history.sh` must compare via
+`horizon_type::text IN ('DAY','PENTAD','DECADE')` or
+`horizon_type::text='MONTH'`; lowercase literals hard-fail with
+`ERROR: invalid input value for enum horizontype: "day"`.
+
 ##### WARNING: default horizon='day' vs `--preserve-legacy-ml-horizons`
 
 Per user-lock L6, the wrapper writes all migrated ML rows as


### PR DESCRIPTION
## Summary

Tracks **MIG-003** — fixes a deployment-blocking SQL bug in the migration toolkit's `bin/export_ml_forecast_history.sh` and `bin/initialize_long_forecast_history.sh` wrappers. Same bug class as Finding 11 / PR #361 (which fixed `model_type`), now applied to `horizon_type`.

### The bug

Four executable SQL queries compared `horizon_type` against lowercase enum literals (`'day'`, `'pentad'`, `'decade'`, `'month'`). The live `sapphire-postprocessing-db` `horizontype` PG enum stores UPPERCASE labels (`DAY`, `PENTAD`, `DECADE`, `MONTH`, `QUARTER`, `SEASON`). Every affected query hard-failed on operational deployments with:

```
ERROR: invalid input value for enum horizontype: "day"
```

This blocked both the ML laptop export and the long-term forecast import wrappers on any real deployment.

### Authority

`sapphire/services/postprocessing/app/models.py:9-17` — the `HorizonType` Python enum where NAMES (uppercase) become PG enum labels and `.value` strings (lowercase) are the API JSON wire form. The dual-representation rule mirrors `ModelType` at `:20-30`, already documented in runbook §6.4.

### The four bug sites

| File | Line | Before | After |
|---|---|---|---|
| `bin/export_ml_forecast_history.sh` | 312 | `horizon_type IN ('day','pentad','decade')` | `horizon_type::text IN ('DAY','PENTAD','DECADE')` |
| `bin/export_ml_forecast_history.sh` | 314 | `horizon_type = 'day'` | `horizon_type::text = 'DAY'` |
| `bin/initialize_long_forecast_history.sh` | 320 | `horizon_type='month'` | `horizon_type::text='MONTH'` |
| `bin/initialize_long_forecast_history.sh` | 469 | `horizon_type='month' AND horizon_value=...` | `horizon_type::text='MONTH' AND horizon_value=...` |

Uses the `::text` cast pattern (NOT `UPPER(...)`) — same rationale as PR #361 Revision #8: the cast sidesteps enum-literal coercion without the non-sargable function wrapper.

## Changes

### SQL fixes (4 sites)
- `bin/export_ml_forecast_history.sh` — `build_where_clause` filter uses uppercase `'DAY'`/`'PENTAD'`/`'DECADE'` via `horizon_type::text`.
- `bin/initialize_long_forecast_history.sh` — `query_target_state` (global) and per-mode `psql -c "..."` calls both use `horizon_type::text='MONTH'`.

### Test changes

**Updated** (assertion changed to enforce new pattern; old assertions enshrined the bug):
- `apps/iEasyHydroForecast/tests/test_initialize_long_forecast.py:793,800,1043` — docstring + assertion swap from `"horizon_type='month'"` to `"horizon_type::text='MONTH'"`.

**New behavioral regression tests** (FAIL if SQL is reverted to lowercase):
- `test_export_dry_run_sql_horizon_type_uses_uppercase_pg_enum_label` — default `horizon_type='DAY'` path.
- `test_export_dry_run_sql_horizon_type_legacy_uses_uppercase_pg_enum_labels` — `--include-legacy-horizons` path.
- `test_wrapper_psql_sql_uses_uppercase_horizon_type_pg_enum_labels` — extracts every `psql -c "<SQL>"` block from the long-forecast wrapper and validates it.

**Intentionally UNCHANGED** (validate the API JSON wire form, which remains lowercase per the dual-representation rule):
- `apps/iEasyHydroForecast/tests/test_forecast_library.py:3498,3539,3794,3870` — still assert `horizon_type='decade'`/`horizon_type='month'` in API calls.

### Documentation
- `doc/prod/update_data_migration_runbook.md` §6.4 representation note extended to cover `horizon_type` alongside `model_type`, citing `models.py:9-17` as authority.
- `doc/plans/issues/high_prio_gi_draft_migration_horizon_type_case_coercion.md` filed.
- `doc/plans/module_issues.md` Tier 1 — MIG-003 row added after MIG-002.

## Why this matters now

This unblocks the `dev_local_backfill.sh` v3 work that consumes `initialize_long_forecast_history.sh` in Phase 2, plus the operational Tajik / Kyrgyz / Uzbek long-term forecast and ML export migration paths.

No image rebuild required — wrappers are read fresh from the operator's checkout on each invocation. No DB migration required — schema already has uppercase enum labels; this PR aligns the wrappers to the schema.

## Test plan

- [x] `SAPPHIRE_TEST_ENV=True bash apps/run_tests.sh iEasyHydroForecast` — **705 passed, 0 failed, 0 unexpected skips**.
- [x] `git grep -nE "horizon_type[ =]*=[ ]*'(day|pentad|decade|month|quarter|season|year)'" bin/` — zero executable-SQL matches (only comments + docstrings remain).
- [x] `git grep -nE "horizon_type IN \('(day|pentad|decade|month)" bin/` — zero executable-SQL matches.
- [x] Wire-format tests in `test_forecast_library.py` left unchanged and still pass.
- [ ] Manual live-DB verification on staging: `psql -c "SELECT COUNT(*) FROM forecasts WHERE horizon_type::text = 'DAY'"` returns a count (not enum error).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>