### PR TITLE
Promote operator scripts: initialize_site_backfill.sh + purge_site_data.sh

### DIFF
--- a/bin/initialize_site_backfill.sh
+++ b/bin/initialize_site_backfill.sh
@@ -1,0 +1,611 @@
+#!/bin/bash
+# Initialize Site Backfill Script
+#
+# Runs preprocessing-runoff, linear-regression (PENTAD + DECAD), and
+# skill-metrics recalculation in `initial` mode (full hindcast from a given
+# start date). Use this script to recover historical data after a site-data
+# purge or any other situation that requires rebuilding the archive.
+#
+# The daily maintenance scripts use SAPPHIRE_SYNC_MODE=maintenance with short
+# lookback windows (30/90 days). After a purge going back further than those
+# windows, those scripts cannot close the gap. This script forces
+# SAPPHIRE_SYNC_MODE=initial with a user-supplied ieasyhydroforecast_START_DATE,
+# then triggers a full skill-metrics recalculation. It runs against ALL
+# stations; UPSERT is a no-op for rows that are already correct.
+#
+# Usage:
+#   bash bin/initialize_site_backfill.sh <env_file_path> \
+#       [--start-date YYYY-MM-DD] [--site-code N] \
+#       [--skip-preprunoff] [--skip-linreg] [--skip-skill] \
+#       [-h|--help]
+#
+# Arguments:
+#   env_file_path         Positional, required. Path to the .env_<org> file.
+#
+# Options:
+#   --start-date YYYY-MM-DD
+#                         Override start date for the hindcast. If omitted,
+#                         falls back to ieasyhydroforecast_START_DATE from the
+#                         env file. Aborts if still empty after fallback.
+#   --site-code N         3-10 digit station code used ONLY for log readability
+#                         and post-run verification SQL counts. Does NOT filter
+#                         the underlying container runs.
+#   --skip-preprunoff     Skip Phase 1 (preprocessing-runoff).
+#   --skip-linreg         Skip Phase 2 (linear-regression PENTAD + DECAD).
+#   --skip-skill          Skip Phase 3 (skill-metrics recalculation).
+#   -h, --help            Print this help message and exit 0.
+#
+# Prerequisites:
+#   - Docker daemon running
+#   - sapphire-preprocessing-db and sapphire-postprocessing-db containers
+#     running (for post-phase verification queries)
+#
+# Author: Beatrice Marti
+
+set -eo pipefail
+
+# ---------------------------------------------------------------------------
+# Source shared helpers
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC1091  # path computed at runtime; can't be statically resolved
+source "$(dirname "$0")/utils/common_functions.sh"
+# shellcheck disable=SC1091  # path computed at runtime; can't be statically resolved
+source "$(dirname "$0")/utils/run_skill_metrics_recalc.sh"
+
+# ---------------------------------------------------------------------------
+# Colors (matching purge_site_data.sh / reset_sapphire_db.sh)
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Defaults / flag variables
+# ---------------------------------------------------------------------------
+ENV_FILE=""
+START_DATE=""
+SITE_CODE=""
+SKIP_PREPRUNOFF=false
+SKIP_LINREG=false
+SKIP_SKILL=false
+
+PHASE_RESULTS=()
+
+# ---------------------------------------------------------------------------
+# Log helper — defined at top-level scope so all phase functions can call it
+# before main() runs.  The log file path (log_file) is set inside main() and
+# must exist before the first log_message call; early calls will write to
+# /dev/null via the fallback below if log_file is not yet set.
+# ---------------------------------------------------------------------------
+
+log_message() {
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")] $1" | tee -a "${log_file:-/dev/null}"
+}
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+print_usage() {
+    cat <<'USAGE'
+Usage: bash bin/initialize_site_backfill.sh <env_file_path> [OPTIONS]
+
+Rebuild historical data by running preprocessing-runoff, linear-regression
+(PENTAD + DECAD), and skill-metrics recalculation in full-hindcast (initial)
+mode.
+
+Arguments:
+  env_file_path         Path to the .env_<org> file (required).
+
+Options:
+  --start-date YYYY-MM-DD
+                        Start date for the hindcast. Falls back to
+                        ieasyhydroforecast_START_DATE in the env file.
+  --site-code N         3–10 digit station code for log readability and
+                        verification queries only. Does NOT filter container runs.
+  --skip-preprunoff     Skip Phase 1 (preprocessing-runoff).
+  --skip-linreg         Skip Phase 2 (linear-regression PENTAD + DECAD).
+  --skip-skill          Skip Phase 3 (skill-metrics recalculation).
+  -h, --help            Print this message and exit 0.
+
+Examples:
+  bash bin/initialize_site_backfill.sh /data/config/.env_kghm \
+      --start-date 2010-01-01 --site-code 19999
+  bash bin/initialize_site_backfill.sh /data/config/.env_kghm \
+      --start-date 2010-01-01 --skip-skill
+USAGE
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+parse_args() {
+    # Handle --help / -h before requiring the positional arg
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help) print_usage; exit 0 ;;
+        esac
+    done
+
+    if [[ $# -eq 0 ]]; then
+        echo -e "${RED}Error: env_file_path is required.${NC}" >&2
+        echo "" >&2
+        print_usage >&2
+        exit 1
+    fi
+
+    # First positional argument is the env file
+    if [[ "$1" != -* ]]; then
+        ENV_FILE="$1"
+        shift
+    else
+        echo -e "${RED}Error: first argument must be the env_file_path (got: $1).${NC}" >&2
+        echo "" >&2
+        print_usage >&2
+        exit 1
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --start-date)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --start-date requires a YYYY-MM-DD value.${NC}" >&2
+                    exit 1
+                fi
+                START_DATE="$2"
+                if [[ ! "$START_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                    echo -e "${RED}Error: --start-date '${START_DATE}' is not in YYYY-MM-DD format.${NC}" >&2
+                    exit 1
+                fi
+                shift 2
+                ;;
+            --site-code)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo -e "${RED}Error: --site-code requires a numeric value.${NC}" >&2
+                    exit 1
+                fi
+                SITE_CODE="$2"
+                shift 2
+                ;;
+            --skip-preprunoff)  SKIP_PREPRUNOFF=true; shift ;;
+            --skip-linreg)      SKIP_LINREG=true;     shift ;;
+            --skip-skill)       SKIP_SKILL=true;       shift ;;
+            -h|--help)          print_usage; exit 0 ;;
+            *)
+                echo -e "${RED}Error: unknown argument: $1${NC}" >&2
+                echo "" >&2
+                print_usage >&2
+                exit 1
+                ;;
+        esac
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+validate_inputs() {
+    # Validate env file exists
+    if [[ ! -f "$ENV_FILE" ]]; then
+        echo -e "${RED}Error: env file not found: ${ENV_FILE}${NC}" >&2
+        exit 1
+    fi
+
+    # Validate --site-code format if supplied
+    if [[ -n "$SITE_CODE" ]]; then
+        if [[ ! "$SITE_CODE" =~ ^[0-9]{3,10}$ ]]; then
+            echo -e "${RED}Error: --site-code '${SITE_CODE}' must be 3–10 decimal digits.${NC}" >&2
+            exit 1
+        fi
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase-result helpers (matching purge_site_data.sh pattern)
+# ---------------------------------------------------------------------------
+
+record_phase() {
+    local phase="$1"
+    local status="$2"   # PASS, FAIL, WARN, SKIP
+    PHASE_RESULTS+=("${status}|${phase}")
+}
+
+# ---------------------------------------------------------------------------
+# DB verification helper (best-effort; never aborts on query failure)
+# ---------------------------------------------------------------------------
+
+verify_db_counts() {
+    local db_container="$1"   # e.g. sapphire-preprocessing-db
+    local database="$2"       # e.g. preprocessing_db
+    local table="$3"
+    local start_date="$4"
+    local site_code="$5"      # may be empty
+
+    local sql
+    if [[ -n "$site_code" ]]; then
+        sql="SELECT COUNT(*) FROM ${table} WHERE code='${site_code}' AND date >= '${start_date}';"
+        local label="${table} (site ${site_code}, date >= ${start_date})"
+    else
+        sql="SELECT code, COUNT(*) FROM ${table} WHERE date >= '${start_date}' GROUP BY code ORDER BY code;"
+        local label="${table} (all sites, date >= ${start_date})"
+    fi
+
+    log_message "  Verifying ${database}.${label}"
+    local result
+    if result=$(docker exec "${db_container}" \
+            psql -U postgres -d "${database}" -t -A -F '|' -c "${sql}" 2>/dev/null); then
+        log_message "    Result: ${result:-<no rows>}"
+    else
+        log_message "  WARN: verification query failed for ${database}.${table} (DB container may not be running)"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1: Preprocessing-runoff init
+# ---------------------------------------------------------------------------
+
+run_preprunoff() {
+    local phase_name="Phase 1: preprocessing-runoff init"
+
+    if [[ "$SKIP_PREPRUNOFF" == true ]]; then
+        log_message "Skipping ${phase_name} (--skip-preprunoff)"
+        record_phase "$phase_name" "SKIP"
+        return 0
+    fi
+
+    log_message "========================================"
+    log_message "${phase_name}"
+    log_message "========================================"
+
+    local IMAGE_ID="mabesa/sapphire-preprunoff:${ieasyhydroforecast_backend_docker_image_tag:-latest}"
+
+    # Pull image if not present locally
+    if ! docker image inspect "$IMAGE_ID" > /dev/null 2>&1; then
+        log_message "Image ${IMAGE_ID} not found locally, pulling..."
+        if ! docker pull "$IMAGE_ID"; then
+            log_message "ERROR: Failed to pull Docker image ${IMAGE_ID}"
+            record_phase "$phase_name" "FAIL"
+            return 1
+        fi
+    fi
+
+    local CONTAINER_NAME="preprunoff-backfill"
+    local SERVICE_LOG="${LOG_DIR}/${CONTAINER_NAME}_${TIMESTAMP}.log"
+
+    log_message "Container name: ${CONTAINER_NAME}"
+    log_message "Service log: ${SERVICE_LOG}"
+    log_message "START_DATE: ${START_DATE}"
+
+    # Remove any stale container
+    if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+        log_message "Removing existing container: ${CONTAINER_NAME}"
+        docker rm -f "${CONTAINER_NAME}"
+    fi
+
+    # shellcheck disable=SC2086  # DOCKER_HOST_OVERRIDE intentionally unquoted: empty=no arg; non-empty word-splits to "-e KEY=VAL"
+    docker run \
+        --name "${CONTAINER_NAME}" \
+        --network host \
+        -e "ieasyhydroforecast_data_root_dir=${ieasyhydroforecast_data_root_dir}" \
+        -e "ieasyhydroforecast_env_file_path=${ieasyhydroforecast_env_file_path}" \
+        -e SAPPHIRE_OPDEV_ENV=True \
+        -e IN_DOCKER=True \
+        -e SAPPHIRE_SYNC_MODE=initial \
+        -e "ieasyhydroforecast_START_DATE=${START_DATE}" \
+        ${DOCKER_HOST_OVERRIDE} \
+        -v "${ieasyhydroforecast_data_ref_dir}/config:${ieasyhydroforecast_container_data_ref_dir}/config" \
+        -v "${ieasyhydroforecast_data_ref_dir}/daily_runoff:${ieasyhydroforecast_container_data_ref_dir}/daily_runoff" \
+        -v "${ieasyhydroforecast_data_ref_dir}/intermediate_data:${ieasyhydroforecast_container_data_ref_dir}/intermediate_data" \
+        -v "${ieasyhydroforecast_data_ref_dir}/bin:${ieasyhydroforecast_container_data_ref_dir}/bin" \
+        --memory=4g \
+        --memory-swap=6g \
+        "${IMAGE_ID}" \
+        2>&1 | tee "${SERVICE_LOG}"
+
+    local EXIT_CODE=$?
+    local CONTAINER_EXIT_CODE
+    CONTAINER_EXIT_CODE=$(docker inspect "${CONTAINER_NAME}" --format='{{.State.ExitCode}}' 2>/dev/null || echo "${EXIT_CODE}")
+
+    if [[ "$CONTAINER_EXIT_CODE" -eq 0 ]]; then
+        log_message "Phase 1 completed successfully"
+        record_phase "$phase_name" "PASS"
+    else
+        log_message "WARNING: Phase 1 completed with exit code: ${CONTAINER_EXIT_CODE}"
+        log_message "Check log file for details: ${SERVICE_LOG}"
+        record_phase "$phase_name" "FAIL"
+    fi
+
+    docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+
+    log_message "Post-phase verification — preprocessing_db:"
+    verify_db_counts "sapphire-preprocessing-db" "preprocessing_db" "runoffs"     "${START_DATE}" "${SITE_CODE}"
+    verify_db_counts "sapphire-preprocessing-db" "preprocessing_db" "hydrographs" "${START_DATE}" "${SITE_CODE}"
+
+    log_message "------"
+    return "$CONTAINER_EXIT_CODE"
+}
+
+# ---------------------------------------------------------------------------
+# Phase 2: Linear-regression init (PENTAD + DECAD)
+# ---------------------------------------------------------------------------
+
+run_linreg() {
+    local phase_name="Phase 2: linear-regression init (PENTAD + DECAD)"
+
+    if [[ "$SKIP_LINREG" == true ]]; then
+        log_message "Skipping ${phase_name} (--skip-linreg)"
+        record_phase "$phase_name" "SKIP"
+        return 0
+    fi
+
+    log_message "========================================"
+    log_message "${phase_name}"
+    log_message "========================================"
+
+    local IMAGE_ID="mabesa/sapphire-linreg:${ieasyhydroforecast_backend_docker_image_tag:-latest}"
+
+    if ! docker image inspect "$IMAGE_ID" > /dev/null 2>&1; then
+        log_message "Image ${IMAGE_ID} not found locally, pulling..."
+        if ! docker pull "$IMAGE_ID"; then
+            log_message "ERROR: Failed to pull Docker image ${IMAGE_ID}"
+            record_phase "$phase_name" "FAIL"
+            return 1
+        fi
+    fi
+
+    local PREDICTION_MODES=("PENTAD" "DECAD")
+    local phase_exit_code=0
+
+    for MODE in "${PREDICTION_MODES[@]}"; do
+        local CONTAINER_NAME="linreg-backfill-${MODE}"
+        local SERVICE_LOG="${LOG_DIR}/${CONTAINER_NAME}_${TIMESTAMP}.log"
+
+        log_message "Starting linear-regression init for ${MODE} mode..."
+        log_message "Container name: ${CONTAINER_NAME}"
+        log_message "Service log: ${SERVICE_LOG}"
+
+        # Remove any stale container
+        if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+            log_message "Removing existing container: ${CONTAINER_NAME}"
+            docker rm -f "${CONTAINER_NAME}"
+        fi
+
+        # shellcheck disable=SC2086  # DOCKER_HOST_OVERRIDE intentionally unquoted: empty=no arg; non-empty word-splits to "-e KEY=VAL"
+        docker run \
+            --name "${CONTAINER_NAME}" \
+            --network host \
+            -e "ieasyhydroforecast_data_root_dir=${ieasyhydroforecast_data_root_dir}" \
+            -e "ieasyhydroforecast_env_file_path=${ieasyhydroforecast_env_file_path}" \
+            -e SAPPHIRE_OPDEV_ENV=True \
+            -e IN_DOCKER=True \
+            -e "SAPPHIRE_PREDICTION_MODE=${MODE}" \
+            -e RUN_MODE=maintenance \
+            -e SAPPHIRE_SYNC_MODE=initial \
+            -e "ieasyhydroforecast_START_DATE=${START_DATE}" \
+            ${DOCKER_HOST_OVERRIDE} \
+            -v "${ieasyhydroforecast_data_ref_dir}/config:${ieasyhydroforecast_container_data_ref_dir}/config" \
+            -v "${ieasyhydroforecast_data_ref_dir}/daily_runoff:${ieasyhydroforecast_container_data_ref_dir}/daily_runoff" \
+            -v "${ieasyhydroforecast_data_ref_dir}/intermediate_data:${ieasyhydroforecast_container_data_ref_dir}/intermediate_data" \
+            -v "${ieasyhydroforecast_data_ref_dir}/bin:${ieasyhydroforecast_container_data_ref_dir}/bin" \
+            --memory=4g \
+            --memory-swap=6g \
+            "${IMAGE_ID}" \
+            sh -c "uv run linear_regression.py --hindcast --start-date ${START_DATE}" \
+            2>&1 | tee "${SERVICE_LOG}"
+
+        local EXIT_CODE=$?
+        local CONTAINER_EXIT_CODE
+        CONTAINER_EXIT_CODE=$(docker inspect "${CONTAINER_NAME}" --format='{{.State.ExitCode}}' 2>/dev/null || echo "${EXIT_CODE}")
+
+        if [[ "$CONTAINER_EXIT_CODE" -eq 0 ]]; then
+            log_message "${MODE} init completed successfully"
+        else
+            log_message "WARNING: ${MODE} init completed with exit code: ${CONTAINER_EXIT_CODE}"
+            log_message "Check log file for details: ${SERVICE_LOG}"
+            phase_exit_code="$CONTAINER_EXIT_CODE"
+        fi
+
+        docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+        log_message "Finished ${MODE} mode"
+        log_message "------"
+    done
+
+    log_message "Post-phase verification — postprocessing_db:"
+    verify_db_counts "sapphire-postprocessing-db" "postprocessing_db" "lr_forecasts" "${START_DATE}" "${SITE_CODE}"
+
+    if [[ "$phase_exit_code" -eq 0 ]]; then
+        record_phase "$phase_name" "PASS"
+    else
+        record_phase "$phase_name" "FAIL"
+    fi
+
+    return "$phase_exit_code"
+}
+
+# ---------------------------------------------------------------------------
+# Phase 3: Skill-metrics recalculation
+# ---------------------------------------------------------------------------
+
+run_skill_recalc() {
+    local phase_name="Phase 3: skill-metrics recalculation"
+
+    if [[ "$SKIP_SKILL" == true ]]; then
+        log_message "Skipping ${phase_name} (--skip-skill)"
+        record_phase "$phase_name" "SKIP"
+        return 0
+    fi
+
+    log_message "========================================"
+    log_message "${phase_name}"
+    log_message "========================================"
+
+    # Pull the postprocessing image if not present
+    local IMAGE_ID="mabesa/sapphire-postprocessing:${ieasyhydroforecast_backend_docker_image_tag:-latest}"
+    if ! docker image inspect "$IMAGE_ID" > /dev/null 2>&1; then
+        log_message "Image ${IMAGE_ID} not found locally, pulling..."
+        if ! docker pull "$IMAGE_ID"; then
+            log_message "ERROR: Failed to pull Docker image ${IMAGE_ID}"
+            record_phase "$phase_name" "FAIL"
+            return 1
+        fi
+    fi
+
+    # Delegate to the shared helper (sourced at top of script)
+    run_skill_metrics_recalc_once "BOTH" "${LOG_DIR}" "${TIMESTAMP}" "postprc-backfill"
+    local SKILL_EXIT_CODE=$?
+
+    if [[ "$SKILL_EXIT_CODE" -eq 0 ]]; then
+        log_message "Phase 3 completed successfully"
+        record_phase "$phase_name" "PASS"
+    else
+        log_message "WARNING: Phase 3 completed with exit code: ${SKILL_EXIT_CODE}"
+        record_phase "$phase_name" "FAIL"
+    fi
+
+    log_message "Post-phase verification — postprocessing_db:"
+    verify_db_counts "sapphire-postprocessing-db" "postprocessing_db" "skill_metrics" "${START_DATE}" "${SITE_CODE}"
+
+    log_message "------"
+    return "$SKILL_EXIT_CODE"
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+print_summary() {
+    echo ""
+    echo -e "${BOLD}========================================"
+    echo -e " BACKFILL SUMMARY"
+    echo -e "========================================${NC}"
+    echo ""
+
+    local any_failed=false
+    for entry in "${PHASE_RESULTS[@]}"; do
+        local status="${entry%%|*}"
+        local phase="${entry#*|}"
+        case "$status" in
+            PASS) echo -e "  ${GREEN}PASS${NC}  ${phase}" ;;
+            FAIL) echo -e "  ${RED}FAIL${NC}  ${phase}"; any_failed=true ;;
+            WARN) echo -e "  ${YELLOW}WARN${NC}  ${phase}" ;;
+            SKIP) echo -e "  ${BLUE}SKIP${NC}  ${phase}" ;;
+        esac
+    done
+
+    echo ""
+
+    if [[ "$any_failed" == true ]]; then
+        echo -e "${RED}One or more phases failed. Check the logs at: ${LOG_DIR}${NC}"
+        return 1
+    fi
+
+    echo -e "${GREEN}Backfill complete. Restart the dashboard to pick up the new data:${NC}"
+    echo "  docker restart sapphire-dashboard"
+    echo ""
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    parse_args "$@"
+    validate_inputs
+
+    # Print the banner (from common_functions.sh)
+    print_banner
+    echo "| Running Site Backfill (initial / full-hindcast mode)"
+
+    # Load .env vars and derive ieasyhydroforecast_* path variables
+    read_configuration "${ENV_FILE}"
+
+    # Validate required env vars (same guard as daily scripts)
+    if [[ -z "${ieasyhydroforecast_data_root_dir:-}" ]] || \
+       [[ -z "${ieasyhydroforecast_env_file_path:-}" ]] || \
+       [[ -z "${ieasyhydroforecast_data_ref_dir:-}" ]] || \
+       [[ -z "${ieasyhydroforecast_container_data_ref_dir:-}" ]]; then
+        echo "| Error: Required environment variables are not set. Please check your .env file."
+        exit 1
+    fi
+
+    # Resolve start date: CLI flag wins; fall back to env var; abort if empty
+    if [[ -z "$START_DATE" ]]; then
+        START_DATE="${ieasyhydroforecast_START_DATE:-}"
+        if [[ -z "$START_DATE" ]]; then
+            echo -e "${RED}Error: --start-date was not provided and ieasyhydroforecast_START_DATE is not set in the env file.${NC}" >&2
+            exit 1
+        fi
+        # Validate the date format sourced from env (the CLI path was already validated)
+        if [[ ! "$START_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo -e "${RED}Error: ieasyhydroforecast_START_DATE '${START_DATE}' is not in YYYY-MM-DD format.${NC}" >&2
+            exit 1
+        fi
+    fi
+
+    # Create log directory
+    LOG_DIR="${ieasyhydroforecast_data_root_dir}/logs/site_backfill"
+    mkdir -p "${LOG_DIR}"
+    echo "| Log directory: ${LOG_DIR}"
+
+    # Timestamped main log file
+    TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+    log_file="${LOG_DIR}/run_${TIMESTAMP}.log"
+
+    log_message "Starting site backfill run"
+    log_message "  env_file:   ${ENV_FILE}"
+    log_message "  start_date: ${START_DATE}"
+    [[ -n "$SITE_CODE" ]] && log_message "  site_code:  ${SITE_CODE} (log/verify only)"
+    log_message "  skip flags: preprunoff=${SKIP_PREPRUNOFF} linreg=${SKIP_LINREG} skill=${SKIP_SKILL}"
+
+    # Verify Docker is running
+    if ! docker info > /dev/null 2>&1; then
+        log_message "ERROR: Docker is not running. Please start Docker and try again."
+        exit 1
+    fi
+
+    # macOS Docker compatibility — copy exact pattern from daily_linreg_maintenance.sh
+    DOCKER_HOST_OVERRIDE=""
+    if [[ "$(uname)" == "Darwin" ]]; then
+        if [[ "${IEASYHYDROHF_HOST:-}" == *"localhost"* ]]; then
+            local DOCKER_IEASYHYDROHF_HOST="${IEASYHYDROHF_HOST//localhost/host.docker.internal}"
+            log_message "macOS detected: overriding IEASYHYDROHF_HOST for Docker container"
+            log_message "  Original: ${IEASYHYDROHF_HOST}"
+            log_message "  Docker:   ${DOCKER_IEASYHYDROHF_HOST}"
+            DOCKER_HOST_OVERRIDE="-e IEASYHYDROHF_HOST=${DOCKER_IEASYHYDROHF_HOST}"
+        fi
+    fi
+
+    # Establish SSH tunnel (no-op when ieasyhydroforecast_ssh_to_iEH != true)
+    establish_ssh_tunnel
+
+    # Register cleanup trap
+    trap cleanup EXIT
+
+    # ---------------------------------------------------------------------------
+    # Run phases — each function uses PHASE_RESULTS, LOG_DIR, TIMESTAMP,
+    # START_DATE, SITE_CODE, DOCKER_HOST_OVERRIDE, and log_message() from scope.
+    # ---------------------------------------------------------------------------
+    local overall_exit=0
+
+    run_preprunoff  || overall_exit=1
+    run_linreg      || overall_exit=1
+    run_skill_recalc || overall_exit=1
+
+    # Clean up old log files (older than 15 days)
+    log_message "Removing log files older than 15 days"
+    find "${LOG_DIR}" -type f -mtime +15 -delete
+
+    log_message "Site backfill run finished"
+
+    print_summary || overall_exit=1
+
+    exit "$overall_exit"
+}
+
+main "$@"

--- a/bin/purge_site_data.sh
+++ b/bin/purge_site_data.sh
@@ -25,10 +25,10 @@
 #   -h, --help                 Show this help message and exit 0
 #
 # Examples:
-#   bash bin/purge_site_data.sh 10001 2024-01-01 --dry-run
-#   bash bin/purge_site_data.sh 10001 2024-01-01
-#   bash bin/purge_site_data.sh 10001 2024-01-01 --include-hydrographs -y
-#   bash bin/purge_site_data.sh 10001 2024-01-01 --postprocessing-only
+#   bash bin/purge_site_data.sh 19999 2024-01-01 --dry-run
+#   bash bin/purge_site_data.sh 19999 2024-01-01
+#   bash bin/purge_site_data.sh 19999 2024-01-01 --include-hydrographs -y
+#   bash bin/purge_site_data.sh 19999 2024-01-01 --postprocessing-only
 #
 # Prerequisites:
 #   - Docker daemon running
@@ -149,10 +149,10 @@ Tables purged:
                      bulletins (year >= from_year), lr_visibility (year >= from_year)
 
 Examples:
-  bash bin/purge_site_data.sh 10001 2024-01-01 --dry-run
-  bash bin/purge_site_data.sh 10001 2024-01-01
-  bash bin/purge_site_data.sh 10001 2024-01-01 --include-hydrographs -y
-  bash bin/purge_site_data.sh 10001 2024-01-01 --postprocessing-only
+  bash bin/purge_site_data.sh 19999 2024-01-01 --dry-run
+  bash bin/purge_site_data.sh 19999 2024-01-01
+  bash bin/purge_site_data.sh 19999 2024-01-01 --include-hydrographs -y
+  bash bin/purge_site_data.sh 19999 2024-01-01 --postprocessing-only
 USAGE
 }
 

--- a/bin/purge_site_data.sh
+++ b/bin/purge_site_data.sh
@@ -1,0 +1,709 @@
+#!/usr/bin/env bash
+
+# =============================================================================
+# SAPPHIRE Site Data Purge
+# =============================================================================
+#
+# Deletes operational data for a single hydropost site from a given date
+# forward, across preprocessing-db and postprocessing-db Postgres containers.
+# Includes backup reminder, dry-run counts, typed confirmation prompt, and
+# fully transactional deletes with rollback on error.
+#
+# Usage:
+#   bash bin/purge_site_data.sh <site_code> <from_date> [FLAGS]
+#
+# Arguments:
+#   site_code   Numeric station code (3–10 digits)
+#   from_date   Start date in YYYY-MM-DD format (rows on/after this date deleted)
+#
+# Flags:
+#   --dry-run                  Show row counts only; do NOT delete
+#   --include-hydrographs      Also delete from hydrographs table
+#   --preprocessing-only       Only touch preprocessing-db
+#   --postprocessing-only      Only touch postprocessing-db
+#   -y, --yes                  Skip confirmation prompt
+#   -h, --help                 Show this help message and exit 0
+#
+# Examples:
+#   bash bin/purge_site_data.sh 10001 2024-01-01 --dry-run
+#   bash bin/purge_site_data.sh 10001 2024-01-01
+#   bash bin/purge_site_data.sh 10001 2024-01-01 --include-hydrographs -y
+#   bash bin/purge_site_data.sh 10001 2024-01-01 --postprocessing-only
+#
+# Prerequisites:
+#   - Docker daemon running
+#   - Run from repository root (parent of sapphire/)
+#   - Containers sapphire-preprocessing-db and sapphire-postprocessing-db running
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Colors (matching reset_sapphire_db.sh)
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+PREPROCESSING_DB="sapphire-preprocessing-db"
+POSTPROCESSING_DB="sapphire-postprocessing-db"
+
+# Flags (defaults)
+DRY_RUN=false
+INCLUDE_HYDROGRAPHS=false
+PREPROCESSING_ONLY=false
+POSTPROCESSING_ONLY=false
+AUTO_YES=false
+
+# Phase tracking
+PHASE_RESULTS=()
+
+# Timing
+SCRIPT_START=0
+
+# Populated after arg parsing
+SITE_CODE=""
+FROM_DATE=""
+FROM_YEAR=""
+
+# Dry-run counts (set in phase_counts, used in phase_confirm and phase_verify)
+CNT_RUNOFFS=0
+CNT_HYDROGRAPHS=0
+CNT_FORECASTS=0
+CNT_LONG_FORECASTS=0
+CNT_LR_FORECASTS=0
+CNT_SKILL_METRICS=0
+CNT_BULLETINS=0
+CNT_LR_VISIBILITY=0
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+log() {
+    local level="$1"
+    shift
+    local msg="$*"
+    local ts
+    ts="$(date '+%H:%M:%S')"
+
+    case "$level" in
+        INFO)  echo -e "${BLUE}[${ts}] ${msg}${NC}" ;;
+        OK)    echo -e "${GREEN}[${ts}] ${msg}${NC}" ;;
+        WARN)  echo -e "${YELLOW}[${ts}] ${msg}${NC}" ;;
+        ERROR) echo -e "${RED}[${ts}] ${msg}${NC}" ;;
+        *)     echo "[${ts}] ${msg}" ;;
+    esac
+}
+
+banner() {
+    local msg="$1"
+    echo ""
+    echo -e "${BOLD}========================================${NC}"
+    echo -e "${BOLD} ${msg}${NC}"
+    echo -e "${BOLD}========================================${NC}"
+}
+
+get_timestamp() {
+    date +%s
+}
+
+record_phase() {
+    local phase="$1"
+    local status="$2"  # PASS, FAIL, WARN, SKIP
+    PHASE_RESULTS+=("${status}|${phase}")
+}
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+print_usage() {
+    cat <<'USAGE'
+Usage: bash bin/purge_site_data.sh <site_code> <from_date> [FLAGS]
+
+Delete operational data for a single hydropost site from a given date forward,
+across preprocessing-db and postprocessing-db Postgres containers.
+
+Arguments:
+  site_code   Numeric station code (3–10 digits)
+  from_date   Start date in YYYY-MM-DD format (rows on/after this date deleted)
+
+Flags:
+  --dry-run                Show row counts only; do NOT delete anything
+  --include-hydrographs    Also delete from hydrographs table (default: skip)
+  --preprocessing-only     Only touch preprocessing-db
+  --postprocessing-only    Only touch postprocessing-db
+  -y, --yes                Skip confirmation prompt
+  -h, --help               Show this help message and exit 0
+
+Tables purged:
+  preprocessing_db : runoffs  [hydrographs if --include-hydrographs]
+  postprocessing_db: forecasts, long_forecasts, lr_forecasts, skill_metrics,
+                     bulletins (year >= from_year), lr_visibility (year >= from_year)
+
+Examples:
+  bash bin/purge_site_data.sh 10001 2024-01-01 --dry-run
+  bash bin/purge_site_data.sh 10001 2024-01-01
+  bash bin/purge_site_data.sh 10001 2024-01-01 --include-hydrographs -y
+  bash bin/purge_site_data.sh 10001 2024-01-01 --postprocessing-only
+USAGE
+}
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+validate_inputs() {
+    # site_code: numeric, 3–10 characters, no shell metacharacters
+    if [[ -z "$SITE_CODE" ]]; then
+        log ERROR "Missing required argument: site_code"
+        print_usage
+        exit 1
+    fi
+    if [[ ! "$SITE_CODE" =~ ^[0-9]{3,10}$ ]]; then
+        log ERROR "Invalid site_code '${SITE_CODE}': must be 3–10 decimal digits."
+        exit 1
+    fi
+
+    # from_date: YYYY-MM-DD
+    if [[ -z "$FROM_DATE" ]]; then
+        log ERROR "Missing required argument: from_date"
+        print_usage
+        exit 1
+    fi
+    if [[ ! "$FROM_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+        log ERROR "Invalid from_date '${FROM_DATE}': expected YYYY-MM-DD."
+        exit 1
+    fi
+
+    # Derive from_year
+    FROM_YEAR="${FROM_DATE:0:4}"
+
+    log OK "Inputs validated: site_code=${SITE_CODE}  from_date=${FROM_DATE}  from_year=${FROM_YEAR}"
+}
+
+# ---------------------------------------------------------------------------
+# Phase 0: Pre-flight
+# ---------------------------------------------------------------------------
+
+phase_preflight() {
+    banner "Phase 0: Pre-flight Checks"
+
+    # Check docker binary
+    if ! command -v docker >/dev/null 2>&1; then
+        log ERROR "docker binary not found on PATH. Install Docker and try again."
+        record_phase "Pre-flight" "FAIL"
+        exit 1
+    fi
+    log OK "docker binary found"
+
+    # Check docker daemon
+    if ! docker info >/dev/null 2>&1; then
+        log ERROR "Docker daemon is not running. Start Docker and try again."
+        record_phase "Pre-flight" "FAIL"
+        exit 1
+    fi
+    log OK "Docker daemon is running"
+
+    # Check required containers
+    local need_pre=true
+    local need_post=true
+
+    if [ "$POSTPROCESSING_ONLY" = true ]; then
+        need_pre=false
+    fi
+    if [ "$PREPROCESSING_ONLY" = true ]; then
+        need_post=false
+    fi
+
+    if [ "$need_pre" = true ]; then
+        local found_pre
+        found_pre=$(docker ps \
+            --filter "name=^/${PREPROCESSING_DB}$" \
+            --filter "status=running" \
+            --format '{{.Names}}' 2>/dev/null || true)
+        if [[ -z "$found_pre" ]]; then
+            log ERROR "Container '${PREPROCESSING_DB}' is not running."
+            log ERROR "Start the SAPPHIRE stack: docker compose -f sapphire/docker-compose.yml up -d"
+            record_phase "Pre-flight" "FAIL"
+            exit 1
+        fi
+        log OK "Container ${PREPROCESSING_DB} is running"
+    fi
+
+    if [ "$need_post" = true ]; then
+        local found_post
+        found_post=$(docker ps \
+            --filter "name=^/${POSTPROCESSING_DB}$" \
+            --filter "status=running" \
+            --format '{{.Names}}' 2>/dev/null || true)
+        if [[ -z "$found_post" ]]; then
+            log ERROR "Container '${POSTPROCESSING_DB}' is not running."
+            log ERROR "Start the SAPPHIRE stack: docker compose -f sapphire/docker-compose.yml up -d"
+            record_phase "Pre-flight" "FAIL"
+            exit 1
+        fi
+        log OK "Container ${POSTPROCESSING_DB} is running"
+    fi
+
+    # Backup reminder (always shown)
+    echo ""
+    echo -e "${YELLOW}  REMINDER: Back up your databases before purging!${NC}"
+    echo -e "${YELLOW}  Run:  bash bin/backup_sapphire_db.sh${NC}"
+    echo ""
+
+    record_phase "Pre-flight" "PASS"
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1: Dry-run counts
+# ---------------------------------------------------------------------------
+
+# Run a psql query against a named container and return tab-separated output.
+# Usage: psql_query <container> <database> <sql>
+psql_query() {
+    local container="$1"
+    local database="$2"
+    local sql="$3"
+    docker exec -i "$container" \
+        psql -U postgres -d "$database" -t -A -F '|' -c "$sql" 2>/dev/null
+}
+
+phase_counts() {
+    banner "Phase 1: Row Count Preview"
+
+    echo ""
+    printf "  %-30s %10s\n" "Table" "Row count"
+    printf "  %-30s %10s\n" "------------------------------" "----------"
+
+    # --- preprocessing-db ---
+    if [ "$POSTPROCESSING_ONLY" = false ]; then
+        local pre_sql
+        pre_sql="SELECT 'runoffs'::text, COUNT(*) FROM runoffs WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}'
+UNION ALL
+SELECT 'hydrographs'::text, COUNT(*) FROM hydrographs WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}';"
+
+        local pre_out
+        pre_out=$(psql_query "$PREPROCESSING_DB" "preprocessing_db" "$pre_sql") || {
+            log ERROR "Failed to query ${PREPROCESSING_DB}"
+            record_phase "Row counts" "FAIL"
+            return 1
+        }
+
+        while IFS='|' read -r tbl cnt; do
+            [[ -z "$tbl" ]] && continue
+            cnt="${cnt//[[:space:]]/}"
+            case "$tbl" in
+                runoffs)     CNT_RUNOFFS="$cnt" ;;
+                hydrographs) CNT_HYDROGRAPHS="$cnt" ;;
+            esac
+        done <<< "$pre_out"
+
+        echo -e "  ${BOLD}preprocessing_db${NC}"
+        printf "    %-28s %10s\n" "runoffs" "$CNT_RUNOFFS"
+        if [ "$INCLUDE_HYDROGRAPHS" = true ]; then
+            printf "    %-28s %10s\n" "hydrographs" "$CNT_HYDROGRAPHS"
+        else
+            printf "    %-28s %10s  %s\n" "hydrographs" "$CNT_HYDROGRAPHS" "(skipped — use --include-hydrographs)"
+        fi
+    fi
+
+    # --- postprocessing-db ---
+    if [ "$PREPROCESSING_ONLY" = false ]; then
+        local post_sql
+        post_sql="SELECT 'forecasts'::text,     COUNT(*) FROM forecasts      WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}'
+UNION ALL
+SELECT 'long_forecasts'::text,  COUNT(*) FROM long_forecasts   WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}'
+UNION ALL
+SELECT 'lr_forecasts'::text,    COUNT(*) FROM lr_forecasts     WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}'
+UNION ALL
+SELECT 'skill_metrics'::text,   COUNT(*) FROM skill_metrics    WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}'
+UNION ALL
+SELECT 'bulletins'::text,       COUNT(*) FROM bulletins        WHERE code='${SITE_CODE}' AND year >= ${FROM_YEAR}
+UNION ALL
+SELECT 'lr_visibility'::text,   COUNT(*) FROM lr_visibility    WHERE code='${SITE_CODE}' AND year >= ${FROM_YEAR};"
+
+        local post_out
+        post_out=$(psql_query "$POSTPROCESSING_DB" "postprocessing_db" "$post_sql") || {
+            log ERROR "Failed to query ${POSTPROCESSING_DB}"
+            record_phase "Row counts" "FAIL"
+            return 1
+        }
+
+        while IFS='|' read -r tbl cnt; do
+            [[ -z "$tbl" ]] && continue
+            cnt="${cnt//[[:space:]]/}"
+            case "$tbl" in
+                forecasts)      CNT_FORECASTS="$cnt" ;;
+                long_forecasts) CNT_LONG_FORECASTS="$cnt" ;;
+                lr_forecasts)   CNT_LR_FORECASTS="$cnt" ;;
+                skill_metrics)  CNT_SKILL_METRICS="$cnt" ;;
+                bulletins)      CNT_BULLETINS="$cnt" ;;
+                lr_visibility)  CNT_LR_VISIBILITY="$cnt" ;;
+            esac
+        done <<< "$post_out"
+
+        echo -e "  ${BOLD}postprocessing_db${NC}"
+        printf "    %-28s %10s\n" "forecasts"      "$CNT_FORECASTS"
+        printf "    %-28s %10s\n" "long_forecasts" "$CNT_LONG_FORECASTS"
+        printf "    %-28s %10s\n" "lr_forecasts"   "$CNT_LR_FORECASTS"
+        printf "    %-28s %10s\n" "skill_metrics"  "$CNT_SKILL_METRICS"
+        printf "    %-28s %10s  %s\n" "bulletins"  "$CNT_BULLETINS"  "(year >= ${FROM_YEAR})"
+        printf "    %-28s %10s  %s\n" "lr_visibility" "$CNT_LR_VISIBILITY" "(year >= ${FROM_YEAR})"
+    fi
+
+    echo ""
+    record_phase "Row counts" "PASS"
+
+    if [ "$DRY_RUN" = true ]; then
+        log INFO "--dry-run: no data will be deleted. Exiting."
+        exit 0
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 2: Confirmation
+# ---------------------------------------------------------------------------
+
+phase_confirm() {
+    banner "Phase 2: Confirmation"
+
+    echo ""
+    echo -e "${BOLD}  About to DELETE the following rows for site ${SITE_CODE}:${NC}"
+    echo ""
+
+    if [ "$POSTPROCESSING_ONLY" = false ]; then
+        echo -e "  ${BOLD}preprocessing_db:${NC}"
+        printf "    %-28s %10s rows\n" "runoffs"     "$CNT_RUNOFFS"
+        if [ "$INCLUDE_HYDROGRAPHS" = true ]; then
+            printf "    %-28s %10s rows\n" "hydrographs" "$CNT_HYDROGRAPHS"
+        else
+            printf "    %-28s %10s rows  %s\n" "hydrographs" "$CNT_HYDROGRAPHS" "(skipped)"
+        fi
+    fi
+
+    if [ "$PREPROCESSING_ONLY" = false ]; then
+        echo -e "  ${BOLD}postprocessing_db:${NC}"
+        printf "    %-28s %10s rows\n" "forecasts"      "$CNT_FORECASTS"
+        printf "    %-28s %10s rows\n" "long_forecasts" "$CNT_LONG_FORECASTS"
+        printf "    %-28s %10s rows\n" "lr_forecasts"   "$CNT_LR_FORECASTS"
+        printf "    %-28s %10s rows\n" "skill_metrics"  "$CNT_SKILL_METRICS"
+        printf "    %-28s %10s rows  %s\n" "bulletins"     "$CNT_BULLETINS"     "(year >= ${FROM_YEAR})"
+        printf "    %-28s %10s rows  %s\n" "lr_visibility" "$CNT_LR_VISIBILITY" "(year >= ${FROM_YEAR})"
+    fi
+
+    echo ""
+
+    if [ "$AUTO_YES" = false ]; then
+        echo -e "${YELLOW}  REMINDER: Back up your databases if you haven't already:${NC}"
+        echo -e "${YELLOW}  Run:  bash bin/backup_sapphire_db.sh${NC}"
+        echo ""
+        echo -ne "${BOLD}  Type the site code to confirm: ${NC}"
+        local typed
+        read -r typed
+        if [[ "$typed" != "$SITE_CODE" ]]; then
+            log ERROR "Confirmation failed: you typed '${typed}', expected '${SITE_CODE}'. Aborting."
+            record_phase "Confirmation" "FAIL"
+            exit 2
+        fi
+        log OK "Confirmed."
+    else
+        log INFO "--yes: skipping confirmation prompt."
+    fi
+
+    record_phase "Confirmation" "PASS"
+}
+
+# ---------------------------------------------------------------------------
+# Phase 3: Deletes (transactional)
+# ---------------------------------------------------------------------------
+
+phase_delete_preprocessing() {
+    if [ "$POSTPROCESSING_ONLY" = true ]; then
+        record_phase "Delete preprocessing" "SKIP"
+        return 0
+    fi
+
+    banner "Phase 3a: Delete from preprocessing_db"
+
+    local hydrograph_stmt=""
+    if [ "$INCLUDE_HYDROGRAPHS" = true ]; then
+        hydrograph_stmt="DELETE FROM hydrographs WHERE code = :'site' AND date >= :'from_date';"
+    fi
+
+    # Use \set + :'var' quoting — psql substitutes and quotes the literal,
+    # so user input never reaches SQL as raw string concatenation.
+    local sql
+    sql=$(cat <<SQL
+\set site '${SITE_CODE}'
+\set from_date '${FROM_DATE}'
+BEGIN;
+DELETE FROM runoffs WHERE code = :'site' AND date >= :'from_date';
+${hydrograph_stmt}
+COMMIT;
+SQL
+)
+
+    local output
+    if output=$(echo "$sql" | docker exec -i "$PREPROCESSING_DB" \
+            psql -U postgres -d preprocessing_db \
+            -v ON_ERROR_STOP=1 -X 2>&1); then
+        # psql prints "DELETE N" for each statement
+        while IFS= read -r line; do
+            case "$line" in
+                DELETE*)
+                    log OK "  preprocessing_db: ${line}"
+                    ;;
+            esac
+        done <<< "$output"
+        record_phase "Delete preprocessing" "PASS"
+    else
+        log ERROR "Transaction failed on preprocessing_db:"
+        echo "$output" >&2
+        record_phase "Delete preprocessing" "FAIL"
+        return 1
+    fi
+}
+
+phase_delete_postprocessing() {
+    if [ "$PREPROCESSING_ONLY" = true ]; then
+        record_phase "Delete postprocessing" "SKIP"
+        return 0
+    fi
+
+    banner "Phase 3b: Delete from postprocessing_db"
+
+    local sql
+    sql=$(cat <<SQL
+\set site '${SITE_CODE}'
+\set from_date '${FROM_DATE}'
+\set from_year ${FROM_YEAR}
+BEGIN;
+DELETE FROM forecasts      WHERE code = :'site' AND date >= :'from_date';
+DELETE FROM long_forecasts WHERE code = :'site' AND date >= :'from_date';
+DELETE FROM lr_forecasts   WHERE code = :'site' AND date >= :'from_date';
+DELETE FROM skill_metrics  WHERE code = :'site' AND date >= :'from_date';
+DELETE FROM bulletins      WHERE code = :'site' AND year >= :from_year;
+DELETE FROM lr_visibility  WHERE code = :'site' AND year >= :from_year;
+COMMIT;
+SQL
+)
+
+    local output
+    if output=$(echo "$sql" | docker exec -i "$POSTPROCESSING_DB" \
+            psql -U postgres -d postprocessing_db \
+            -v ON_ERROR_STOP=1 -X 2>&1); then
+        while IFS= read -r line; do
+            case "$line" in
+                DELETE*)
+                    log OK "  postprocessing_db: ${line}"
+                    ;;
+            esac
+        done <<< "$output"
+        record_phase "Delete postprocessing" "PASS"
+    else
+        log ERROR "Transaction failed on postprocessing_db:"
+        echo "$output" >&2
+        record_phase "Delete postprocessing" "FAIL"
+        return 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 4: Verification
+# ---------------------------------------------------------------------------
+
+phase_verify() {
+    banner "Phase 4: Verification"
+
+    local any_failed=false
+
+    # Re-run count queries and check all targeted tables are at zero.
+    if [ "$POSTPROCESSING_ONLY" = false ]; then
+        local pre_sql
+        pre_sql="SELECT 'runoffs'::text, COUNT(*) FROM runoffs WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}';"
+        if [ "$INCLUDE_HYDROGRAPHS" = true ]; then
+            pre_sql="SELECT 'runoffs'::text, COUNT(*) FROM runoffs WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}'
+UNION ALL
+SELECT 'hydrographs'::text, COUNT(*) FROM hydrographs WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}';"
+        fi
+
+        local pre_out
+        pre_out=$(psql_query "$PREPROCESSING_DB" "preprocessing_db" "$pre_sql") || {
+            log ERROR "Verification query failed on ${PREPROCESSING_DB}"
+            any_failed=true
+        }
+
+        if [[ -n "$pre_out" ]]; then
+            while IFS='|' read -r tbl cnt; do
+                [[ -z "$tbl" ]] && continue
+                cnt="${cnt//[[:space:]]/}"
+                if [[ "$cnt" != "0" ]]; then
+                    log ERROR "  preprocessing_db.${tbl}: ${cnt} rows remain (expected 0)"
+                    any_failed=true
+                else
+                    log OK "  preprocessing_db.${tbl}: 0 rows remain"
+                fi
+            done <<< "$pre_out"
+        fi
+    fi
+
+    if [ "$PREPROCESSING_ONLY" = false ]; then
+        local post_sql
+        post_sql="SELECT 'forecasts'::text,     COUNT(*) FROM forecasts      WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}'
+UNION ALL
+SELECT 'long_forecasts'::text,  COUNT(*) FROM long_forecasts   WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}'
+UNION ALL
+SELECT 'lr_forecasts'::text,    COUNT(*) FROM lr_forecasts     WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}'
+UNION ALL
+SELECT 'skill_metrics'::text,   COUNT(*) FROM skill_metrics    WHERE code='${SITE_CODE}' AND date >= '${FROM_DATE}'
+UNION ALL
+SELECT 'bulletins'::text,       COUNT(*) FROM bulletins        WHERE code='${SITE_CODE}' AND year >= ${FROM_YEAR}
+UNION ALL
+SELECT 'lr_visibility'::text,   COUNT(*) FROM lr_visibility    WHERE code='${SITE_CODE}' AND year >= ${FROM_YEAR};"
+
+        local post_out
+        post_out=$(psql_query "$POSTPROCESSING_DB" "postprocessing_db" "$post_sql") || {
+            log ERROR "Verification query failed on ${POSTPROCESSING_DB}"
+            any_failed=true
+        }
+
+        if [[ -n "$post_out" ]]; then
+            while IFS='|' read -r tbl cnt; do
+                [[ -z "$tbl" ]] && continue
+                cnt="${cnt//[[:space:]]/}"
+                if [[ "$cnt" != "0" ]]; then
+                    log ERROR "  postprocessing_db.${tbl}: ${cnt} rows remain (expected 0)"
+                    any_failed=true
+                else
+                    log OK "  postprocessing_db.${tbl}: 0 rows remain"
+                fi
+            done <<< "$post_out"
+        fi
+    fi
+
+    if [ "$any_failed" = true ]; then
+        record_phase "Verification" "FAIL"
+        return 1
+    fi
+
+    record_phase "Verification" "PASS"
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+print_summary() {
+    banner "PURGE SUMMARY"
+    echo ""
+
+    for entry in "${PHASE_RESULTS[@]}"; do
+        local status="${entry%%|*}"
+        local phase="${entry#*|}"
+        case "$status" in
+            PASS) echo -e "  ${GREEN}PASS${NC}  ${phase}" ;;
+            FAIL) echo -e "  ${RED}FAIL${NC}  ${phase}" ;;
+            WARN) echo -e "  ${YELLOW}WARN${NC}  ${phase}" ;;
+            SKIP) echo -e "  ${BLUE}SKIP${NC}  ${phase}" ;;
+        esac
+    done
+
+    echo ""
+
+    for entry in "${PHASE_RESULTS[@]}"; do
+        local status="${entry%%|*}"
+        if [ "$status" = "FAIL" ]; then
+            log ERROR "One or more phases failed."
+            return 1
+        fi
+    done
+
+    echo -e "${GREEN}Site ${SITE_CODE} purged successfully.${NC}"
+    echo ""
+    echo "Re-run the pipeline to regenerate data:"
+    echo "  bash apps/run_locally.sh maintenance"
+    echo "  bash apps/run_locally.sh recalculate_skill_metrics"
+    echo ""
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    # --- Consume positional args before flags ---
+    if [[ $# -gt 0 && "$1" != -* ]]; then
+        SITE_CODE="$1"
+        shift
+    fi
+    if [[ $# -gt 0 && "$1" != -* ]]; then
+        FROM_DATE="$1"
+        shift
+    fi
+
+    # Parse flags
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dry-run)               DRY_RUN=true ;;
+            --include-hydrographs)   INCLUDE_HYDROGRAPHS=true ;;
+            --preprocessing-only)    PREPROCESSING_ONLY=true ;;
+            --postprocessing-only)   POSTPROCESSING_ONLY=true ;;
+            -y|--yes)                AUTO_YES=true ;;
+            -h|--help)               print_usage; exit 0 ;;
+            *)
+                log ERROR "Unknown argument: $1"
+                print_usage
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    # Mutually exclusive scope flags
+    if [ "$PREPROCESSING_ONLY" = true ] && [ "$POSTPROCESSING_ONLY" = true ]; then
+        log ERROR "--preprocessing-only and --postprocessing-only are mutually exclusive."
+        exit 1
+    fi
+
+    # shellcheck disable=SC2034  # reserved for future elapsed-time reporting; not yet consumed
+    SCRIPT_START=$(get_timestamp)
+
+    banner "SAPPHIRE Site Data Purge"
+
+    validate_inputs
+
+    # Phase 0: Pre-flight
+    phase_preflight || exit 1
+
+    # Phase 1: Dry-run counts (also acts as early exit when --dry-run is set)
+    phase_counts || exit 1
+
+    # Phase 2: Confirmation
+    phase_confirm || exit 1
+
+    # Phase 3: Transactional deletes
+    phase_delete_preprocessing || exit 1
+    phase_delete_postprocessing || exit 1
+
+    # Phase 4: Verification
+    phase_verify || {
+        log ERROR "Verification failed — some rows were not deleted."
+        print_summary
+        exit 1
+    }
+
+    # Summary
+    print_summary
+    exit $?
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Promotes `ce2df91` from `infra_taj_sapphire_2_deployment` to mainline. Adds two operator scripts used during site-level backfill and emergency data purge.

- `bin/initialize_site_backfill.sh` — per-site backfill helper (unblocks `dev_local_backfill.sh` v3.5 Phase 4a)
- `bin/purge_site_data.sh` — scoped data purge with `--dry-run`, `--include-hydrographs`, `--postprocessing-only` flags

A follow-up commit replaces the help-text example site code `10001` with the project sentinel `19999` per the no-real-codes policy.

## Commits

1. `ce2df91` (cherry-pick) — original addition of both scripts from deployment branch
2. New commit — replace `10001` → `19999` in `purge_site_data.sh` (8 sites)

## Test plan

- [x] `bash -n bin/initialize_site_backfill.sh` passes
- [x] `bash -n bin/purge_site_data.sh` passes
- [x] `grep -n '10001' bin/purge_site_data.sh` returns zero hits
- [x] `--help` output reviewed for both scripts
- [ ] Operator smoke test on KGHM/TJHM staging (post-merge)

## Plan reference

`doc/plans/working/promotion_taj_to_maxat_plan.md` §4 PR 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
