### PR TITLE
Checklist hardening: TODO resolutions + section swap + priority badges

### DIFF
--- a/doc/prod/update_deployment_checklist.md
+++ b/doc/prod/update_deployment_checklist.md
@@ -5,7 +5,7 @@ This checklist guides you through a **routine update** of an existing SAPPHIRE F
 > **First-time deployment?** Use `doc/prod/first_deploy_checklist.md` instead. That doc covers the one-time steps (SSH tunnel setup, initial schema preparation, `RunInitializeWorkflow`, historical backfill) that are *not* part of a routine update.
 >
 
-## Operator setup — set these once per session
+## Operator setup — set these once per session [Required]
 
 Before running any command below, set these variables once in your shell session. Everywhere in this doc that you see `${ORG_SLUG}`, `${DATA_DIR}`, `${ENV_FILE_PATH}`, or `${LOG_DIR}`, those are the values being substituted.
 
@@ -27,9 +27,9 @@ export LOG_DIR=/home/ubuntu/logs                                 # adapt to your
 
 ---
 
-## 1. PRE-UPDATE PREPARATION
+## 1. PRE-UPDATE PREPARATION [Required]
 
-### 1.1 SSH Access Verification
+### 1.1 SSH Access Verification [Required]
 
 - [ ] Verify you have SSH access to the server
   ```bash
@@ -44,11 +44,11 @@ export LOG_DIR=/home/ubuntu/logs                                 # adapt to your
   ls -la /data/SAPPHIRE_Forecast_Tools
   ```
 
-### 1.2 iEasyHydro HF Connectivity (if applicable)
+### 1.2 iEasyHydro HF Connectivity (if applicable) [Required]
 
 If you are setting up this server for the first time, complete the SSH tunnel setup steps in `doc/prod/first_deploy_checklist.md` first. For routine updates, just verify the tunnel is healthy: `sudo systemctl status <tunnel-service>.service`.
 
-### 1.3 Timing Considerations
+### 1.3 Timing Considerations [Required]
 
 - [ ] Check the current time relative to scheduled cron jobs
   ```bash
@@ -60,7 +60,7 @@ If you are setting up this server for the first time, complete the SSH tunnel se
 - [ ] Consider notifying stakeholders if dashboards will be temporarily unavailable
 - [ ] Plan update during low-usage period (e.g., weekends or early morning local time)
 
-### 1.4 Verify Current State
+### 1.4 Verify Current State [Required]
 
 **Check running services:**
 
@@ -108,7 +108,7 @@ If you are setting up this server for the first time, complete the SSH tunnel se
   git branch --show-current
   ```
 
-### 1.5 Backup Critical Files
+### 1.5 Backup Critical Files [Required]
 
 **Create timestamped backup directory:**
 
@@ -185,7 +185,7 @@ If you are setting up this server for the first time, complete the SSH tunnel se
   echo "Backup complete: $BACKUP_DIR"
   ```
 
-### 1.6 Pre-Update Checklist Summary
+### 1.6 Pre-Update Checklist Summary [Required]
 
 Before proceeding to the update steps, confirm:
 
@@ -203,9 +203,9 @@ Before proceeding to the update steps, confirm:
 
 ---
 
-## 2. CORE UPDATE STEPS
+## 2. CORE UPDATE STEPS [Required]
 
-### 2.1 Stop Services
+### 2.1 Stop Services [Required]
 
 Before updating, stop all running SAPPHIRE services to prevent conflicts during the update.
 
@@ -239,7 +239,7 @@ Before updating, stop all running SAPPHIRE services to prevent conflicts during 
 
 ---
 
-### 2.2 Update Repository
+### 2.2 Update Repository [Required]
 
 Pull the latest changes from the repository.
 
@@ -278,7 +278,7 @@ Pull the latest changes from the repository.
 
 ---
 
-### 2.3 Update .env File (BEFORE running containers)
+### 2.3 Update .env File (BEFORE running containers) [Required]
 
 > **IMPORTANT**: Complete this section BEFORE Section 2.4 (Pull Docker Images). The .env file must be updated before pulling images or running any containers, as scripts read configuration from this file.
 
@@ -378,7 +378,7 @@ The server .env and the local repo .env are on different machines, so you need t
   ```
 
 ---
-### 2.4 Pull New Docker Images
+### 2.4 Pull New Docker Images [Required]
 
 - [ ] **Remove old SAPPHIRE DockerHub images only**
   ```bash
@@ -522,7 +522,7 @@ To force a rebuild after a code update:
 ---
 
 
-### 2.4.5 Bring up SAPPHIRE microservices stack
+### 2.4.5 Bring up SAPPHIRE microservices stack [Required]
 
 **Why this step matters:** the cron scripts (`bin/run_pentadal_forecasts.sh`,
 `bin/run_decadal_forecasts.sh`, `bin/run_preprocessing_gateway.sh`, etc.) and the
@@ -578,7 +578,7 @@ The stack is defined in `sapphire/docker-compose.yml` and includes:
 
 ---
 
-### 2.4.6 Apply schema migrations
+### 2.4.6 Apply schema migrations [Required]
 
 The preprocessing and postprocessing services use **Alembic** for schema management.
 Pulling new images without applying outstanding migrations can leave the DB schema
@@ -622,7 +622,7 @@ behind the code — for example, the snow-stat write path requires migration
 
 ---
 
-### 2.5 Update Crontabs
+### 2.5 Update Crontabs [Required]
 
 Update the cron schedule for automated forecast runs.
 
@@ -749,7 +749,7 @@ The canonical schedule below follows the post-S1-2026 consolidated Luigi-wrapper
   ls -ld /var/backups/sapphire
   ```
 
-### 2.6 Test Cron Commands Manually
+### 2.6 Test Cron Commands Manually [Required]
 
 > **Prerequisite — the SAPPHIRE microservices stack must be up before any
 > cron command below will succeed.** Every cron command reads/writes through
@@ -821,9 +821,9 @@ After updating crontabs, run each cron command manually (one by one) to verify t
 
 ---
 
-## 3. POST-UPDATE VERIFICATION
+## 3. POST-UPDATE VERIFICATION [Required]
 
-### 3.1 Start Services
+### 3.1 Start Services [Required]
 
 Start the services in the correct order to ensure proper initialization.
 
@@ -880,7 +880,7 @@ Expected output should include the microservices (`sapphire-api-gateway`,
 - `sapphire-luigi-daemon` (or similar) - Up, port 8082
 - `sapphire-dashboard` - Up, port 5006
 
-### 3.2 Verify Services Running
+### 3.2 Verify Services Running [Required]
 
 #### Post-deploy probe suite
 
@@ -979,7 +979,7 @@ apply the `network_mode: host` fix.
   docker logs sapphire-dashboard --tail 50
   ```
 
-### 3.3 Test Forecast Run
+### 3.3 Test Forecast Run [Required]
 
 Perform a quick manual test to verify the pipeline works correctly.
 
@@ -1074,11 +1074,11 @@ succeeded and verified`.
 
 ---
 
-## 4. LOG CLEANUP (Optional)
+## 4. LOG CLEANUP [Optional]
 
 Clean up old log files to prevent disk space issues.
 
-### 4.1 Clean Up Pipeline Logs
+### 4.1 Clean Up Pipeline Logs [Optional]
 
 Log files are stored in `${LOG_DIR}/`
 
@@ -1097,7 +1097,7 @@ Log files are stored in `${LOG_DIR}/`
   ls -lh ${LOG_DIR}/
   ```
 
-### 4.2 Clean Up Docker Logs (Optional)
+### 4.2 Clean Up Docker Logs [Optional]
 
 Docker container logs can also grow large over time.
 
@@ -1111,7 +1111,7 @@ Docker container logs can also grow large over time.
   find ${DATA_DIR}/intermediate_data/docker_logs -name "*.log" -mtime +7 -delete 2>/dev/null
   ```
 
-### 4.3 Prune Docker System (Optional)
+### 4.3 Prune Docker System [Optional]
 
 Remove unused Docker resources:
 
@@ -1127,7 +1127,7 @@ Remove unused Docker resources:
 
 ---
 
-## 5. ROLLBACK PROCEDURE
+## 5. ROLLBACK PROCEDURE [Emergency only]
 
 If the update causes issues, follow these steps to revert. The forward path had four
 state-changing actions: image pull (§2.4), `.env` edit (§2.3), `alembic upgrade head`
@@ -1135,7 +1135,7 @@ state-changing actions: image pull (§2.4), `.env` edit (§2.3), `alembic upgrad
 each in the opposite order: stop services → restore `.env` → downgrade schema (if
 upgraded forward) → restore Luigi markers → restart with previous image tag.
 
-### 5.1 Stop Current Services
+### 5.1 Stop Current Services [Emergency only]
 
 - [ ] Stop all SAPPHIRE services (project-name-safe `down` on the Luigi compose):
   ```bash
@@ -1145,7 +1145,7 @@ upgraded forward) → restore Luigi markers → restart with previous image tag.
   Without `-p sapphire` on the Luigi compose, the persistent `luigi-daemon` container
   is silently missed (see §2.1 note). The dashboard stops with the microservices stack.
 
-### 5.2 Restore Previous Docker Images
+### 5.2 Restore Previous Docker Images [Emergency only]
 
 - [ ] Pull previous image versions (replace `<previous-tag>` with actual version):
   ```bash
@@ -1158,7 +1158,7 @@ upgraded forward) → restore Luigi markers → restart with previous image tag.
   docker images | grep sapphire
   ```
 
-### 5.3 Restore .env Backup
+### 5.3 Restore .env Backup [Emergency only]
 
 If you backed up your .env file before the update:
 
@@ -1167,7 +1167,7 @@ If you backed up your .env file before the update:
   cp ${BACKUP_DIR}/.env_develop_${ORG_SLUG} ${ENV_FILE_PATH}
   ```
 
-### 5.4 Update Image Tags
+### 5.4 Update Image Tags [Emergency only]
 
 - [ ] Edit your .env file to use the previous image tag:
   ```bash
@@ -1176,7 +1176,7 @@ If you backed up your .env file before the update:
   ieasyhydroforecast_frontend_docker_image_tag=<previous-tag>
   ```
 
-### 5.5 Restore database state
+### 5.5 Restore database state [Emergency only]
 
 Apply this section only if the forward path included `alembic upgrade head` (§2.4.6)
 or if data was corrupted by the update. Skip the schema-downgrade step if alembic
@@ -1220,7 +1220,7 @@ Bring the microservices stack up briefly to run the downgrade:
 > dashboard write path will silently null out stat fields until the schema is
 > re-upgraded.
 
-### 5.6 Restore Luigi marker files
+### 5.6 Restore Luigi marker files [Emergency only]
 
 If the rolled-back image expects an earlier marker state, restore from backup. If
 markers are not restored, tasks may silently short-circuit on stale completion
@@ -1231,7 +1231,7 @@ markers from the failed forward run.
   cp ${BACKUP_DIR}/luigi_markers/*.marker ${DATA_DIR}/intermediate_data/luigi_markers/
   ```
 
-### 5.7 Restart Services with Previous Version
+### 5.7 Restart Services with Previous Version [Emergency only]
 
 The microservices stack may still be up from §5.5.2; only Luigi and dashboards
 need to be (re)started.
@@ -1261,17 +1261,17 @@ The dashboard was restarted as part of the microservices stack `up -d` above; no
 
 ---
 
-## 6. FINAL CHECKLIST
+## 6. FINAL CHECKLIST [Required]
 
 Complete this summary checklist before considering the update complete.
 
-### Services Running
+### Services Running [Required]
 
 - [ ] Luigi daemon is running and accessible at port 8082
 - [ ] Dashboard is running and accessible at port 5006
 - [ ] All containers show "healthy" status
 
-### Crontabs Configured
+### Crontabs Configured [Required]
 
 - [ ] Verify crontab entries are correct:
   ```bash
@@ -1281,13 +1281,13 @@ Complete this summary checklist before considering the update complete.
 - [ ] Confirm scheduled times are appropriate for your timezone
 - [ ] Verify log cleanup job is configured (typically at 02:00 UTC)
 
-### Next Scheduled Run
+### Next Scheduled Run [Required]
 
 - [ ] Identify next scheduled forecast run from crontab
 - [ ] Note the expected time: _______________
 - [ ] Plan to check logs after next scheduled run to confirm everything works
 
-### Documentation
+### Documentation [Required]
 
 - [ ] Note any configuration changes made during this update
 - [ ] Update deployment notes if procedures changed

--- a/doc/prod/update_deployment_checklist.md
+++ b/doc/prod/update_deployment_checklist.md
@@ -270,6 +270,106 @@ Pull the latest changes from the repository.
 
 ---
 
+### 2.3 Update .env File (BEFORE running containers)
+
+> **IMPORTANT**: Complete this section BEFORE Section 2.4 (Pull Docker Images). The .env file must be updated before pulling images or running any containers, as scripts read configuration from this file.
+
+#### Step 1: Download server .env to local machine
+
+The server .env and the local repo .env are on different machines, so you need to compare them locally.
+
+- [ ] **Copy server .env to local machine via scp**
+  ```bash
+  # From your LOCAL machine (not the server)
+  # Replace <server> with your server hostname/alias
+  # If you connect via a specific user, use user@<server>
+  # If you connect via a specific port, add -P <port>
+  scp <server>:${ENV_FILE_PATH} \
+      ~/Downloads/.env_develop_${ORG_SLUG}_server
+  ```
+
+#### Step 2: Compare with local repo .env
+
+- [ ] **Compare the two files locally**
+  ```bash
+  # On your LOCAL machine
+  diff ~/Downloads/.env_develop_${ORG_SLUG}_server \
+       /path/to/SAPPHIRE_forecast_tools/apps/config/.env_develop_${ORG_SLUG}
+  ```
+
+  Or side-by-side:
+  ```bash
+  diff -y --suppress-common-lines \
+       ~/Downloads/.env_develop_${ORG_SLUG}_server \
+       /path/to/SAPPHIRE_forecast_tools/apps/config/.env_develop_${ORG_SLUG}
+  ```
+
+#### Step 3: Identify changes needed
+
+- [ ] **New variables to add** (in local repo but not on server)
+- [ ] **Variables to update** (different values between server and repo)
+- [ ] **Variables to keep unchanged** (server-specific credentials, API keys, paths)
+
+**Key variables to review:**
+
+| Variable | Description | Expected Value |
+|----------|-------------|----------------|
+| `ieasyhydroforecast_backend_docker_image_tag` | Backend image tag | `local` |
+| `ieasyhydroforecast_frontend_docker_image_tag` | Frontend image tag | `local` |
+| `ieasyhydroforecast_run_ML_models` | Enable ML forecasting | `true` or `false` |
+| `ieasyhydroforecast_run_CM_models` | Enable conceptual models | `true` or `false` |
+| `ieasyhydroforecast_organization` | Organization identifier | `${ORG_SLUG}` |
+
+**Variables to preserve** (don't overwrite with repo values):
+- `IEASYHYDRO_HOST` - Server-specific API endpoint
+- `IEASYHYDRO_PASSWORD` - Credentials
+- `ieasyhydroforecast_API_KEY_GATEAWAY` - API keys
+- Path variables if customized for server
+
+#### Step 4: Edit the server .env locally
+
+- [ ] **Make a working copy**
+  ```bash
+  cp ~/Downloads/.env_develop_${ORG_SLUG}_server ~/Downloads/.env_develop_${ORG_SLUG}_updated
+  ```
+
+- [ ] **Edit the file locally** (use your preferred editor)
+  ```bash
+  code ~/Downloads/.env_develop_${ORG_SLUG}_updated
+  # Or: nano, vim, etc.
+  ```
+
+- [ ] **Add new variables**
+- [ ] **Update changed variables**
+- [ ] **Verify Docker image tags are set correctly**
+
+#### Step 5: Upload updated .env back to server
+
+- [ ] **Copy updated .env to server via scp**
+  ```bash
+  # From your LOCAL machine
+  scp ~/Downloads/.env_develop_${ORG_SLUG}_updated \
+      <server>:${ENV_FILE_PATH}
+  ```
+
+- [ ] **Verify on server**
+  ```bash
+  # On the SERVER
+  grep -E "docker_image_tag" ${ENV_FILE_PATH}
+  ```
+  Expected output:
+  ```
+  ieasyhydroforecast_backend_docker_image_tag=local
+  ieasyhydroforecast_frontend_docker_image_tag=local
+  ```
+
+- [ ] **Validate syntax on server** (no trailing spaces, proper quoting)
+  ```bash
+  grep -n "= " ${ENV_FILE_PATH}  # Spaces after =
+  grep -n " $" ${ENV_FILE_PATH}  # Trailing spaces
+  ```
+
+---
 ### 2.4 Pull New Docker Images
 
 > **Prerequisite**: Complete Section 2.3 (Update .env File) first!
@@ -402,106 +502,6 @@ To force a rebuild after a code update:
 
 ---
 
-### 2.3 Update .env File (BEFORE running containers)
-
-> **IMPORTANT**: Complete this section BEFORE Section 2.4 (Pull Docker Images). The .env file must be updated before pulling images or running any containers, as scripts read configuration from this file.
-
-#### Step 1: Download server .env to local machine
-
-The server .env and the local repo .env are on different machines, so you need to compare them locally.
-
-- [ ] **Copy server .env to local machine via scp**
-  ```bash
-  # From your LOCAL machine (not the server)
-  # Replace <server> with your server hostname/alias
-  # If you connect via a specific user, use user@<server>
-  # If you connect via a specific port, add -P <port>
-  scp <server>:${ENV_FILE_PATH} \
-      ~/Downloads/.env_develop_${ORG_SLUG}_server
-  ```
-
-#### Step 2: Compare with local repo .env
-
-- [ ] **Compare the two files locally**
-  ```bash
-  # On your LOCAL machine
-  diff ~/Downloads/.env_develop_${ORG_SLUG}_server \
-       /path/to/SAPPHIRE_forecast_tools/apps/config/.env_develop_${ORG_SLUG}
-  ```
-
-  Or side-by-side:
-  ```bash
-  diff -y --suppress-common-lines \
-       ~/Downloads/.env_develop_${ORG_SLUG}_server \
-       /path/to/SAPPHIRE_forecast_tools/apps/config/.env_develop_${ORG_SLUG}
-  ```
-
-#### Step 3: Identify changes needed
-
-- [ ] **New variables to add** (in local repo but not on server)
-- [ ] **Variables to update** (different values between server and repo)
-- [ ] **Variables to keep unchanged** (server-specific credentials, API keys, paths)
-
-**Key variables to review:**
-
-| Variable | Description | Expected Value |
-|----------|-------------|----------------|
-| `ieasyhydroforecast_backend_docker_image_tag` | Backend image tag | `local` |
-| `ieasyhydroforecast_frontend_docker_image_tag` | Frontend image tag | `local` |
-| `ieasyhydroforecast_run_ML_models` | Enable ML forecasting | `true` or `false` |
-| `ieasyhydroforecast_run_CM_models` | Enable conceptual models | `true` or `false` |
-| `ieasyhydroforecast_organization` | Organization identifier | `${ORG_SLUG}` |
-
-**Variables to preserve** (don't overwrite with repo values):
-- `IEASYHYDRO_HOST` - Server-specific API endpoint
-- `IEASYHYDRO_PASSWORD` - Credentials
-- `ieasyhydroforecast_API_KEY_GATEAWAY` - API keys
-- Path variables if customized for server
-
-#### Step 4: Edit the server .env locally
-
-- [ ] **Make a working copy**
-  ```bash
-  cp ~/Downloads/.env_develop_${ORG_SLUG}_server ~/Downloads/.env_develop_${ORG_SLUG}_updated
-  ```
-
-- [ ] **Edit the file locally** (use your preferred editor)
-  ```bash
-  code ~/Downloads/.env_develop_${ORG_SLUG}_updated
-  # Or: nano, vim, etc.
-  ```
-
-- [ ] **Add new variables**
-- [ ] **Update changed variables**
-- [ ] **Verify Docker image tags are set correctly**
-
-#### Step 5: Upload updated .env back to server
-
-- [ ] **Copy updated .env to server via scp**
-  ```bash
-  # From your LOCAL machine
-  scp ~/Downloads/.env_develop_${ORG_SLUG}_updated \
-      <server>:${ENV_FILE_PATH}
-  ```
-
-- [ ] **Verify on server**
-  ```bash
-  # On the SERVER
-  grep -E "docker_image_tag" ${ENV_FILE_PATH}
-  ```
-  Expected output:
-  ```
-  ieasyhydroforecast_backend_docker_image_tag=local
-  ieasyhydroforecast_frontend_docker_image_tag=local
-  ```
-
-- [ ] **Validate syntax on server** (no trailing spaces, proper quoting)
-  ```bash
-  grep -n "= " ${ENV_FILE_PATH}  # Spaces after =
-  grep -n " $" ${ENV_FILE_PATH}  # Trailing spaces
-  ```
-
----
 
 ### 2.4.5 Bring up SAPPHIRE microservices stack
 

--- a/doc/prod/update_deployment_checklist.md
+++ b/doc/prod/update_deployment_checklist.md
@@ -1295,7 +1295,7 @@ Complete this summary checklist before considering the update complete.
   - Backend image tag: _______________
   - Frontend image tag: _______________
 
-### Monitoring (if configured)
+### Monitoring (if configured) [Required]
 
 - [ ] Verify monitoring services are running:
   ```bash

--- a/doc/prod/update_deployment_checklist.md
+++ b/doc/prod/update_deployment_checklist.md
@@ -79,11 +79,13 @@ If you are setting up this server for the first time, complete the SSH tunnel se
   ```bash
   docker inspect --format "{{.State.Health.Status}}" sapphire-dashboard
   ```
+  TODO carried forward: known Dockerfile healthcheck bug — `sapphire-dashboard` container reports unhealthy despite dashboard being functional. Operator may safely ignore this status; not blocking ops. Fix tracked separately.
 
 - [ ] Verify dashboards are accessible
   ```bash
   curl -s -o /dev/null -w "%{http_code}" http://localhost:5006/forecast_dashboard
   ```
+  TBD: confirm expected HTTP code on staging (likely 200; possibly 302 if dashboard root redirects to a sub-path). Update this line once verified.
 
 **Check recent pipeline activity:**
 
@@ -138,8 +140,12 @@ If you are setting up this server for the first time, complete the SSH tunnel se
 
 - [ ] Dump preprocessing, postprocessing, user, and auth DBs to timestamped `.dump` files
   ```bash
-  bash bin/backup_sapphire_db.sh -d /var/backups/sapphire/pre_update_$(date +%Y%m%d_%H%M%S)
+  export DB_BACKUP_DIR="/var/backups/sapphire/pre_update_$(date +%Y%m%d_%H%M%S)"
+  sudo mkdir -p "$DB_BACKUP_DIR"
+  sudo chown "$USER" "$DB_BACKUP_DIR"
+  bash bin/backup_sapphire_db.sh -e ${ENV_FILE_PATH} -d "$DB_BACKUP_DIR" -r 30
   ```
+  The `-e` flag points the backup script at the deployment env file; `-d` must point to an existing writable directory because `bin/backup_sapphire_db.sh` does not create it for you. Use `-r 0` instead of `-r 30` if no retention pruning should happen during this backup.
   This is the supported `pg_dump`-based backup mechanism (`bin/backup_sapphire_db.sh`).
   It writes one `.dump` file per database to the target directory. Required before
   applying schema migrations — DB state is the only state that cannot be regenerated
@@ -151,12 +157,14 @@ If you are setting up this server for the first time, complete the SSH tunnel se
   ```bash
   cp ${DATA_DIR}/intermediate_data/last_successful_run.txt "$BACKUP_DIR/" 2>/dev/null || echo "File not found"
   ```
+  Optional — only required if this deployment uses `ieasyforecast_last_successful_run_file`. Verify with: `grep ieasyforecast_last_successful_run_file ${ENV_FILE_PATH}` before skipping. Retained pending LR-003 cleanup gi_draft.
 
 - [ ] Backup Luigi marker files (required for clean rollback — see §5)
   ```bash
   mkdir -p "$BACKUP_DIR/luigi_markers"
   cp ${DATA_DIR}/intermediate_data/luigi_markers/*.marker "$BACKUP_DIR/luigi_markers/" 2>/dev/null || echo "No marker files"
   ```
+  Optional — only required for clean Luigi rollback; can skip if Luigi state was already reset elsewhere.
 
 **Record current Docker image versions:**
 
@@ -371,6 +379,17 @@ The server .env and the local repo .env are on different machines, so you need t
 
 ---
 ### 2.4 Pull New Docker Images
+
+- [ ] **Remove old SAPPHIRE DockerHub images only**
+  ```bash
+  old_sapphire_images="$(docker images 'mabesa/sapphire-*' --format '{{.Repository}}:{{.Tag}}' | sort -u)"
+  printf '%s\n' "$old_sapphire_images"
+  read -r -p "Remove only the mabesa/sapphire-* images listed above? [y/N] " confirm
+  if [ "$confirm" = "y" ] && [ -n "$old_sapphire_images" ]; then
+    printf '%s\n' "$old_sapphire_images" | xargs -r docker rmi
+  fi
+  ```
+  Do not remove `nginx-proxy-manager`, `postgres:15`, locally built microservice images, or any other non-`mabesa/sapphire-*` image.
 
 > **Prerequisite**: Complete Section 2.3 (Update .env File) first!
 
@@ -651,7 +670,7 @@ The canonical schedule below follows the post-S1-2026 consolidated Luigi-wrapper
   0 2 * * * find ${LOG_DIR} -name "sapphire_*.log" -mtime +7 -delete
 
   # Daily DB backup at 01:00 UTC (pg_dump-based, 30-day retention)
-  0 1 * * * bash /data/SAPPHIRE_Forecast_Tools/bin/backup_sapphire_db.sh -d /var/backups/sapphire -r 30 >> ${LOG_DIR}/sapphire_db_backup_$(date +\%Y\%m\%d).log 2>&1
+  0 1 * * * bash /data/SAPPHIRE_Forecast_Tools/bin/backup_sapphire_db.sh -e ${ENV_FILE_PATH} -d /var/backups/sapphire -r 30 >> ${LOG_DIR}/sapphire_db_backup_$(date +\%Y\%m\%d).log 2>&1
 
   # (1) Gateway Preprocessing at 03:00 UTC. Independent of daily data.
   0 3 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_preprocessing_gateway.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_gateway_preprocessing_$(date +\%Y\%m\%d).log 2>&1
@@ -751,7 +770,7 @@ After updating crontabs, run each cron command manually (one by one) to verify t
 
 - [ ] **Run database backup**
   ```bash
-  bash /data/SAPPHIRE_Forecast_Tools/bin/backup_sapphire_db.sh -d /var/backups/sapphire -r 30
+  bash /data/SAPPHIRE_Forecast_Tools/bin/backup_sapphire_db.sh -e ${ENV_FILE_PATH} -d /var/backups/sapphire -r 30
   ```
 
 - [ ] **Run gateway preprocessing**


### PR DESCRIPTION
## Status update (2026-06-11)

**Blocked on #370.** Originally stacked on #367, which has been closed and **superseded by #370** (a docs-only rescope after the audit found #367 would silently revert three `set -u` safety fixes and delete two toolkit files added by `07ed459` on `maxat_sapphire_2`).

This PR's 4 commits depend on the `update_deployment_checklist.md` rewrite that lives in #370 (operator session-variable block, stale-path cleanup, dup iEH HF tunnel removal). They do NOT apply cleanly to `maxat_sapphire_2` directly — confirmed by cherry-pick test:

| Commit | Title | Applies to mainline? |
|---|---|---|
| `a2e5f47` | Swap §2.3 before §2.4 | ❌ patches assume #370's rewrite |
| `aa67b02` | Resolve 8 Tajik TODOs | ❌ same |
| `4102eb0` | Add priority badges | ❌ same |
| `06eb79d` | Monitoring badge | ✅ single-line addition |

**Plan**: once #370 merges, this PR will be rebuilt by cherry-picking these 4 commits onto current `maxat_sapphire_2` (which will then include #370's rewrite). No content changes; just a new base.

---

## Summary

Resolves 8 TODOs surfaced during the Tajik live-server deployment, fixes the §2.3/§2.4 section-numbering inversion, and adds priority badges (`[Required]` / `[Optional]` / `[Emergency only]`) to operator-facing section headings.

**Reviewer note**: read commit-by-commit (3 commits, one per stream). The Stream B swap commit is a clean block move with zero content changes; the Stream A and C commits then add the resolutions and badges on top.

## Commits

1. Stream B — Swap §2.3 (Update .env File) before §2.4 (Pull New Docker Images). Zero text changes to the 19 cross-references that mention §2.3/§2.4/§2.4.x because section numbers and titles are preserved by the swap.
2. Stream A — Resolve 8 TODO items raised by reviewers during the Tajik deployment review:
    - Backup command: `mkdir -p` + `chown` instructions added inline
    - Backup script: `-e` short flag documented; pre-create-dir step noted
    - `last_successful_run.txt`: legacy-file conditionality note added
    - Luigi markers: marked optional with safe-to-skip note
    - Healthcheck known-bug note appended
    - HTTP code carrier: marked `TBD: confirm expected HTTP code on staging`
    - Image scope: scoped `mabesa/sapphire-*` filter snippet for image cleanup
    - Cron line / §2.6 manual test: `-e ${ENV_FILE_PATH}` added consistently
3. Stream C — Add priority badges to all operator-facing section headings.

## Reviewer feedback (carried forward from #368 thread)

- `doc/deployment.md:437` deep-link to `update_deployment_checklist.md#12-ieasyhydro-hf-connectivity-if-applicable` will silently 404 after the `[Required]` badge is added (auto-anchor becomes `…-required`). To address either by removing the badge from that specific heading or by also updating the link in `deployment.md`.
- `### 1.2 iEasyHydro HF Connectivity (if applicable) [Required]` — heading wording is internally contradictory (`if applicable` vs `Required`). Consider `[Required if applicable]` or leave unbadged.

These two reviewer items will be addressed in the rebuild PR after #370 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
