### PR TITLE
Add first-deploy checklist; harden update checklist with operator session block

### DIFF
--- a/doc/prod/first_deploy_checklist.md
+++ b/doc/prod/first_deploy_checklist.md
@@ -1,0 +1,912 @@
+# SAPPHIRE Forecast Tools - First Deployment Checklist
+
+This checklist covers one-time setup steps required when deploying SAPPHIRE Forecast Tools to a new server. These steps install permanent services (such as the SSH tunnel systemd unit) and prepare the server for routine forecast operations. Run this checklist once per new deployment; for ongoing updates use `doc/prod/update_deployment_checklist.md`.
+
+> **First deploy vs. update:** "Stop services" and "Backup Critical Files" sections do not apply on a first deploy — there are no prior services to stop and no prior state to preserve. They are covered in `doc/prod/update_deployment_checklist.md`.
+>
+> **Cron installation** is covered in section 12 of this doc. The same canonical cron block is reproduced in `doc/prod/update_deployment_checklist.md` §2.5 so routine-update operators can diff against the running crontab without consulting two sources.
+
+## Operator setup — set these once per session
+
+Before running any command below, set these variables once in your shell session. Everywhere in this doc that you see `${ORG_SLUG}`, `${DATA_DIR}`, `${ENV_FILE_PATH}`, or `${LOG_DIR}`, those are the values being substituted.
+
+```bash
+# Operator: set these variables once per deployment session. The rest of
+# this checklist references them. Adapt to your deployment.
+export ORG_SLUG=tjhm                                             # one of: kghm, tjhm, uzhm
+export DATA_DIR=/data/taj_data_forecast_tools                    # adapt to your data path
+export ENV_FILE_PATH="${DATA_DIR}/config/.env_develop_${ORG_SLUG}"
+export LOG_DIR=/home/ubuntu/logs                                 # adapt to your logs path
+```
+
+---
+
+## 1. Pre-flight server provisioning
+
+These steps prepare the bare server before any SAPPHIRE services are installed.
+
+### 1.1 Verify SSH access and sudo
+
+- [ ] Confirm you have SSH access to the deployment server with a user that has `sudo` privileges:
+  ```bash
+  ssh <user>@<server-ip>
+  sudo -v
+  ```
+- [ ] Verify a non-root unprivileged user exists for running SAPPHIRE containers (typically `ubuntu`). All cron jobs and Docker containers run as this user.
+
+### 1.2 Verify disk space, hostname, and time
+
+- [ ] Confirm disk space is sufficient for first-deploy. The full Docker image set plus four PostgreSQL volumes typically needs ≥ 30 GB free on `/var/lib/docker` and ≥ 20 GB free on the data directory:
+  ```bash
+  df -h /var/lib/docker "${DATA_DIR}" "${LOG_DIR}"
+  ```
+- [ ] Set hostname (for log clarity) and verify:
+  ```bash
+  hostnamectl
+  ```
+- [ ] Verify system clock is synchronised (cron schedules depend on this):
+  ```bash
+  timedatectl
+  ```
+  Expected: `System clock synchronized: yes` and `NTP service: active`.
+
+### 1.3 Install Docker engine + Docker Compose plugin
+
+If Docker is not already installed, follow the upstream Ubuntu instructions and ensure the non-root user is added to the `docker` group. Confirm:
+
+```bash
+docker --version
+docker compose version
+docker ps
+```
+
+The last command must succeed without `sudo` for the deploy user, and without `permission denied` errors.
+
+### 1.4 Clone the repository
+
+- [ ] Clone the repository into a predictable directory (commonly `/data/SAPPHIRE_Forecast_Tools`):
+  ```bash
+  sudo mkdir -p /data
+  sudo chown "${USER}:${USER}" /data
+  cd /data
+  git clone https://github.com/hydrosolutions/SAPPHIRE_forecast_tools.git SAPPHIRE_Forecast_Tools
+  cd SAPPHIRE_Forecast_Tools
+  ```
+- [ ] Check out the intended deployment branch or tag:
+  ```bash
+  git fetch --all
+  git checkout <deployment-tag-or-branch>
+  ```
+
+### 1.5 Prepare the data directory layout
+
+- [ ] Create the data directory layout used by the pipeline (paths align with the operator placeholder block above):
+  ```bash
+  mkdir -p "${DATA_DIR}/config" \
+           "${DATA_DIR}/intermediate_data" \
+           "${DATA_DIR}/intermediate_data/luigi_markers" \
+           "${DATA_DIR}/templates" \
+           "${DATA_DIR}/reports" \
+           "${DATA_DIR}/bin" \
+           "${LOG_DIR}"
+  ```
+- [ ] Copy or create the deployment `.env` at `${ENV_FILE_PATH}`. See section 5 of this doc for the required variables. **Do not commit this file to git.**
+
+---
+
+## 2. iEasyHydro HF connectivity (if applicable)
+
+SAPPHIRE can run as a standalone forecast tool without iEasyHydro HF. However, certain organization configurations (e.g., `kghm`, `tjhm`) require connectivity to the iEasyHydro HF database for data retrieval. Check your `.env` file for `ieasyhydroforecast_organization` to determine if this applies.
+
+**If your deployment requires iEasyHydro HF**, the configuration depends on your network setup:
+
+**Option A: Same Network with Direct API Access**
+
+If the SAPPHIRE server and iEasyHydro HF server are on the same local network AND the API is accessible from the network:
+
+- [ ] Verify network connectivity to iEasyHydro HF server
+  ```bash
+  ping -c 3 <ieasyhydro-server-ip>
+  ```
+- [ ] Verify API is accessible directly (test common ports):
+  ```bash
+  curl -s http://<ieasyhydro-server-ip>:5555/api/v1/ | head
+  curl -s http://<ieasyhydro-server-ip>:8000/api/v1/ | head
+  ```
+- [ ] If API responds, configure `.env` with direct IP:
+  ```
+  IEASYHYDROHF_HOST=http://<ieasyhydro-server-ip>:<port>
+  ```
+
+**Option B: Same Network but API Only on Localhost (SSH Tunnel Required)**
+
+If iEasyHydro HF API only listens on localhost (common security configuration):
+
+- [ ] Verify ping works but direct API access fails
+- [ ] Test manual SSH tunnel:
+  ```bash
+  ssh -f -N -L <local-port>:localhost:<remote-port> <user>@<ieasyhydro-server-ip>
+  curl -s http://localhost:<local-port>/api/v1/ | head
+  ```
+  Where `<remote-port>` is the port iEasyHydro HF listens on (typically 5555) and `<local-port>` is the port you want to use locally (can be the same or different, e.g., 5554 if 5555 is already in use by another tunnel).
+- [ ] Configure `.env` to use localhost:
+  ```
+  IEASYHYDROHF_HOST=http://localhost:<local-port>
+  ```
+- [ ] **Set up permanent tunnel with autossh + systemd:**
+
+  1. Install autossh:
+     ```bash
+     sudo apt-get update && sudo apt-get install -y autossh
+     ```
+
+  2. Verify SSH key authentication (no password prompt):
+     ```bash
+     ssh -o BatchMode=yes <user>@<ieasyhydro-server-ip> echo "OK"
+     ```
+
+  3. Create systemd service (`/etc/systemd/system/ieasyhydro-tunnel.service`):
+     ```ini
+     [Unit]
+     Description=SSH Tunnel to iEasyHydro HF Server
+     After=network-online.target
+     Wants=network-online.target
+
+     [Service]
+     Type=simple
+     User=<your-user>
+     Environment="AUTOSSH_GATETIME=0"
+     ExecStart=/usr/bin/autossh -M 0 -N -o "ServerAliveInterval=30" -o "ServerAliveCountMax=3" -o "ExitOnForwardFailure=yes" -L <local-port>:localhost:<remote-port> <user>@<ieasyhydro-server-ip>
+     Restart=always
+     RestartSec=10
+
+     [Install]
+     WantedBy=multi-user.target
+     ```
+
+  4. Enable and start:
+     ```bash
+     sudo systemctl daemon-reload
+     sudo systemctl enable ieasyhydro-tunnel.service
+     sudo systemctl start ieasyhydro-tunnel.service
+     ```
+
+- [ ] Verify permanent tunnel:
+  ```bash
+  sudo systemctl status ieasyhydro-tunnel.service
+  curl -s http://localhost:<local-port>/api/v1/ | head
+  ```
+
+**Dashboard tunnel reachability (Docker bridge networking)**
+
+The SSH tunnel binds to host loopback (`127.0.0.1:<local-port>`) for security. Dashboard containers run on a Docker bridge network and have their own loopback — they cannot reach the host loopback. Symptom: dashboard logs `iEHHF not available, falling back to file. Error: ... Connection refused` on the `/api/v1/auth/token-obtain` path. (The misleading hardcoded warning text may mention `hf.ieasyhydro.org` — do not chase that hostname; the real failure is on `localhost:<local-port>` inside the dashboard container.)
+
+Fix: add `network_mode: host` to the dashboard service in `sapphire/docker-compose.yml` (and `bin/docker-compose-dashboards.yml` if its dashboards also call iEH HF). This makes the container share the host network namespace and reach the host loopback tunnel.
+
+**Important:** This fix is **not currently committed** in the repository. Production servers running iEH HF behind a tunnel may have applied it as a server-side override. Coordinate with the team before relying on it; future code may rewrite `IEASYHYDROHF_HOST` for Docker symmetrically with `IEASYHYDRO_HOST` and obviate the workaround.
+
+Verification step (run after the stack is up in section 3 below):
+```bash
+docker exec sapphire-dashboard curl -sf http://localhost:<local-port>/api/v1/
+```
+If this returns 200 from inside the dashboard container, the bridge-network workaround is in place. If it fails with `Connection refused` even though the host-side `curl http://localhost:<local-port>/api/v1/` succeeds, the dashboard service still needs `network_mode: host`.
+
+**Option C: Different Networks (SSH Tunnel with Port Forwarding)**
+
+If the SAPPHIRE server and iEasyHydro HF are on different networks (e.g., AWS server connecting to a local installation at a hydromet service), an SSH tunnel with port forwarding is required.
+
+**Prerequisites:**
+- SSH access to the iEasyHydro HF server (username, IP, port)
+- The remote server's IT team must allow inbound SSH from the SAPPHIRE server IP
+- The iEasyHydro HF API must be listening on a known port on the remote server (typically 5555)
+
+**Step 1: Install autossh**
+
+- [ ] Install autossh on the SAPPHIRE server:
+  ```bash
+  sudo apt-get update && sudo apt-get install -y autossh
+  ```
+
+**Step 2: Generate SSH key**
+
+- [ ] Generate a dedicated SSH key for the tunnel:
+  ```bash
+  ssh-keygen -t ed25519 -f ~/.ssh/<remote-name>_ieh_key -N ""
+  ```
+  Replace `<remote-name>` with a short identifier (e.g., `tajhm`, `kghm`).
+
+**Step 3: Install public key on remote server**
+
+- [ ] Copy the public key to the remote server:
+  ```bash
+  ssh-copy-id -i ~/.ssh/<remote-name>_ieh_key.pub -p <ssh-port> <user>@<remote-ip>
+  ```
+  If `ssh-copy-id` is not available, use the manual approach:
+  ```bash
+  cat ~/.ssh/<remote-name>_ieh_key.pub | ssh -p <ssh-port> <user>@<remote-ip> \
+    "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
+  ```
+  > **Note:** This step requires either the current password for the remote user, or coordination with the remote IT team to add the key manually.
+
+**Step 4: Add remote server to known_hosts**
+
+- [ ] Add the remote server's host key:
+  ```bash
+  ssh-keyscan -p <ssh-port> <remote-ip> >> ~/.ssh/known_hosts
+  ```
+
+**Step 5: Test the connection**
+
+- [ ] Verify key-based SSH login works:
+  ```bash
+  ssh -i ~/.ssh/<remote-name>_ieh_key -p <ssh-port> <user>@<remote-ip>
+  ```
+
+- [ ] Test port forwarding manually:
+  ```bash
+  ssh -i ~/.ssh/<remote-name>_ieh_key -p <ssh-port> -L <local-port>:localhost:<remote-port> -N <user>@<remote-ip>
+  ```
+  In a second terminal, verify the local port is listening:
+  ```bash
+  ss -tlnp | grep <local-port>
+  curl -s http://localhost:<local-port>/api/v1/ | head
+  ```
+  Press `Ctrl+C` to stop the manual tunnel.
+
+**Step 6: Create systemd service**
+
+- [ ] Create the service file `/etc/systemd/system/<remote-name>-ieh-hf-ssh-tunnel.service`:
+  ```bash
+  sudo tee /etc/systemd/system/<remote-name>-ieh-hf-ssh-tunnel.service << 'EOF'
+  [Unit]
+  Description=AutoSSH tunnel to <remote-name> iEH HF
+  After=network-online.target
+  Wants=network-online.target
+
+  [Service]
+  User=<local-user>
+  Environment="AUTOSSH_GATETIME=0"
+  ExecStart=/usr/bin/autossh -M 0 \
+    -o "ServerAliveInterval 30" \
+    -o "ServerAliveCountMax 3" \
+    -o "ExitOnForwardFailure=yes" \
+    -o "StrictHostKeyChecking=no" \
+    -N \
+    -p <ssh-port> \
+    -L <local-port>:localhost:<remote-port> \
+    -i /home/<local-user>/.ssh/<remote-name>_ieh_key \
+    <user>@<remote-ip>
+  Restart=always
+  RestartSec=10
+
+  [Install]
+  WantedBy=multi-user.target
+  EOF
+  ```
+
+  Replace all `<placeholders>` with your actual values. Common configurations:
+
+  | Placeholder | Example (same network, non-standard port) | Example (different network) |
+  |---|---|---|
+  | `<remote-name>` | `kghm` | `tajhm` |
+  | `<remote-ip>` | `192.168.1.50` | `195.7.15.46` |
+  | `<ssh-port>` | `22` | `56222` |
+  | `<user>` | `imomo` | `ieasyhydro` |
+  | `<local-port>` | `5555` | `5554` |
+  | `<remote-port>` | `5555` | `5555` |
+  | `<local-user>` | `ubuntu` | `ubuntu` |
+
+**Step 7: Enable and start the service**
+
+- [ ] Enable and start:
+  ```bash
+  sudo systemctl daemon-reload
+  sudo systemctl enable <remote-name>-ieh-hf-ssh-tunnel
+  sudo systemctl start <remote-name>-ieh-hf-ssh-tunnel
+  ```
+
+- [ ] Configure `.env` to use the local tunnel port:
+  ```
+  IEASYHYDROHF_HOST=http://localhost:<local-port>
+  ```
+
+**Step 8: Verify**
+
+- [ ] Check service status:
+  ```bash
+  sudo systemctl status <remote-name>-ieh-hf-ssh-tunnel
+  ```
+- [ ] Verify tunnel is listening:
+  ```bash
+  ss -tlnp | grep <local-port>
+  ```
+- [ ] Test API access:
+  ```bash
+  curl -s http://localhost:<local-port>/api/v1/ | head
+  ```
+- [ ] View logs if needed:
+  ```bash
+  sudo journalctl -u <remote-name>-ieh-hf-ssh-tunnel -f
+  ```
+
+> **Troubleshooting:** If the tunnel fails, check: (1) port reachability with `nc -zv <remote-ip> <ssh-port>`, (2) key is in remote `authorized_keys`, (3) no port conflicts with `ss -tlnp | grep <local-port>`, (4) logs with `journalctl -u <remote-name>-ieh-hf-ssh-tunnel --since "1 hour ago"`.
+
+**Dashboard tunnel reachability (Docker bridge networking)**
+
+The SSH tunnel binds to host loopback (`127.0.0.1:<local-port>`) for security. Dashboard containers run on a Docker bridge network and have their own loopback — they cannot reach the host loopback. Symptom: dashboard logs `iEHHF not available, falling back to file. Error: ... Connection refused` on the `/api/v1/auth/token-obtain` path. (The misleading hardcoded warning text may mention `hf.ieasyhydro.org` — do not chase that hostname; the real failure is on `localhost:<local-port>` inside the dashboard container.)
+
+Fix: add `network_mode: host` to the dashboard service in `sapphire/docker-compose.yml` (and `bin/docker-compose-dashboards.yml` if its dashboards also call iEH HF). This makes the container share the host network namespace and reach the host loopback tunnel.
+
+**Important:** This fix is **not currently committed** in the repository. Production servers running iEH HF behind a tunnel may have applied it as a server-side override. Coordinate with the team before relying on it; future code may rewrite `IEASYHYDROHF_HOST` for Docker symmetrically with `IEASYHYDRO_HOST` and obviate the workaround.
+
+Verification step (run after the stack is up in section 3 below):
+```bash
+docker exec sapphire-dashboard curl -sf http://localhost:<local-port>/api/v1/
+```
+If this returns 200 from inside the dashboard container, the bridge-network workaround is in place. If it fails with `Connection refused` even though the host-side `curl http://localhost:<local-port>/api/v1/` succeeds, the dashboard service still needs `network_mode: host`.
+
+**Option D: iEasyHydro HF Cloud Version**
+
+If using the iEasyHydro HF cloud version:
+
+- [ ] Configure cloud API endpoint in `.env`:
+  ```
+  IEASYHYDRO_HOST=<cloud-api-endpoint>
+  ```
+- [ ] Ensure API credentials are set in `.env`
+- [ ] Verify firewall allows outbound HTTPS connections
+
+---
+
+## 3. Environment variable review
+
+Before bringing up the stack, review `${ENV_FILE_PATH}` and confirm all required variables are set. For the authoritative list cross-reference `doc/plans/working/taj_deploy_gap_analysis.md` §5a and `sapphire/.env.example`; the critical first-deploy variables are enumerated inline below.
+
+**Microservices / API integration (required):**
+
+- `SAPPHIRE_API_ENABLED=true` — gates API write path vs. CSV (legacy CSV path is being removed).
+- `SAPPHIRE_API_URL=http://localhost:8000` — base URL of the api-gateway.
+- `API_GATEWAY_URL=http://localhost:8000` — read by the dashboard and pipeline containers.
+
+**Snow stat dashboard gate (set after backfill):**
+
+- `SAPPHIRE_SNOW_STATS_AVAILABLE=false` until the snow-stat backfill in section 8 has been run successfully; then flip to `true`.
+- `SAPPHIRE_SEASON_START_MONTH` / `SAPPHIRE_SEASON_END_MONTH` — integer month numbers defining the hydrological-year window for the snow plot (e.g., `10` / `9`).
+
+**PostgreSQL credentials (required for the four SAPPHIRE databases):**
+
+- `POSTGRES_USER` and `POSTGRES_PASSWORD` — shared credentials for the four DB containers.
+- `PREPROCESSING_DB`, `POSTPROCESSING_DB`, `USER_DB`, `AUTH_DB` — database names.
+
+**Organization and image tags (required):**
+
+- `ieasyhydroforecast_organization` — one of `kghm`, `tjhm`, `uzhm`, `demo`. Drives URL routing in `bin/utils/common_functions.sh` and the timezone lookup in `setup_library.py`.
+- `ieasyhydroforecast_backend_docker_image_tag` — image tag for `mabesa/sapphire-*` pipeline images (e.g., `local`, `v1.0.0`).
+- `ieasyhydroforecast_frontend_docker_image_tag` — image tag for `mabesa/sapphire-dashboard`.
+
+**iEasyHydro HF connectivity (required only if section 2 applies):**
+
+- `IEASYHYDROHF_HOST=http://localhost:<local-port>` — tunnel host:port from section 2 (or direct IP for Option A; cloud endpoint for Option D).
+- `IEASYHYDRO_HOST` — cloud endpoint when using the cloud version.
+- `ieasyhydroforecast_connect_to_iEH=true` and `ieasyhydroforecast_ssh_to_iEH=true` when a tunnel is in use.
+
+**Auth / JWT (required for the auth-api):**
+
+- `JWT_SECRET_KEY`, `JWT_ALGORITHM`, `ACCESS_TOKEN_EXPIRE_MINUTES`, `REFRESH_TOKEN_EXPIRE_DAYS`.
+
+**API gateway tuning (required):**
+
+- `REQUEST_TIMEOUT`, `HEALTH_CHECK_TIMEOUT`, `API_KEY_ENABLED`, `API_KEY`, `RATE_LIMIT_ENABLED`.
+
+**Optional integrations:**
+
+- `GOOGLE_SHEETS_ENABLED=false` unless this deployment uses Google Sheets as a discharge source. If `true`, also set `GOOGLE_SHEETS_DISCHARGE_ID`, `GOOGLE_SHEETS_CREDENTIALS_PATH`, `GOOGLE_SHEETS_SITE_CODES`.
+- `SAPPHIRE_PIPELINE_EMAIL_RECIPIENTS`, `SAPPHIRE_PIPELINE_SMTP_*` — pipeline failure notifications (added 2026-04).
+
+**Sanity check:**
+
+- [ ] Confirm the file exists and is readable only by the deploy user:
+  ```bash
+  ls -l "${ENV_FILE_PATH}"
+  chmod 600 "${ENV_FILE_PATH}"
+  ```
+- [ ] Confirm no obsolete variables remain. Specifically remove `POSTPROCESSING_GAPFILL_WINDOW_DAYS` if present (removed from code).
+
+---
+
+## 4. Pull (or build) Docker images
+
+The first deploy needs the full image inventory. Image categories:
+
+**Pipeline images** (built/pushed to DockerHub as `mabesa/sapphire-*`; pulled at deploy time):
+
+```bash
+TAG="${ieasyhydroforecast_backend_docker_image_tag:-latest}"
+FRONTEND_TAG="${ieasyhydroforecast_frontend_docker_image_tag:-latest}"
+
+docker pull mabesa/sapphire-pythonbaseimage:${TAG}
+docker pull mabesa/sapphire-pipeline:${TAG}
+docker pull mabesa/sapphire-preprunoff:${TAG}
+docker pull mabesa/sapphire-prepgateway:${TAG}
+docker pull mabesa/sapphire-linreg:${TAG}
+docker pull mabesa/sapphire-ml:${TAG}
+docker pull mabesa/sapphire-postprocessing:${TAG}
+docker pull mabesa/sapphire-lt-forecasting:${TAG}
+docker pull mabesa/sapphire-preprocessing-station-forcing:${TAG}
+docker pull mabesa/sapphire-dashboard:${FRONTEND_TAG}
+```
+
+Conditional / optional:
+- `mabesa/sapphire-conceptmod:${TAG}` — only if `ieasyhydroforecast_run_CM_models=true`.
+
+**Microservices images** (built locally from `sapphire/docker-compose.yml`):
+
+The five FastAPI services (`api-gateway`, `preprocessing`, `postprocessing`, `user`, `auth`) build from `sapphire/services/*/Dockerfile`. On first deploy, run the build before the bring-up:
+
+```bash
+cd /data/SAPPHIRE_Forecast_Tools/sapphire
+docker compose --env-file "${ENV_FILE_PATH}" -f docker-compose.yml build
+```
+
+> Naming note: there is an unfortunate name collision between the app image `mabesa/sapphire-postprocessing` (operational postprocessing wrappers built from `apps/postprocessing_forecasts/Dockerfile`) and the service image built from `sapphire/services/postprocessing/Dockerfile` (FastAPI). They are different images for different layers — do not confuse them.
+
+**Infrastructure images:**
+
+- `sapphire/luigi-daemon:${TAG}` — built locally via `bin/luigi-daemon.Dockerfile`. First build:
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools
+  docker build -f bin/luigi-daemon.Dockerfile -t sapphire/luigi-daemon:${TAG} .
+  ```
+- `postgres:15` — pulled from DockerHub on first start of the DB containers; no manual pull required.
+
+---
+
+## 5. First bring-up of the SAPPHIRE microservices stack
+
+The `sapphire/docker-compose.yml` stack is the first thing to start on a fresh deployment. It defines the four PostgreSQL databases, the five FastAPI services, and the pentad dashboard.
+
+**Expected containers (10 total):**
+
+| Container | Service | Host port |
+|---|---|---|
+| `sapphire-preprocessing-db` | PostgreSQL 15 — preprocessing | 5433 |
+| `sapphire-postprocessing-db` | PostgreSQL 15 — postprocessing | 5434 |
+| `sapphire-user-db` | PostgreSQL 15 — user | 5435 |
+| `sapphire-auth-db` | PostgreSQL 15 — auth | 5436 |
+| `sapphire-api-gateway` | FastAPI api-gateway | 8000 |
+| `sapphire-preprocessing-api` | FastAPI preprocessing service | 8002 |
+| `sapphire-postprocessing-api` | FastAPI postprocessing service | 8003 |
+| `sapphire-user-api` | FastAPI user service | 8004 |
+| `sapphire-auth-api` | FastAPI auth service | 8005 |
+| `sapphire-dashboard` | Pentad dashboard (panel) | 5006 |
+
+**Bring up the stack:**
+
+```bash
+cd /data/SAPPHIRE_Forecast_Tools
+docker compose --env-file "${ENV_FILE_PATH}" -f sapphire/docker-compose.yml up -d
+```
+
+Wait ~30 s for all containers to become healthy, then verify:
+
+```bash
+docker ps --filter name=sapphire-
+curl -sf http://localhost:8000/health && echo " — api-gateway alive"
+curl -sf http://localhost:8000/health/ready && echo " — api-gateway ready (backends OK)"
+```
+
+If `/health/ready` fails, one or more backend services did not come up. Check `docker logs sapphire-<service>-api`.
+
+---
+
+## 6. Apply initial database schema (alembic)
+
+The preprocessing and postprocessing services use **Alembic** for schema management. On a fresh DB, run alembic upgrade once each.
+
+**Preprocessing:**
+
+```bash
+docker exec sapphire-preprocessing-api alembic current
+docker exec sapphire-preprocessing-api alembic upgrade head
+```
+
+Baseline revision is `a6210b339f17` (creates `runoffs`, `hydrographs`, `meteo`, `snow` tables). Current head is `9f1e72108f01`, which adds 12 snow-stat columns (`count`, `mean`, `std`, `min`, `max`, `q05`, `q25`, `q50`, `q75`, `q95`, `previous`, `current`) on the `snow` table.
+
+**Postprocessing:**
+
+```bash
+docker exec sapphire-postprocessing-api alembic current
+docker exec sapphire-postprocessing-api alembic upgrade head
+```
+
+Baseline revision is `34b227f37299`. No non-baseline migrations exist yet.
+
+**Auth and user:** both services auto-apply their alembic baselines on first boot; no operator action required.
+
+> If a preprocessing or postprocessing DB pre-existed from a pre-Alembic deployment (created with `create_all`), stamp it at the baseline first to avoid "table already exists" errors:
+> ```bash
+> docker exec sapphire-preprocessing-api alembic stamp a6210b339f17
+> docker exec sapphire-postprocessing-api alembic stamp 34b227f37299
+> ```
+> Then run `alembic upgrade head` as above.
+
+---
+
+## 7. Start the Luigi daemon
+
+The Luigi daemon runs the pipeline scheduler in a persistent container. **`COMPOSE_PROJECT_NAME=sapphire` must be set** so long-term-forecast tasks can join the network named `sapphire_sapphire-network`.
+
+```bash
+cd /data/SAPPHIRE_Forecast_Tools
+export COMPOSE_PROJECT_NAME=sapphire
+docker compose -f bin/docker-compose-luigi.yml -p sapphire up -d luigi-daemon
+```
+
+Wait a few seconds, then verify the Luigi UI is reachable:
+
+```bash
+curl -sf http://localhost:8082/ && echo " — Luigi UI alive"
+```
+
+---
+
+## 8. Run RunInitializeWorkflow (first-deploy only)
+
+`RunInitializeWorkflow` is the Luigi bootstrap workflow that populates the preprocessing DB with historical site data and seeds the linear-regression model state and skill metrics. **This step is first-deploy only.** The workflow is idempotent (Luigi marker files short-circuit subsequent runs), so it is unnecessary — and skipped automatically — on routine updates documented in `update_deployment_checklist.md`.
+
+**Prerequisites (all must be satisfied first):**
+
+- Sections 1–7 of this checklist completed.
+- iEH HF tunnel up and reachable from the host (section 2).
+- All four databases healthy and schema upgraded (sections 5–6).
+- Luigi daemon running on port 8082 (section 7).
+
+**Run the workflow:**
+
+```bash
+cd /data/SAPPHIRE_Forecast_Tools
+docker compose -f bin/docker-compose-luigi.yml -p sapphire run --rm \
+  --entrypoint "" \
+  preprocessing-runoff \
+  uv run luigi \
+    --scheduler-host luigi-daemon \
+    --scheduler-port 8082 \
+    --module apps.pipeline.pipeline_docker \
+    RunInitializeWorkflow
+```
+
+The workflow chain (per `apps/pipeline/pipeline_docker.py:2604`) is:
+
+```
+PrepRunoffMaintenance → InitialApiSync → LinRegInitial(PENTAD/DECAD)
+                                       → SkillMetricsInitial(PENTAD/DECAD)
+                                       → RunInitializeWorkflow
+```
+
+On success, a marker file `initial_workflow_complete` is written to the Luigi marker directory inside the data volume. Any later run of `RunInitializeWorkflow` short-circuits on this marker. **Do not delete this marker file** unless you genuinely intend to re-initialise from scratch.
+
+Confirm in the Luigi UI:
+```bash
+curl -s "http://localhost:8082/api/task_list?upstream_status=&search=RunInitializeWorkflow" | python3 -m json.tool | head -40
+```
+
+---
+
+## 9. Historical data backfill (optional)
+
+The following tracked recovery / backfill scripts are useful on first deploy when the operator wants historical years populated beyond what `RunInitializeWorkflow` produces. Run them after section 8 succeeds.
+
+**Snow stat historical backfill** (`bin/backfill_snow_stats_history.sh`):
+
+Populates the 12 snow-stat columns introduced by Alembic revision `9f1e72108f01` for historical years. Snow stats are read by the dashboard snow tab and gated by `SAPPHIRE_SNOW_STATS_AVAILABLE`.
+
+```bash
+ieasyhydroforecast_env_file_path="${ENV_FILE_PATH}" \
+  bash bin/backfill_snow_stats_history.sh --start-year 2010
+```
+
+The script loops years sequentially, writing a progress file so re-runs resume from the last completed year.
+
+> **Known quirk:** a known shell-script issue causes the script to exit with code 1 even on full success (an unbound `$ieasyhydroforecast_ssh_tunnel_pid` in the shared `bin/utils/common_functions.sh` cleanup trap fires on shell exit). Do **not** interpret exit code 1 alone as failure. Inspect the log tail:
+> ```bash
+> tail -50 "${LOG_DIR}/sapphire_backfill_snow_stats_*.log"
+> ```
+> A successful run ends with `all years processed`. If you see that string, the backfill succeeded and you can flip `SAPPHIRE_SNOW_STATS_AVAILABLE=true` in `${ENV_FILE_PATH}`. If you do not, treat as a genuine failure and investigate.
+
+**Other tracked periodic wrappers** that may make sense on first deploy:
+
+- `bin/yearly_snow_norm_recalculation.sh "${ENV_FILE_PATH}"` — annual snow-norm recalculation. Run once to seed the current year's norms.
+- `bin/yearly_runoff_hydrograph_aggregation.sh "${ENV_FILE_PATH}"` — long-horizon monthly + April–September seasonal hydrograph. Replaces the retired `YearlyMonthlyNormsRecalculation` Luigi task. Run once on first deploy to seed the long-horizon hydrograph view.
+- `bin/bimonthly_long_term_postprocessing.sh "${ENV_FILE_PATH}"` — long-term forecast postprocessing.
+
+Recurring schedules for these wrappers belong in the cron installation step, not here.
+
+---
+
+## 10. Start the dashboards
+
+The pentad dashboard is started as part of the SAPPHIRE stack (section 5). The decad dashboard is currently served from the legacy `bin/docker-compose-dashboards.yml`.
+
+> **Known issue — port 5006 dual-binding:** Both `sapphire/docker-compose.yml` (`dashboard` service, port 5006) and `bin/docker-compose-dashboards.yml` (`pentaddashboard` service, port 5006) can bind the same port. The live convention is: pentad dashboard moved to `sapphire/docker-compose.yml`, decad dashboard still served from the legacy compose file. Before starting the legacy compose, comment out or delete the `pentaddashboard` service in `bin/docker-compose-dashboards.yml` to avoid a port conflict. Verify which compose actually exposes 5006 on your deployment.
+
+**Start the decad dashboard from the legacy compose:**
+
+```bash
+cd /data/SAPPHIRE_Forecast_Tools
+docker compose -f bin/docker-compose-dashboards.yml --env-file "${ENV_FILE_PATH}" up -d decaddashboard
+```
+
+If your deployment still uses the legacy compose for the pentad dashboard, add `pentaddashboard` to the `up -d` command — but only one source of truth should bind port 5006.
+
+Verify the dashboards are up:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5006/forecast_dashboard
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5007/forecast_dashboard
+```
+
+Both should return `200`.
+
+---
+
+## 11. First smoke test (post-deploy probe suite)
+
+Run the full post-deploy probe suite from `doc/plans/working/taj_deploy_operational_readiness.md` §4. All probes should return HTTP 200.
+
+**Liveness / readiness:**
+
+```bash
+curl -sf http://localhost:8000/health        && echo " — api-gateway liveness"
+curl -sf http://localhost:8000/health/ready  && echo " — api-gateway readiness (backends ok)"
+```
+
+**Backend service health (probes each service directly, bypassing the gateway):**
+
+```bash
+curl -sf http://localhost:8002/health && echo " — preprocessing-api"
+curl -sf http://localhost:8003/health && echo " — postprocessing-api"
+curl -sf http://localhost:8004/health && echo " — user-api"
+curl -sf http://localhost:8005/health && echo " — auth-api"
+```
+
+**Luigi scheduler UI:**
+
+```bash
+curl -sf http://localhost:8082/ && echo " — Luigi scheduler UI"
+```
+
+**Dashboards:**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5006/forecast_dashboard   # pentad
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5007/forecast_dashboard   # decad
+```
+
+Both `5006` and `5007` should return `200`.
+
+**Preprocessing read smoke (via api-gateway):**
+
+```bash
+curl -s "http://localhost:8000/api/preprocessing/runoff/?limit=1" | python3 -m json.tool | head -20
+curl -s "http://localhost:8000/api/preprocessing/snow/?limit=1"   | python3 -m json.tool | head -20
+```
+
+Both should return a non-empty JSON array. If the snow endpoint returns rows but the stat columns are all null, the snow-stat backfill (section 9) has not yet been run — leave `SAPPHIRE_SNOW_STATS_AVAILABLE=false` until it has.
+
+**Postprocessing read smoke:**
+
+```bash
+curl -s "http://localhost:8000/api/postprocessing/forecasts/?limit=1"     | python3 -m json.tool | head -20
+curl -s "http://localhost:8000/api/postprocessing/skill-metric/?limit=1"  | python3 -m json.tool | head -20
+```
+
+Empty results here are expected if no forecast has been run yet; they will populate after the first scheduled (or manually triggered) forecast cycle.
+
+**Visual smoke (requires browser or screenshot):**
+
+- Open `http://<server-ip>:5006/forecast_dashboard` — pentad dashboard renders with data.
+- Open `http://<server-ip>:5007/forecast_dashboard` — decad dashboard renders.
+- Navigate to the **Snow** tab — chart renders. If snow-stat backfill has run and `SAPPHIRE_SNOW_STATS_AVAILABLE=true`, statistical bands (q05–q95, min–max) are visible.
+
+---
+
+## 12. Install operational cron schedule
+
+The microservices stack, Luigi daemon, and dashboards are now running. The final first-deploy step is to put the forecast pipeline on a production cadence by installing the SAPPHIRE crontab. After this section completes, the operational forecasts and the daily/periodic maintenance jobs will run on their own.
+
+This section is the authoritative install procedure. The same canonical cron block is reproduced in `doc/prod/update_deployment_checklist.md` §2.5 so routine-update operators can diff their running crontab against it on later updates without re-reading the first-deploy doc.
+
+> **Prerequisites:**
+> - The SAPPHIRE microservices stack is up (section 5). Every cron command reads/writes through the api-gateway at `http://localhost:8000`; without the stack up, each command fails immediately with `Connection refused`. Confirm with `curl -sf http://localhost:8000/health/ready && echo READY`.
+> - The first smoke test in section 11 passed.
+> - The Luigi daemon is running (section 7). Cron-driven scripts start it automatically if it is not, but verifying once here avoids surprises.
+
+### 12.1 Back up any existing crontab
+
+On a fresh server there is usually no crontab to back up, but on a recycled host there may be. Run this in either case — `crontab -l` returns non-zero if nothing is installed, which is fine:
+
+```bash
+crontab -l > ~/crontab_backup_$(date +%Y%m%d).txt 2>/dev/null || true
+ls -la ~/crontab_backup_*.txt
+```
+
+### 12.2 Install the canonical cron block
+
+The block below is the post-S1-2026 consolidated Luigi-wrapper pattern. The authoritative source is [`doc/deployment.md` §"Set up cron job"](../deployment.md#set-up-cron-job); this section keeps the same block inline for operator convenience.
+
+> **Cron does not expand shell variables.** The `${...}` placeholders below are for readability — when you paste these into `crontab -e`, substitute the literal values of `${ENV_FILE_PATH}` and `${LOG_DIR}` (as set in the operator placeholder block at the top of this doc) into each line.
+
+- [ ] **Edit crontab**
+  ```bash
+  crontab -e
+  ```
+
+- [ ] **Paste the canonical block** (substituting literal values for `${ENV_FILE_PATH}` and `${LOG_DIR}`):
+
+  ```bash
+  # m h  dom mon dow   command
+  # ---------------------------------------------------------------------------
+  # SAPPHIRE Forecast Tools Schedule (Times are in UTC)
+  # Cron does not expand shell variables. Before pasting, substitute the
+  # literal values of ${ENV_FILE_PATH} and ${LOG_DIR} (see Operator setup at
+  # the top of this doc).
+  # ---------------------------------------------------------------------------
+
+  # Log cleanup: delete logs older than 7 days (runs daily at 02:00 UTC)
+  0 2 * * * find ${LOG_DIR} -name "sapphire_*.log" -mtime +7 -delete
+
+  # Daily DB backup at 01:00 UTC (pg_dump-based, 30-day retention)
+  0 1 * * * bash /data/SAPPHIRE_Forecast_Tools/bin/backup_sapphire_db.sh -d /var/backups/sapphire -r 30 >> ${LOG_DIR}/sapphire_db_backup_$(date +\%Y\%m\%d).log 2>&1
+
+  # (1) Gateway Preprocessing at 03:00 UTC. Independent of daily data.
+  0 3 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_preprocessing_gateway.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_gateway_preprocessing_$(date +\%Y\%m\%d).log 2>&1
+
+  # (2) Pentadal Forecast at 04:00 UTC. Luigi triggers runoff preprocessing.
+  0 4 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_pentadal_forecasts.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_pentadal_forecast_$(date +\%Y\%m\%d).log 2>&1
+
+  # (3) Decadal Forecast at 05:00 UTC.
+  0 5 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_decadal_forecasts.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_decadal_forecast_$(date +\%Y\%m\%d).log 2>&1
+
+  # (4) Long-Term Forecast at 06:00 UTC on the 10th and 25th of each month.
+  # The script self-gates via lt_schedule_query.py — it only fires on
+  # predefined operational forecast dates (±5 day tolerance).
+  0 6 10,25 * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_long_term_forecasts.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_long_term_$(date +\%Y\%m\%d).log 2>&1
+
+  # (4b) Bimonthly long-term skill metrics recalculation at 10:00 UTC on the
+  # 10th and 25th (4 hours after the long-term forecast). Keeps the
+  # dashboard long-term skill tiles fresh between yearly full recalcs.
+  0 10 10,25 * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/bimonthly_long_term_skill_metrics_recalculation.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_bimonthly_lt_skill_recalc_$(date +\%Y\%m\%d).log 2>&1
+
+  # (5) Daily Maintenance at 19:00 UTC (consolidated Luigi wrapper).
+  # Replaces the legacy individual daily_*_maintenance.sh scripts. Luigi
+  # enforces dependency order: PrepRunoff + Gateway → LinReg → ML →
+  # PostProcessing → Frontend. ML concurrency limited to 3 via Luigi resources.
+  0 19 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_daily_maintenance.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_daily_maintenance_$(date +\%Y\%m\%d).log 2>&1
+
+  # (6) Bimonthly long-term postprocessing at 22:00 UTC on the 1st of odd
+  # months (consolidated Luigi wrapper). Supersedes legacy
+  # bin/bimonthly_long_term_postprocessing.sh (kept for manual / debugging
+  # use only).
+  0 22 1 1,3,5,7,9,11 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh long_term ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_lt_postproc_$(date +\%Y\%m\%d).log 2>&1
+
+  # (7) Yearly skill metrics recalculation at 01:00 UTC on December 31
+  # (consolidated Luigi wrapper). Full-history safety net.
+  0 1 31 12 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_yearly_skill_recalc_$(date +\%Y\%m\%d).log 2>&1
+
+  # (8) Yearly snow norm/stat recalculation at 02:00 UTC on August 31
+  # (consolidated Luigi wrapper). Supersedes legacy
+  # bin/yearly_snow_norm_recalculation.sh (kept for manual / debugging
+  # use only).
+  0 2 31 8 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_yearly_snow_norm_$(date +\%Y\%m\%d).log 2>&1
+
+  # (9) Yearly runoff hydrograph aggregation at 03:00 UTC on January 1.
+  # Replaces the retired YearlyMonthlyNormsRecalculation Luigi task. Builds
+  # the long-horizon monthly + April–September seasonal hydrograph view
+  # used by the dashboard.
+  0 3 1 1 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/yearly_runoff_hydrograph_aggregation.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_yearly_runoff_hydrograph_$(date +\%Y\%m\%d).log 2>&1
+  ```
+
+  > **Legacy scripts to avoid:** `bin/daily_preprunoff_maintenance.sh`, `bin/daily_ml_maintenance.sh`, `bin/daily_linreg_maintenance.sh`, `bin/daily_postprc_maintenance.sh`, `bin/daily_gateway_maintenance.sh`, and `bin/daily_update_sapphire_frontend.sh` are marked `[Legacy]` in `bin/README.md`. They remain on origin for manual debugging only — do not schedule them via cron. The single `run_daily_maintenance.sh` entry above replaces all of them and enforces dependency order via Luigi.
+
+### 12.3 Verify the crontab installed correctly
+
+- [ ] **Show the installed crontab**
+  ```bash
+  crontab -l
+  ```
+  Compare against the block in §12.2.
+
+- [ ] **Ensure the log directory exists**
+  ```bash
+  mkdir -p ${LOG_DIR}
+  ls -ld ${LOG_DIR}
+  ```
+
+- [ ] **Verify the cron service is running**
+  ```bash
+  sudo systemctl status cron
+  ```
+
+- [ ] **Verify the database backup target directory exists and is writable**
+  ```bash
+  sudo mkdir -p /var/backups/sapphire
+  sudo chown $(whoami): /var/backups/sapphire
+  ls -ld /var/backups/sapphire
+  ```
+
+### 12.4 Manual cron tests
+
+> **Prerequisite — the SAPPHIRE microservices stack must be up before any
+> cron command below will succeed.** Every cron command reads/writes through
+> the api-gateway at `http://localhost:8000`; without the stack up, each
+> command fails immediately with `Connection refused`. Verify before
+> proceeding:
+> ```bash
+> curl -sf http://localhost:8000/health/ready && echo "READY"
+> ```
+> If the stack is not up, start it from section 5 (`docker compose --env-file ${ENV_FILE_PATH} -f sapphire/docker-compose.yml up -d`, or equivalently `bash bin/restart_sapphire_stack.sh ${ENV_FILE_PATH}`).
+
+Run each cron command once to confirm the wrapper script, env file, and microservices stack agree. The Luigi daemon starts automatically when needed. Monitor progress in the Luigi web UI at http://localhost:8082.
+
+- [ ] **Run database backup**
+  ```bash
+  bash /data/SAPPHIRE_Forecast_Tools/bin/backup_sapphire_db.sh -d /var/backups/sapphire -r 30
+  ```
+
+- [ ] **Run gateway preprocessing**
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_preprocessing_gateway.sh ${ENV_FILE_PATH}
+  ```
+
+- [ ] **Run pentadal forecast**
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_pentadal_forecasts.sh ${ENV_FILE_PATH}
+  ```
+
+- [ ] **Run decadal forecast**
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_decadal_forecasts.sh ${ENV_FILE_PATH}
+  ```
+
+- [ ] **Run long-term forecast** (dry-run is safe on any date; full run only fires on operational forecast dates)
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_long_term_forecasts.sh --dry-run ${ENV_FILE_PATH}
+  ```
+
+- [ ] **Run consolidated daily maintenance** (replaces the four legacy `daily_*_maintenance.sh` wrappers)
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_daily_maintenance.sh ${ENV_FILE_PATH}
+  ```
+
+- [ ] **Run periodic maintenance tasks** (one per task type; pick those that match the current calendar)
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh long_term     ${ENV_FILE_PATH}
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc  ${ENV_FILE_PATH}
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms    ${ENV_FILE_PATH}
+  ```
+
+- [ ] **Run bimonthly long-term skill metrics recalculation**
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/bimonthly_long_term_skill_metrics_recalculation.sh ${ENV_FILE_PATH}
+  ```
+
+- [ ] **Run yearly runoff hydrograph aggregation**
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/yearly_runoff_hydrograph_aggregation.sh ${ENV_FILE_PATH}
+  ```
+
+- [ ] **Check logs after each command completes** under `${LOG_DIR}/sapphire_*.log`.
+
+> For *subsequent* updates to the cron schedule (e.g., a new wrapper script added in a later release), follow `doc/prod/update_deployment_checklist.md` §2.5–§2.6 — that section walks through diffing the running crontab against the updated canonical block and re-running the affected manual cron tests.
+
+---
+
+## 13. Next steps
+
+The microservices stack, Luigi daemon, dashboards, and cron schedule are now running. The deployment is on a production cadence.
+
+1. **Routine updates** — for subsequent image-tag bumps, `.env` diffs, microservices restarts, and cron schedule changes, follow `doc/prod/update_deployment_checklist.md`. That checklist also covers stopping services, backups, alembic migrations, and rollback for an existing deployment.
+
+---
+
+*This is the first-deploy checklist. For routine updates see `doc/prod/update_deployment_checklist.md`.*

--- a/doc/prod/update_deployment_checklist.md
+++ b/doc/prod/update_deployment_checklist.md
@@ -1,13 +1,29 @@
 # SAPPHIRE Forecast Tools - Update Deployment Checklist
 
-This checklist guides you through updating an existing SAPPHIRE Forecast Tools deployment. It covers updating Docker images, configuration files, crontabs, and log cleanup.
+This checklist guides you through a **routine update** of an existing SAPPHIRE Forecast Tools deployment. It covers refreshing the repository, pulling new Docker images, applying schema migrations, restarting the microservices and Luigi stacks, verifying health, and rolling back if needed.
+
+> **First-time deployment?** Use `doc/prod/first_deploy_checklist.md` instead. That doc covers the one-time steps (SSH tunnel setup, initial schema preparation, `RunInitializeWorkflow`, historical backfill) that are *not* part of a routine update.
+>
+
+## Operator setup — set these once per session
+
+Before running any command below, set these variables once in your shell session. Everywhere in this doc that you see `${ORG_SLUG}`, `${DATA_DIR}`, `${ENV_FILE_PATH}`, or `${LOG_DIR}`, those are the values being substituted.
+
+```bash
+# Operator: set these variables once per deployment session. The rest of
+# this checklist references them. Adapt to your deployment.
+export ORG_SLUG=tjhm                                             # one of: kghm, tjhm, uzhm
+export DATA_DIR=/data/taj_data_forecast_tools                    # adapt to your data path
+export ENV_FILE_PATH="${DATA_DIR}/config/.env_develop_${ORG_SLUG}"
+export LOG_DIR=/home/ubuntu/logs                                 # adapt to your logs path
+```
 
 **Target Server Paths:**
 - Project: `/data/SAPPHIRE_Forecast_Tools`
-- Config: `/data/kyg_data_forecast_tools/config/.env_develop_kghm`
-- Logs: `/home/ubuntu/logs/`
+- Config: `${ENV_FILE_PATH}`
+- Logs: `${LOG_DIR}/`
 - Luigi daemon port: 8082
-- Dashboard ports: 5006 (pentad), 5007 (decad)
+- Dashboard port: 5006
 
 ---
 
@@ -30,237 +46,7 @@ This checklist guides you through updating an existing SAPPHIRE Forecast Tools d
 
 ### 1.2 iEasyHydro HF Connectivity (if applicable)
 
-SAPPHIRE can run as a standalone forecast tool without iEasyHydro HF. However, certain organization configurations (e.g., `kghm`, `tjhm`) require connectivity to the iEasyHydro HF database for data retrieval. Check your `.env` file for `ieasyhydroforecast_organization` to determine if this applies.
-
-**If your deployment requires iEasyHydro HF**, the configuration depends on your network setup:
-
-**Option A: Same Network with Direct API Access**
-
-If the SAPPHIRE server and iEasyHydro HF server are on the same local network AND the API is accessible from the network:
-
-- [ ] Verify network connectivity to iEasyHydro HF server
-  ```bash
-  ping -c 3 <ieasyhydro-server-ip>
-  ```
-- [ ] Verify API is accessible directly (test common ports):
-  ```bash
-  curl -s http://<ieasyhydro-server-ip>:5555/api/v1/ | head
-  curl -s http://<ieasyhydro-server-ip>:8000/api/v1/ | head
-  ```
-- [ ] If API responds, configure `.env` with direct IP:
-  ```
-  IEASYHYDROHF_HOST=http://<ieasyhydro-server-ip>:<port>
-  ```
-
-**Option B: Same Network but API Only on Localhost (SSH Tunnel Required)**
-
-If iEasyHydro HF API only listens on localhost (common security configuration):
-
-- [ ] Verify ping works but direct API access fails
-- [ ] Test manual SSH tunnel:
-  ```bash
-  ssh -f -N -L <local-port>:localhost:<remote-port> <user>@<ieasyhydro-server-ip>
-  curl -s http://localhost:<local-port>/api/v1/ | head
-  ```
-  Where `<remote-port>` is the port iEasyHydro HF listens on (typically 5555) and `<local-port>` is the port you want to use locally (can be the same or different, e.g., 5554 if 5555 is already in use by another tunnel).
-- [ ] Configure `.env` to use localhost:
-  ```
-  IEASYHYDROHF_HOST=http://localhost:<local-port>
-  ```
-- [ ] **Set up permanent tunnel with autossh + systemd:**
-
-  1. Install autossh:
-     ```bash
-     sudo apt-get update && sudo apt-get install -y autossh
-     ```
-
-  2. Verify SSH key authentication (no password prompt):
-     ```bash
-     ssh -o BatchMode=yes <user>@<ieasyhydro-server-ip> echo "OK"
-     ```
-
-  3. Create systemd service (`/etc/systemd/system/ieasyhydro-tunnel.service`):
-     ```ini
-     [Unit]
-     Description=SSH Tunnel to iEasyHydro HF Server
-     After=network-online.target
-     Wants=network-online.target
-
-     [Service]
-     Type=simple
-     User=<your-user>
-     Environment="AUTOSSH_GATETIME=0"
-     ExecStart=/usr/bin/autossh -M 0 -N -o "ServerAliveInterval=30" -o "ServerAliveCountMax=3" -o "ExitOnForwardFailure=yes" -L <local-port>:localhost:<remote-port> <user>@<ieasyhydro-server-ip>
-     Restart=always
-     RestartSec=10
-
-     [Install]
-     WantedBy=multi-user.target
-     ```
-
-  4. Enable and start:
-     ```bash
-     sudo systemctl daemon-reload
-     sudo systemctl enable ieasyhydro-tunnel.service
-     sudo systemctl start ieasyhydro-tunnel.service
-     ```
-
-- [ ] Verify permanent tunnel:
-  ```bash
-  sudo systemctl status ieasyhydro-tunnel.service
-  curl -s http://localhost:<local-port>/api/v1/ | head
-  ```
-
-**Option C: Different Networks (SSH Tunnel with Port Forwarding)**
-
-If the SAPPHIRE server and iEasyHydro HF are on different networks (e.g., AWS server connecting to a local installation at a hydromet service), an SSH tunnel with port forwarding is required.
-
-**Prerequisites:**
-- SSH access to the iEasyHydro HF server (username, IP, port)
-- The remote server's IT team must allow inbound SSH from the SAPPHIRE server IP
-- The iEasyHydro HF API must be listening on a known port on the remote server (typically 5555)
-
-**Step 1: Install autossh**
-
-- [ ] Install autossh on the SAPPHIRE server:
-  ```bash
-  sudo apt-get update && sudo apt-get install -y autossh
-  ```
-
-**Step 2: Generate SSH key**
-
-- [ ] Generate a dedicated SSH key for the tunnel:
-  ```bash
-  ssh-keygen -t ed25519 -f ~/.ssh/<remote-name>_ieh_key -N ""
-  ```
-  Replace `<remote-name>` with a short identifier (e.g., `tajhm`, `kghm`).
-
-**Step 3: Install public key on remote server**
-
-- [ ] Copy the public key to the remote server:
-  ```bash
-  ssh-copy-id -i ~/.ssh/<remote-name>_ieh_key.pub -p <ssh-port> <user>@<remote-ip>
-  ```
-  If `ssh-copy-id` is not available, use the manual approach:
-  ```bash
-  cat ~/.ssh/<remote-name>_ieh_key.pub | ssh -p <ssh-port> <user>@<remote-ip> \
-    "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
-  ```
-  > **Note:** This step requires either the current password for the remote user, or coordination with the remote IT team to add the key manually.
-
-**Step 4: Add remote server to known_hosts**
-
-- [ ] Add the remote server's host key:
-  ```bash
-  ssh-keyscan -p <ssh-port> <remote-ip> >> ~/.ssh/known_hosts
-  ```
-
-**Step 5: Test the connection**
-
-- [ ] Verify key-based SSH login works:
-  ```bash
-  ssh -i ~/.ssh/<remote-name>_ieh_key -p <ssh-port> <user>@<remote-ip>
-  ```
-
-- [ ] Test port forwarding manually:
-  ```bash
-  ssh -i ~/.ssh/<remote-name>_ieh_key -p <ssh-port> -L <local-port>:localhost:<remote-port> -N <user>@<remote-ip>
-  ```
-  In a second terminal, verify the local port is listening:
-  ```bash
-  ss -tlnp | grep <local-port>
-  curl -s http://localhost:<local-port>/api/v1/ | head
-  ```
-  Press `Ctrl+C` to stop the manual tunnel.
-
-**Step 6: Create systemd service**
-
-- [ ] Create the service file `/etc/systemd/system/<remote-name>-ieh-hf-ssh-tunnel.service`:
-  ```bash
-  sudo tee /etc/systemd/system/<remote-name>-ieh-hf-ssh-tunnel.service << 'EOF'
-  [Unit]
-  Description=AutoSSH tunnel to <remote-name> iEH HF
-  After=network-online.target
-  Wants=network-online.target
-
-  [Service]
-  User=<local-user>
-  Environment="AUTOSSH_GATETIME=0"
-  ExecStart=/usr/bin/autossh -M 0 \
-    -o "ServerAliveInterval 30" \
-    -o "ServerAliveCountMax 3" \
-    -o "ExitOnForwardFailure=yes" \
-    -o "StrictHostKeyChecking=no" \
-    -N \
-    -p <ssh-port> \
-    -L <local-port>:localhost:<remote-port> \
-    -i /home/<local-user>/.ssh/<remote-name>_ieh_key \
-    <user>@<remote-ip>
-  Restart=always
-  RestartSec=10
-
-  [Install]
-  WantedBy=multi-user.target
-  EOF
-  ```
-
-  Replace all `<placeholders>` with your actual values. Common configurations:
-
-  | Placeholder | Example (same network, non-standard port) | Example (different network) |
-  |---|---|---|
-  | `<remote-name>` | `kghm` | `tajhm` |
-  | `<remote-ip>` | `192.168.1.50` | `195.7.15.46` |
-  | `<ssh-port>` | `22` | `56222` |
-  | `<user>` | `imomo` | `ieasyhydro` |
-  | `<local-port>` | `5555` | `5554` |
-  | `<remote-port>` | `5555` | `5555` |
-  | `<local-user>` | `ubuntu` | `ubuntu` |
-
-**Step 7: Enable and start the service**
-
-- [ ] Enable and start:
-  ```bash
-  sudo systemctl daemon-reload
-  sudo systemctl enable <remote-name>-ieh-hf-ssh-tunnel
-  sudo systemctl start <remote-name>-ieh-hf-ssh-tunnel
-  ```
-
-- [ ] Configure `.env` to use the local tunnel port:
-  ```
-  IEASYHYDROHF_HOST=http://localhost:<local-port>
-  ```
-
-**Step 8: Verify**
-
-- [ ] Check service status:
-  ```bash
-  sudo systemctl status <remote-name>-ieh-hf-ssh-tunnel
-  ```
-- [ ] Verify tunnel is listening:
-  ```bash
-  ss -tlnp | grep <local-port>
-  ```
-- [ ] Test API access:
-  ```bash
-  curl -s http://localhost:<local-port>/api/v1/ | head
-  ```
-- [ ] View logs if needed:
-  ```bash
-  sudo journalctl -u <remote-name>-ieh-hf-ssh-tunnel -f
-  ```
-
-> **Troubleshooting:** If the tunnel fails, check: (1) port reachability with `nc -zv <remote-ip> <ssh-port>`, (2) key is in remote `authorized_keys`, (3) no port conflicts with `ss -tlnp | grep <local-port>`, (4) logs with `journalctl -u <remote-name>-ieh-hf-ssh-tunnel --since "1 hour ago"`.
-
-**Option D: iEasyHydro HF Cloud Version**
-
-If using the iEasyHydro HF cloud version:
-
-- [ ] Configure cloud API endpoint in `.env`:
-  ```
-  IEASYHYDRO_HOST=<cloud-api-endpoint>
-  ```
-- [ ] Ensure API credentials are set in `.env`
-- [ ] Verify firewall allows outbound HTTPS connections
+If you are setting up this server for the first time, complete the SSH tunnel setup steps in `doc/prod/first_deploy_checklist.md` first. For routine updates, just verify the tunnel is healthy: `sudo systemctl status <tunnel-service>.service`.
 
 ### 1.3 Timing Considerations
 
@@ -286,27 +72,25 @@ If using the iEasyHydro HF cloud version:
 
 - [ ] Verify dashboard containers are running
   ```bash
-  docker ps | grep sapphire-frontend
+  docker ps | grep sapphire-dashboard
   ```
 
 - [ ] Check dashboard health status
   ```bash
-  docker inspect --format "{{.State.Health.Status}}" sapphire-frontend-forecast-pentad
-  docker inspect --format "{{.State.Health.Status}}" sapphire-frontend-forecast-decad
+  docker inspect --format "{{.State.Health.Status}}" sapphire-dashboard
   ```
 
 - [ ] Verify dashboards are accessible
   ```bash
   curl -s -o /dev/null -w "%{http_code}" http://localhost:5006/forecast_dashboard
-  curl -s -o /dev/null -w "%{http_code}" http://localhost:5007/forecast_dashboard
   ```
 
 **Check recent pipeline activity:**
 
 - [ ] Review today's pipeline logs for any issues
   ```bash
-  ls -lt /home/ubuntu/logs/sapphire_*.log | head -5
-  tail -50 /home/ubuntu/logs/sapphire_pentadal_$(date +%Y%m%d).log
+  ls -lt ${LOG_DIR}/sapphire_*.log | head -5
+  tail -50 ${LOG_DIR}/sapphire_pentadal_$(date +%Y%m%d).log
   ```
 
 - [ ] Check Luigi task history for recent failures
@@ -337,7 +121,7 @@ If using the iEasyHydro HF cloud version:
 
 - [ ] Backup the .env file
   ```bash
-  cp /data/kyg_data_forecast_tools/config/.env_develop_kghm "$BACKUP_DIR/"
+  cp ${ENV_FILE_PATH} "$BACKUP_DIR/"
   ```
 
 - [ ] Backup crontab
@@ -350,22 +134,28 @@ If using the iEasyHydro HF cloud version:
   cp /data/SAPPHIRE_Forecast_Tools/bin/docker-compose-luigi.yml "$BACKUP_DIR/" 2>/dev/null || echo "Using default compose file"
   ```
 
-- [ ] Backup dashboard compose file (if customized)
+**Backup the four Postgres databases:**
+
+- [ ] Dump preprocessing, postprocessing, user, and auth DBs to timestamped `.dump` files
   ```bash
-  cp /data/SAPPHIRE_Forecast_Tools/bin/docker-compose-dashboards.yml "$BACKUP_DIR/" 2>/dev/null || echo "Using default compose file"
+  bash bin/backup_sapphire_db.sh -d /var/backups/sapphire/pre_update_$(date +%Y%m%d_%H%M%S)
   ```
+  This is the supported `pg_dump`-based backup mechanism (`bin/backup_sapphire_db.sh`).
+  It writes one `.dump` file per database to the target directory. Required before
+  applying schema migrations — DB state is the only state that cannot be regenerated
+  from source. See `bin/reset_sapphire_db.sh --help` for the restore counterpart.
 
 **Backup application state:**
 
 - [ ] Backup last successful run timestamp
   ```bash
-  cp /data/kyg_data_forecast_tools/intermediate_data/last_successful_run.txt "$BACKUP_DIR/" 2>/dev/null || echo "File not found"
+  cp ${DATA_DIR}/intermediate_data/last_successful_run.txt "$BACKUP_DIR/" 2>/dev/null || echo "File not found"
   ```
 
-- [ ] Backup Luigi marker files (optional, for debugging)
+- [ ] Backup Luigi marker files (required for clean rollback — see §5)
   ```bash
   mkdir -p "$BACKUP_DIR/luigi_markers"
-  cp /data/kyg_data_forecast_tools/intermediate_data/luigi_markers/*.marker "$BACKUP_DIR/luigi_markers/" 2>/dev/null || echo "No marker files"
+  cp ${DATA_DIR}/intermediate_data/luigi_markers/*.marker "$BACKUP_DIR/luigi_markers/" 2>/dev/null || echo "No marker files"
   ```
 
 **Record current Docker image versions:**
@@ -398,6 +188,8 @@ Before proceeding to the update steps, confirm:
 - [ ] Recent logs checked for issues
 - [ ] .env file backed up
 - [ ] Crontab backed up
+- [ ] Four Postgres DBs backed up via `bin/backup_sapphire_db.sh`
+- [ ] Luigi marker files backed up
 - [ ] Current Docker images documented
 - [ ] Backup directory location noted: `________________`
 
@@ -409,16 +201,22 @@ Before proceeding to the update steps, confirm:
 
 Before updating, stop all running SAPPHIRE services to prevent conflicts during the update.
 
-- [ ] **Stop the Luigi daemon and pipeline services**
+> **Project-name discipline**: the Luigi daemon container is started with `COMPOSE_PROJECT_NAME=sapphire` (see §3.1). Without `-p sapphire`, `docker compose down` derives the project name from `basename $PWD` (= `sapphire_forecast_tools`), which **does not match** and silently leaves `luigi-daemon` running. Always pass `-p sapphire` on the down command, or export `COMPOSE_PROJECT_NAME=sapphire` before invoking compose.
+
+- [ ] **Stop the Luigi daemon and pipeline services** (project-name-safe)
   ```bash
   cd /data/SAPPHIRE_Forecast_Tools
-  docker compose -f bin/docker-compose-luigi.yml down
+  docker compose -f bin/docker-compose-luigi.yml -p sapphire down
   ```
 
-- [ ] **Stop the forecast dashboards**
+> The dashboard (`sapphire-dashboard`) is part of the microservices stack defined in `sapphire/docker-compose.yml` and stops with it; no separate dashboard stop is required.
+
+- [ ] **Stop the SAPPHIRE microservices stack** (api-gateway, four backend services, four DBs)
   ```bash
-  docker compose -f bin/docker-compose-dashboards.yml down
+  docker compose --env-file ${ENV_FILE_PATH} -f sapphire/docker-compose.yml down
   ```
+  This stops the api-gateway (8000), preprocessing-api (8002), postprocessing-api (8003),
+  user-api (8004), auth-api (8005), and the four Postgres DB containers. Volumes are preserved.
 
 - [ ] **Verify all SAPPHIRE containers are stopped**
   ```bash
@@ -482,6 +280,18 @@ Pull the updated Docker images with the `:local` tag.
 > - **Option A**: Pull images manually now (see below)
 > - **Option B**: Skip manual pull and let the first cron job / manual script run pull the images
 
+**Image inventory — three categories**
+
+The deployment uses three categories of images. **Only the pipeline layer is pulled
+from DockerHub**; the microservices layer is built locally via `sapphire/docker-compose.yml`,
+and the infrastructure layer mixes a locally-built Luigi daemon with the upstream
+`postgres:15` image.
+
+> **Name-collision warning**: the app-side image `mabesa/sapphire-postprocessing` (operational
+> postprocessing wrappers, pulled here) is **different** from the service-side image
+> `sapphire-postprocessing` (FastAPI service, built locally by the microservices compose).
+> They share the suffix `postprocessing` but serve different purposes.
+
 **Set environment variables:**
 
 - [ ] **Export the image tag**
@@ -490,7 +300,11 @@ Pull the updated Docker images with the `:local` tag.
   export ieasyhydroforecast_frontend_docker_image_tag=local
   ```
 
-**Pull core images (required for all deployments):**
+#### 2.4.1 Pipeline images (pulled from DockerHub)
+
+These are the `apps/*` layer images run by Luigi tasks and dashboards.
+
+**Core (required for all deployments):**
 
 - [ ] **Pull base image**
   ```bash
@@ -502,9 +316,14 @@ Pull the updated Docker images with the `:local` tag.
   docker pull mabesa/sapphire-pipeline:local
   ```
 
-- [ ] **Pull preprocessing images**
+- [ ] **Pull preprocessing-runoff image**
   ```bash
   docker pull mabesa/sapphire-preprunoff:local
+  ```
+
+- [ ] **Pull station-forcing preprocessing image** (new since 2026-01-30)
+  ```bash
+  docker pull mabesa/sapphire-preprocessing-station-forcing:local
   ```
 
 - [ ] **Pull linear regression forecasting image**
@@ -512,7 +331,12 @@ Pull the updated Docker images with the `:local` tag.
   docker pull mabesa/sapphire-linreg:local
   ```
 
-- [ ] **Pull postprocessing image**
+- [ ] **Pull long-term forecasting image** (new since 2026-01-30)
+  ```bash
+  docker pull mabesa/sapphire-lt-forecasting:local
+  ```
+
+- [ ] **Pull postprocessing image** (operational app — distinct from the service-side image)
   ```bash
   docker pull mabesa/sapphire-postprocessing:local
   ```
@@ -522,7 +346,7 @@ Pull the updated Docker images with the `:local` tag.
   docker pull mabesa/sapphire-dashboard:local
   ```
 
-**Pull optional images (based on deployment configuration):**
+**Optional (based on deployment configuration):**
 
 If `ieasyhydroforecast_run_ML_models=true` in your .env file:
 
@@ -538,33 +362,43 @@ If `ieasyhydroforecast_run_ML_models=true` in your .env file:
 
 If `ieasyhydroforecast_run_CM_models=true` in your .env file:
 
-- [ ] **Pull conceptual model image** (if used)
+- [ ] **Pull conceptual model image** (rarely used; gated by `ieasyhydroforecast_run_CM_models`)
   ```bash
   docker pull mabesa/sapphire-conceptmod:local
   ```
 
-**Utility images:**
+#### 2.4.2 Microservices images (built locally)
 
-- [ ] **Pull rerun utility image** (for hindcasts/reruns from dashboard)
+The microservices layer is defined in `sapphire/docker-compose.yml` and is **built
+locally** rather than pulled. The services are:
+
+- `sapphire-api-gateway` (port 8000) — built from `sapphire/services/api-gateway/Dockerfile`
+- `sapphire-auth` (port 8005) — built from `sapphire/services/auth/Dockerfile`
+- `sapphire-user` (port 8004) — built from `sapphire/services/user/Dockerfile`
+- `sapphire-preprocessing` (port 8002) — built from `sapphire/services/preprocessing/Dockerfile`
+- `sapphire-postprocessing` (port 8003) — built from `sapphire/services/postprocessing/Dockerfile`
+  (distinct from the app-side `mabesa/sapphire-postprocessing` above)
+
+The `docker compose ... up -d` in §2.5 will build any missing images automatically.
+To force a rebuild after a code update:
+
+- [ ] **Rebuild microservices** (only if Dockerfiles or `requirements.txt` changed)
   ```bash
-  docker pull mabesa/sapphire-rerun:local
+  docker compose --env-file ${ENV_FILE_PATH} -f sapphire/docker-compose.yml build
   ```
 
-**Verify pulled images:**
+#### 2.4.3 Infrastructure images
+
+- `sapphire/luigi-daemon` — built locally from `bin/luigi-daemon.Dockerfile` (see `bin/docker-compose-luigi.yml`).
+- `postgres:15` — upstream image used by the four DB containers (`preprocessing-db`,
+  `postprocessing-db`, `user-db`, `auth-db`). Pulled automatically on first stack bring-up.
+
+#### 2.4.4 Verify pulled images
 
 - [ ] **List all SAPPHIRE images with `local` tag**
   ```bash
   docker images | grep sapphire | grep local
   ```
-
-**Alternative: Use the setup script**
-
-The setup script automatically pulls images based on your .env configuration:
-
-```bash
-cd /data/SAPPHIRE_Forecast_Tools
-bash bin/setup_docker.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm
-```
 
 ---
 
@@ -582,8 +416,8 @@ The server .env and the local repo .env are on different machines, so you need t
   # Replace <server> with your server hostname/alias
   # If you connect via a specific user, use user@<server>
   # If you connect via a specific port, add -P <port>
-  scp <server>:/data/kyg_data_forecast_tools/config/.env_develop_kghm \
-      ~/Downloads/.env_develop_kghm_server
+  scp <server>:${ENV_FILE_PATH} \
+      ~/Downloads/.env_develop_${ORG_SLUG}_server
   ```
 
 #### Step 2: Compare with local repo .env
@@ -591,15 +425,15 @@ The server .env and the local repo .env are on different machines, so you need t
 - [ ] **Compare the two files locally**
   ```bash
   # On your LOCAL machine
-  diff ~/Downloads/.env_develop_kghm_server \
-       /path/to/SAPPHIRE_forecast_tools/apps/config/.env_develop_kghm
+  diff ~/Downloads/.env_develop_${ORG_SLUG}_server \
+       /path/to/SAPPHIRE_forecast_tools/apps/config/.env_develop_${ORG_SLUG}
   ```
 
   Or side-by-side:
   ```bash
   diff -y --suppress-common-lines \
-       ~/Downloads/.env_develop_kghm_server \
-       /path/to/SAPPHIRE_forecast_tools/apps/config/.env_develop_kghm
+       ~/Downloads/.env_develop_${ORG_SLUG}_server \
+       /path/to/SAPPHIRE_forecast_tools/apps/config/.env_develop_${ORG_SLUG}
   ```
 
 #### Step 3: Identify changes needed
@@ -616,7 +450,7 @@ The server .env and the local repo .env are on different machines, so you need t
 | `ieasyhydroforecast_frontend_docker_image_tag` | Frontend image tag | `local` |
 | `ieasyhydroforecast_run_ML_models` | Enable ML forecasting | `true` or `false` |
 | `ieasyhydroforecast_run_CM_models` | Enable conceptual models | `true` or `false` |
-| `ieasyhydroforecast_organization` | Organization identifier | e.g., `kghm` |
+| `ieasyhydroforecast_organization` | Organization identifier | `${ORG_SLUG}` |
 
 **Variables to preserve** (don't overwrite with repo values):
 - `IEASYHYDRO_HOST` - Server-specific API endpoint
@@ -628,12 +462,12 @@ The server .env and the local repo .env are on different machines, so you need t
 
 - [ ] **Make a working copy**
   ```bash
-  cp ~/Downloads/.env_develop_kghm_server ~/Downloads/.env_develop_kghm_updated
+  cp ~/Downloads/.env_develop_${ORG_SLUG}_server ~/Downloads/.env_develop_${ORG_SLUG}_updated
   ```
 
 - [ ] **Edit the file locally** (use your preferred editor)
   ```bash
-  code ~/Downloads/.env_develop_kghm_updated
+  code ~/Downloads/.env_develop_${ORG_SLUG}_updated
   # Or: nano, vim, etc.
   ```
 
@@ -646,14 +480,14 @@ The server .env and the local repo .env are on different machines, so you need t
 - [ ] **Copy updated .env to server via scp**
   ```bash
   # From your LOCAL machine
-  scp ~/Downloads/.env_develop_kghm_updated \
-      <server>:/data/kyg_data_forecast_tools/config/.env_develop_kghm
+  scp ~/Downloads/.env_develop_${ORG_SLUG}_updated \
+      <server>:${ENV_FILE_PATH}
   ```
 
 - [ ] **Verify on server**
   ```bash
   # On the SERVER
-  grep -E "docker_image_tag" /data/kyg_data_forecast_tools/config/.env_develop_kghm
+  grep -E "docker_image_tag" ${ENV_FILE_PATH}
   ```
   Expected output:
   ```
@@ -663,9 +497,109 @@ The server .env and the local repo .env are on different machines, so you need t
 
 - [ ] **Validate syntax on server** (no trailing spaces, proper quoting)
   ```bash
-  grep -n "= " /data/kyg_data_forecast_tools/config/.env_develop_kghm  # Spaces after =
-  grep -n " $" /data/kyg_data_forecast_tools/config/.env_develop_kghm  # Trailing spaces
+  grep -n "= " ${ENV_FILE_PATH}  # Spaces after =
+  grep -n " $" ${ENV_FILE_PATH}  # Trailing spaces
   ```
+
+---
+
+### 2.4.5 Bring up SAPPHIRE microservices stack
+
+**Why this step matters:** the cron scripts (`bin/run_pentadal_forecasts.sh`,
+`bin/run_decadal_forecasts.sh`, `bin/run_preprocessing_gateway.sh`, etc.) and the
+Luigi pipeline tasks read and write through the api-gateway at
+`http://localhost:8000`. Without the microservices stack up, every cron command
+in §2.6 fails immediately with `Connection refused` to `SAPPHIRE_API_URL` /
+`API_GATEWAY_URL`. The dashboards also depend on the api-gateway.
+
+The stack is defined in `sapphire/docker-compose.yml` and includes:
+
+| Service | Host port | Container name |
+|---------|-----------|----------------|
+| `api-gateway` | 8000 | `sapphire-api-gateway` |
+| `preprocessing-api` | 8002 | `sapphire-preprocessing-api` |
+| `postprocessing-api` | 8003 | `sapphire-postprocessing-api` |
+| `user-api` | 8004 | `sapphire-user-api` |
+| `auth-api` | 8005 | `sapphire-auth-api` |
+| `preprocessing-db` (postgres:15) | 5433 | `sapphire-preprocessing-db` |
+| `postprocessing-db` (postgres:15) | 5434 | `sapphire-postprocessing-db` |
+| `user-db` (postgres:15) | 5435 | `sapphire-user-db` |
+| `auth-db` (postgres:15) | 5436 | `sapphire-auth-db` |
+
+> **First-time deploy?** If this is the initial deployment on this server, also
+> follow `doc/prod/first_deploy_checklist.md` — that doc covers initial schema
+> preparation (alembic stamp) and the one-time `RunInitializeWorkflow` task that
+> bootstraps the preprocessing DB with historical site data. For routine updates,
+> the schema is already populated.
+
+- [ ] **Start the microservices stack**
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools
+  docker compose --env-file ${ENV_FILE_PATH} -f sapphire/docker-compose.yml up -d
+  ```
+  Alternatively, the wrapper `bin/restart_sapphire_stack.sh ${ENV_FILE_PATH}` performs
+  the same bring-up.
+
+- [ ] **Wait for the api-gateway to be live and ready**
+  ```bash
+  # Liveness: returns 200 as soon as the gateway process is up
+  curl -sf http://localhost:8000/health && echo "PASS: gateway live"
+
+  # Readiness: gateway-side health check that also probes the four backend services
+  curl -sf http://localhost:8000/health/ready && echo "PASS: gateway ready"
+  ```
+  Wait up to 60 s for `/health/ready` to return 200. If it does not, run
+  `docker compose --env-file ${ENV_FILE_PATH} -f sapphire/docker-compose.yml ps`
+  and check `docker logs sapphire-<service>-api` for the unhealthy service.
+
+- [ ] **Verify all nine service+DB containers are running**
+  ```bash
+  docker ps --filter "name=sapphire-" --format "table {{.Names}}\t{{.Status}}"
+  ```
+
+---
+
+### 2.4.6 Apply schema migrations
+
+The preprocessing and postprocessing services use **Alembic** for schema management.
+Pulling new images without applying outstanding migrations can leave the DB schema
+behind the code — for example, the snow-stat write path requires migration
+`9f1e72108f01` (preprocessing) which adds 12 columns to the `snow` table.
+
+> **Baseline revisions** (for reference / rollback): preprocessing baseline is
+> `a6210b339f17`; postprocessing baseline is `34b227f37299`. The latest preprocessing
+> migration is `9f1e72108f01` (snow stat columns).
+
+- [ ] **Record current revisions** (for rollback)
+  ```bash
+  docker exec sapphire-preprocessing-api alembic current  | tee -a "$BACKUP_DIR/alembic_pre_update.txt"
+  docker exec sapphire-postprocessing-api alembic current | tee -a "$BACKUP_DIR/alembic_pre_update.txt"
+  ```
+  Capture the output in your backup directory (`$BACKUP_DIR` from §1.5). You will
+  need these revision hashes if a rollback (§5) requires `alembic downgrade`.
+
+- [ ] **Apply preprocessing migrations**
+  ```bash
+  docker exec sapphire-preprocessing-api alembic upgrade head
+  ```
+  This brings the preprocessing schema forward to `9f1e72108f01` if not already
+  there. The migration adds the 12 nullable snow-stat columns required for the
+  snow dashboard write path.
+
+- [ ] **Apply postprocessing migrations**
+  ```bash
+  docker exec sapphire-postprocessing-api alembic upgrade head
+  ```
+
+- [ ] **Confirm new revisions**
+  ```bash
+  docker exec sapphire-preprocessing-api alembic current
+  docker exec sapphire-postprocessing-api alembic current
+  ```
+
+> **Note on user/auth services**: both have alembic scaffolding but no
+> non-baseline migrations today. They self-stamp on first boot and require no
+> manual action during routine updates.
 
 ---
 
@@ -675,7 +609,9 @@ Update the cron schedule for automated forecast runs.
 
 > **Note**: The cron scripts handle Docker image pulling automatically. Once crontabs are configured, the first scheduled run will pull the required images.
 
-> **Important**: Adapt paths for your server. Replace `/home/ubuntu` with your user's home directory (e.g., `/home/sapphire`).
+> **First-time deploy on this server?** Cron installation is covered end-to-end (with backup of any prior crontab, log-dir creation, and the same canonical block as below) in `doc/prod/first_deploy_checklist.md` §12 "Install operational cron schedule". This §2.5 covers cron *updates* on an existing deployment — diffing the running crontab against the canonical block, removing retired entries, and adding new ones introduced since the last update.
+
+The canonical schedule below follows the post-S1-2026 consolidated Luigi-wrapper pattern (one `bin/run_daily_maintenance.sh` for daily maintenance, `bin/run_periodic_maintenance.sh <task>` for bimonthly/yearly tasks). It supersedes the legacy per-app `daily_*` scripts (`daily_preprunoff_maintenance.sh`, `daily_ml_maintenance.sh`, `daily_linreg_maintenance.sh`, `daily_postprc_maintenance.sh`, `daily_gateway_maintenance.sh`, `daily_update_sapphire_frontend.sh`). Those legacy scripts remain on origin for manual debugging only — do **not** schedule them via cron.
 
 - [ ] **Backup current crontab** (if not done in pre-update)
   ```bash
@@ -684,7 +620,14 @@ Update the cron schedule for automated forecast runs.
 
 - [ ] **Review the recommended crontab schedule**
 
-  The full recommended schedule is documented in [deployment.md - Set up cron job](../deployment.md#set-up-cron-job).
+  The authoritative source is [deployment.md - Set up cron job](../deployment.md#set-up-cron-job). The block reproduced below is kept in sync with that source.
+
+- [ ] **Diff the running crontab against the canonical block**
+  ```bash
+  crontab -l > /tmp/crontab_current.txt
+  diff /tmp/crontab_current.txt <(sed -n '/# m h  dom mon dow/,/^```$/p' "$(pwd)/doc/prod/update_deployment_checklist.md")
+  ```
+  Identify legacy entries to remove and new entries to add. The most common change since v0.3.0 is replacing four separate `daily_*_maintenance.sh` lines with one `run_daily_maintenance.sh` line.
 
 - [ ] **Edit crontab**
   ```bash
@@ -693,37 +636,75 @@ Update the cron schedule for automated forecast runs.
 
 - [ ] **Verify/update the following cron entries:**
 
+  > **Cron does not expand shell variables.** The `${...}` placeholders below are for readability — when you paste these into `crontab -e`, substitute the literal values of `${ENV_FILE_PATH}` and `${LOG_DIR}` (as set in the operator placeholder block at the top of this doc) into each line.
+
   ```bash
   # m h  dom mon dow   command
   # ---------------------------------------------------------------------------
   # SAPPHIRE Forecast Tools Schedule (Times are in UTC)
-  # Adapt /home/ubuntu to your server's user home directory
+  # Cron does not expand shell variables. Before pasting, substitute the
+  # literal values of ${ENV_FILE_PATH} and ${LOG_DIR} (see Operator setup at
+  # the top of this doc).
   # ---------------------------------------------------------------------------
 
-  # Log cleanup: delete logs older than 7 days
-  0 2 * * * find /home/ubuntu/logs -name "sapphire_*.log" -mtime +7 -delete
+  # Log cleanup: delete logs older than 7 days (runs daily at 02:00 UTC)
+  0 2 * * * find ${LOG_DIR} -name "sapphire_*.log" -mtime +7 -delete
 
-  # (1) Gateway Preprocessing at 03:00 UTC
-  0 3 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_preprocessing_gateway.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_gateway_preprocessing_$(date +\%Y\%m\%d).log 2>&1
+  # Daily DB backup at 01:00 UTC (pg_dump-based, 30-day retention)
+  0 1 * * * bash /data/SAPPHIRE_Forecast_Tools/bin/backup_sapphire_db.sh -d /var/backups/sapphire -r 30 >> ${LOG_DIR}/sapphire_db_backup_$(date +\%Y\%m\%d).log 2>&1
 
-  # (2) Pentadal Forecast at 04:00 UTC
-  0 4 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_pentadal_forecasts.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_pentadal_forecast_$(date +\%Y\%m\%d).log 2>&1
+  # (1) Gateway Preprocessing at 03:00 UTC. Independent of daily data.
+  0 3 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_preprocessing_gateway.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_gateway_preprocessing_$(date +\%Y\%m\%d).log 2>&1
 
-  # (3) Decadal Forecast at 05:00 UTC
-  0 5 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_decadal_forecasts.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_decadal_forecast_$(date +\%Y\%m\%d).log 2>&1
+  # (2) Pentadal Forecast at 04:00 UTC. Luigi triggers runoff preprocessing.
+  0 4 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_pentadal_forecasts.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_pentadal_forecast_$(date +\%Y\%m\%d).log 2>&1
 
-  # (4) Maintenance jobs (evening UTC)
-  # Frontend update
-  2 19 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/daily_update_sapphire_frontend.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_frontend_$(date +\%Y\%m\%d).log 2>&1
+  # (3) Decadal Forecast at 05:00 UTC.
+  0 5 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_decadal_forecasts.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_decadal_forecast_$(date +\%Y\%m\%d).log 2>&1
 
-  # Preprocessing runoff maintenance (gap filling)
-  4 19 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/daily_preprunoff_maintenance.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_preprunoff_maintenance_$(date +\%Y\%m\%d).log 2>&1
+  # (4) Long-Term Forecast at 06:00 UTC on the 10th and 25th of each month.
+  # The script self-gates via lt_schedule_query.py (only fires on predefined
+  # operational forecast dates with ±5 day tolerance), so daily * * * is also
+  # safe but wasteful. The 10th/25th schedule matches operational expectations.
+  0 6 10,25 * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_long_term_forecasts.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_long_term_$(date +\%Y\%m\%d).log 2>&1
 
-  # ML model maintenance (hindcast catch-up)
-  0 20 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/daily_ml_maintenance.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_ml_maintenance_$(date +\%Y\%m\%d).log 2>&1
+  # (4b) Bimonthly long-term skill metrics recalculation at 10:00 UTC on the
+  # 10th and 25th (4 hours after the long-term forecast). Refreshes MONTHLY,
+  # QUARTERLY, and SEASONAL skill metrics so long-term skill tiles on the
+  # dashboard do not stay stale for a year. Log-and-continue: one failing
+  # mode does not block the others, but the job exits non-zero so errors
+  # still surface in the cron log.
+  0 10 10,25 * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/bimonthly_long_term_skill_metrics_recalculation.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_bimonthly_lt_skill_recalc_$(date +\%Y\%m\%d).log 2>&1
 
-  # Linear regression maintenance (hindcast catch-up)
-  34 20 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/daily_linreg_maintenance.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_linreg_maintenance_$(date +\%Y\%m\%d).log 2>&1
+  # (5) Daily Maintenance at 19:00 UTC (consolidated; replaces legacy
+  # daily_preprunoff_maintenance.sh / daily_ml_maintenance.sh /
+  # daily_linreg_maintenance.sh / daily_postprc_maintenance.sh /
+  # daily_gateway_maintenance.sh / daily_update_sapphire_frontend.sh).
+  # Luigi enforces dependency order: PrepRunoff + Gateway → LinReg → ML →
+  # PostProcessing → Frontend. ML concurrency limited to 3 via Luigi resources.
+  0 19 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_daily_maintenance.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_daily_maintenance_$(date +\%Y\%m\%d).log 2>&1
+
+  # (6) Periodic maintenance tasks (consolidated Luigi wrapper)
+  # Bimonthly long-term postprocessing at 22:00 UTC on the 1st of odd months.
+  # Supersedes the legacy bin/bimonthly_long_term_postprocessing.sh standalone
+  # wrapper (kept on origin for manual / debugging use only).
+  0 22 1 1,3,5,7,9,11 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh long_term ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_lt_postproc_$(date +\%Y\%m\%d).log 2>&1
+
+  # (7) Yearly skill metrics recalculation at 01:00 UTC on December 31.
+  # Full-history safety net (the bimonthly skill recalc above keeps the
+  # dashboard tiles fresh; this is the annual deep recalc).
+  0 1 31 12 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_yearly_skill_recalc_$(date +\%Y\%m\%d).log 2>&1
+
+  # (8) Yearly snow norm/stat recalculation at 02:00 UTC on August 31.
+  # Consolidated Luigi wrapper. Supersedes legacy bin/yearly_snow_norm_recalculation.sh
+  # (kept on origin for manual / debugging use only).
+  0 2 31 8 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_yearly_snow_norm_$(date +\%Y\%m\%d).log 2>&1
+
+  # (9) Yearly runoff hydrograph aggregation at 03:00 UTC on January 1.
+  # Replaces the retired YearlyMonthlyNormsRecalculation Luigi task. Builds
+  # the long-horizon monthly + April–September seasonal hydrograph view used
+  # by the dashboard.
+  0 3 1 1 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/yearly_runoff_hydrograph_aggregation.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_yearly_runoff_hydrograph_$(date +\%Y\%m\%d).log 2>&1
   ```
 
 - [ ] **Verify crontab was saved correctly**
@@ -733,8 +714,8 @@ Update the cron schedule for automated forecast runs.
 
 - [ ] **Ensure log directory exists**
   ```bash
-  mkdir -p /home/ubuntu/logs
-  ls -la /home/ubuntu/logs/
+  mkdir -p ${LOG_DIR}
+  ls -la ${LOG_DIR}/
   ```
 
 - [ ] **Verify cron service is running**
@@ -742,31 +723,78 @@ Update the cron schedule for automated forecast runs.
   sudo systemctl status cron
   ```
 
+- [ ] **Verify backup target directory exists and is writable** (for the daily DB backup at 01:00 UTC)
+  ```bash
+  sudo mkdir -p /var/backups/sapphire
+  sudo chown $(whoami): /var/backups/sapphire
+  ls -ld /var/backups/sapphire
+  ```
+
 ### 2.6 Test Cron Commands Manually
 
-After updating crontabs, run each cron command manually (one by one) to verify they work correctly before waiting for scheduled execution. The Luigi daemon starts automatically when needed.
+> **Prerequisite — the SAPPHIRE microservices stack must be up before any
+> cron command below will succeed.** Every cron command reads/writes through
+> the api-gateway at `http://localhost:8000`; without the stack up, each
+> command fails immediately with `Connection refused`. If you have not
+> already brought the stack up in §2.4.5, do so now:
+> ```bash
+> docker compose --env-file ${ENV_FILE_PATH} -f sapphire/docker-compose.yml up -d
+> # or, equivalently:
+> bash bin/restart_sapphire_stack.sh ${ENV_FILE_PATH}
+> ```
+> Verify before proceeding:
+> ```bash
+> curl -sf http://localhost:8000/health/ready && echo "READY"
+> ```
+
+After updating crontabs, run each cron command manually (one by one) to verify they work correctly before waiting for scheduled execution. The Luigi daemon starts automatically when needed. The list below mirrors the canonical cron block in §2.5 — run each once to confirm the wrapper script, env file, and microservices stack agree.
+
+- [ ] **Run database backup**
+  ```bash
+  bash /data/SAPPHIRE_Forecast_Tools/bin/backup_sapphire_db.sh -d /var/backups/sapphire -r 30
+  ```
 
 - [ ] **Run gateway preprocessing**
   ```bash
-  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_preprocessing_gateway.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_preprocessing_gateway.sh ${ENV_FILE_PATH}
   ```
 
 - [ ] **Run pentadal forecast**
   ```bash
-  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_pentadal_forecasts.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_pentadal_forecasts.sh ${ENV_FILE_PATH}
   ```
 
 - [ ] **Run decadal forecast**
   ```bash
-  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_decadal_forecasts.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_decadal_forecasts.sh ${ENV_FILE_PATH}
   ```
 
-- [ ] **Run maintenance jobs** (optional - run if time permits)
+- [ ] **Run long-term forecast** (self-gates on schedule; safe to run any day for the dry-run path)
   ```bash
-  cd /data/SAPPHIRE_Forecast_Tools && bash bin/daily_update_sapphire_frontend.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm
-  cd /data/SAPPHIRE_Forecast_Tools && bash bin/daily_preprunoff_maintenance.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm
-  cd /data/SAPPHIRE_Forecast_Tools && bash bin/daily_ml_maintenance.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm
-  cd /data/SAPPHIRE_Forecast_Tools && bash bin/daily_linreg_maintenance.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_long_term_forecasts.sh --dry-run ${ENV_FILE_PATH}
+  ```
+  Drop `--dry-run` once the dry-run succeeds to exercise the full pipeline on a real forecast date.
+
+- [ ] **Run consolidated daily maintenance** (replaces the four legacy `daily_*_maintenance.sh` wrappers)
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_daily_maintenance.sh ${ENV_FILE_PATH}
+  ```
+
+- [ ] **Run periodic maintenance tasks** (one per task type; run only the ones relevant to the current calendar)
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh long_term     ${ENV_FILE_PATH}
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc  ${ENV_FILE_PATH}
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms    ${ENV_FILE_PATH}
+  ```
+
+- [ ] **Run bimonthly long-term skill metrics recalculation**
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/bimonthly_long_term_skill_metrics_recalculation.sh ${ENV_FILE_PATH}
+  ```
+
+- [ ] **Run yearly runoff hydrograph aggregation**
+  ```bash
+  cd /data/SAPPHIRE_Forecast_Tools && bash bin/yearly_runoff_hydrograph_aggregation.sh ${ENV_FILE_PATH}
   ```
 
 - [ ] **Monitor progress** in Luigi UI at http://localhost:8082
@@ -780,7 +808,18 @@ After updating crontabs, run each cron command manually (one by one) to verify t
 
 Start the services in the correct order to ensure proper initialization.
 
-#### Start Luigi Daemon (First)
+**Order:** microservices stack (already started in §2.4.5) → Luigi daemon → dashboards.
+
+#### Verify SAPPHIRE microservices stack is up (already started in §2.4.5)
+
+- [ ] Confirm the api-gateway and four backend services are healthy:
+  ```bash
+  curl -sf http://localhost:8000/health/ready && echo "PASS: gateway ready"
+  docker ps --filter "name=sapphire-" --format "table {{.Names}}\t{{.Status}}"
+  ```
+  If the stack is not running, return to §2.4.5 and start it before proceeding.
+
+#### Start Luigi Daemon
 
 The Luigi daemon must be running before any pipeline tasks can execute.
 
@@ -805,12 +844,9 @@ The Luigi daemon must be running before any pipeline tasks can execute.
   echo "Luigi daemon is ready"
   ```
 
-#### Start Dashboards (Second)
+#### Dashboard
 
-- [ ] Start the pentad and decad dashboards:
-  ```bash
-  docker compose -f bin/docker-compose-dashboards.yml --env-file /data/kyg_data_forecast_tools/config/.env_develop_kghm up -d
-  ```
+The `sapphire-dashboard` container is part of the microservices stack and was already started by §2.4.5; no separate dashboard start step is required.
 
 #### Verify Services Started
 
@@ -819,12 +855,40 @@ The Luigi daemon must be running before any pipeline tasks can execute.
   docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
   ```
 
-Expected output should show:
+Expected output should include the microservices (`sapphire-api-gateway`,
+`sapphire-preprocessing-api`, `sapphire-postprocessing-api`, `sapphire-user-api`,
+`sapphire-auth-api`, plus four `sapphire-*-db` containers) and:
 - `sapphire-luigi-daemon` (or similar) - Up, port 8082
-- `sapphire-frontend-forecast-pentad` - Up, port 5006
-- `sapphire-frontend-forecast-decad` - Up, port 5007
+- `sapphire-dashboard` - Up, port 5006
 
 ### 3.2 Verify Services Running
+
+#### Post-deploy probe suite
+
+Run the full probe suite below. All commands should return HTTP 200 within 5 s.
+
+```bash
+# API gateway readiness (gates backend services)
+curl -sf http://localhost:8000/health
+curl -sf http://localhost:8000/health/ready
+
+# Backend service health
+curl -sf http://localhost:8002/health    # preprocessing-api
+curl -sf http://localhost:8003/health    # postprocessing-api
+curl -sf http://localhost:8004/health    # user-api
+curl -sf http://localhost:8005/health    # auth-api
+
+# Luigi UI
+curl -sf http://localhost:8082/
+
+# Dashboards
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5006/forecast_dashboard
+```
+
+Acceptance: all `curl -sf` commands exit 0; the dashboard probe returns `200`.
+If `/health/ready` fails (200 from `/health` but failure from `/health/ready`),
+one or more backend services did not start correctly — inspect
+`docker logs sapphire-<service>-api`.
 
 #### Check Luigi UI
 
@@ -834,9 +898,33 @@ Expected output should show:
 
 #### Check Dashboards
 
-- [ ] Pentad dashboard accessible: `http://<your-server-ip>:5006/forecast_dashboard`
-- [ ] Decad dashboard accessible: `http://<your-server-ip>:5007/forecast_dashboard`
-- [ ] Both dashboards load data correctly (charts display, station selector works)
+- [ ] Dashboard accessible: `http://<your-server-ip>:5006/forecast_dashboard`
+- [ ] Dashboard loads data correctly (charts display, station selector works)
+
+#### Troubleshooting — dashboard cannot reach iEH HF via SSH tunnel
+
+> **If dashboard logs show `iEHHF not available ... Connection refused` on the
+> `/api/v1/auth/token-obtain` path:** the dashboard container is on a Docker bridge
+> network and cannot reach the host SSH tunnel on `localhost:<port>`. The fix is
+> `network_mode: host` on the dashboard service in `sapphire/docker-compose.yml`
+> (and in `bin/docker-compose-dashboards.yml` if used).
+>
+> See `doc/prod/first_deploy_checklist.md` §1.2 Option B / Option C "Dashboard
+> tunnel reachability" for the full procedure. Per memory note
+> `iehhf_tunnel_docker_bridge_fix.md`, this fix is currently applied server-side
+> only on Tajik and is **not** in the committed compose files; expect to apply
+> it on any deployment where iEH HF is reached via SSH tunnel.
+
+Diagnostic commands:
+```bash
+# Confirm the SSH tunnel is listening on the host
+ss -tlnp | grep <tunnel-port>
+
+# From inside the dashboard container, try to reach the tunnel
+docker exec sapphire-dashboard curl -sf http://localhost:<tunnel-port>/api/v1/
+```
+If the host probe succeeds but the container probe returns `Connection refused`,
+apply the `network_mode: host` fix.
 
 #### Check Container Health
 
@@ -860,10 +948,16 @@ Expected output should show:
   docker logs sapphire-luigi-daemon --tail 50
   ```
 
+- [ ] Review microservices logs:
+  ```bash
+  docker logs sapphire-api-gateway --tail 50
+  docker logs sapphire-preprocessing-api --tail 50
+  docker logs sapphire-postprocessing-api --tail 50
+  ```
+
 - [ ] Review dashboard logs for startup errors:
   ```bash
-  docker logs sapphire-frontend-forecast-pentad --tail 50
-  docker logs sapphire-frontend-forecast-decad --tail 50
+  docker logs sapphire-dashboard --tail 50
   ```
 
 ### 3.3 Test Forecast Run
@@ -877,13 +971,13 @@ This is a lightweight test that verifies the pipeline infrastructure:
 - [ ] Run preprocessing gateway task:
   ```bash
   cd /data/SAPPHIRE_Forecast_Tools
-  bash bin/run_preprocessing_gateway.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm
+  bash bin/run_preprocessing_gateway.sh ${ENV_FILE_PATH}
   ```
 
 - [ ] Monitor progress in Luigi UI at http://localhost:8082
 - [ ] Check logs for successful completion:
   ```bash
-  tail -f /home/ubuntu/logs/sapphire_gateway_$(date +%Y%m%d).log
+  tail -f ${LOG_DIR}/sapphire_gateway_$(date +%Y%m%d).log
   ```
 
 #### Full Test - Run Pentadal Forecast (Optional)
@@ -893,7 +987,7 @@ For a comprehensive test, run a full pentadal forecast cycle:
 - [ ] Run pentadal forecast:
   ```bash
   cd /data/SAPPHIRE_Forecast_Tools
-  bash bin/run_pentadal_forecasts.sh /data/kyg_data_forecast_tools/config/.env_develop_kghm >> /home/ubuntu/logs/sapphire_pentadal_$(date +%Y%m%d).log 2>&1
+  bash bin/run_pentadal_forecasts.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_pentadal_$(date +%Y%m%d).log 2>&1
   ```
 
 - [ ] Monitor progress in Luigi UI
@@ -903,7 +997,7 @@ For a comprehensive test, run a full pentadal forecast cycle:
 
 - [ ] Check that no ERROR or CRITICAL messages appear in logs:
   ```bash
-  grep -iE "error|critical|exception" /home/ubuntu/logs/sapphire_*.log | tail -20
+  grep -iE "error|critical|exception" ${LOG_DIR}/sapphire_*.log | tail -20
   ```
 
 - [ ] Verify tasks completed successfully in Luigi UI (all tasks show green checkmarks)
@@ -967,21 +1061,21 @@ Clean up old log files to prevent disk space issues.
 
 ### 4.1 Clean Up Pipeline Logs
 
-Log files are stored in `/home/ubuntu/logs/`
+Log files are stored in `${LOG_DIR}/`
 
 - [ ] View current log files and sizes:
   ```bash
-  ls -lh /home/ubuntu/logs/sapphire_*.log
+  ls -lh ${LOG_DIR}/sapphire_*.log
   ```
 
 - [ ] Delete logs older than 7 days:
   ```bash
-  find /home/ubuntu/logs -name "sapphire_*.log" -mtime +7 -delete
+  find ${LOG_DIR} -name "sapphire_*.log" -mtime +7 -delete
   ```
 
 - [ ] Verify cleanup (check remaining files):
   ```bash
-  ls -lh /home/ubuntu/logs/
+  ls -lh ${LOG_DIR}/
   ```
 
 ### 4.2 Clean Up Docker Logs (Optional)
@@ -990,12 +1084,12 @@ Docker container logs can also grow large over time.
 
 - [ ] Check intermediate_data/docker_logs if it exists:
   ```bash
-  ls -lh /data/kyg_data_forecast_tools/intermediate_data/docker_logs/ 2>/dev/null || echo "Directory does not exist"
+  ls -lh ${DATA_DIR}/intermediate_data/docker_logs/ 2>/dev/null || echo "Directory does not exist"
   ```
 
 - [ ] Clean up old Docker logs (if directory exists):
   ```bash
-  find /data/kyg_data_forecast_tools/intermediate_data/docker_logs -name "*.log" -mtime +7 -delete 2>/dev/null
+  find ${DATA_DIR}/intermediate_data/docker_logs -name "*.log" -mtime +7 -delete 2>/dev/null
   ```
 
 ### 4.3 Prune Docker System (Optional)
@@ -1016,15 +1110,21 @@ Remove unused Docker resources:
 
 ## 5. ROLLBACK PROCEDURE
 
-If the update causes issues, follow these steps to revert.
+If the update causes issues, follow these steps to revert. The forward path had four
+state-changing actions: image pull (§2.4), `.env` edit (§2.3), `alembic upgrade head`
+(§2.4.6), and Luigi marker file updates (implicit, via runs). Rollback must reverse
+each in the opposite order: stop services → restore `.env` → downgrade schema (if
+upgraded forward) → restore Luigi markers → restart with previous image tag.
 
 ### 5.1 Stop Current Services
 
-- [ ] Stop all SAPPHIRE services:
+- [ ] Stop all SAPPHIRE services (project-name-safe `down` on the Luigi compose):
   ```bash
-  docker compose -f bin/docker-compose-dashboards.yml down
-  docker compose -f bin/docker-compose-luigi.yml down
+  docker compose -f bin/docker-compose-luigi.yml -p sapphire down
+  docker compose --env-file ${ENV_FILE_PATH} -f sapphire/docker-compose.yml down
   ```
+  Without `-p sapphire` on the Luigi compose, the persistent `luigi-daemon` container
+  is silently missed (see §2.1 note). The dashboard stops with the microservices stack.
 
 ### 5.2 Restore Previous Docker Images
 
@@ -1043,9 +1143,9 @@ If the update causes issues, follow these steps to revert.
 
 If you backed up your .env file before the update:
 
-- [ ] Restore the backup (use your backup directory from Section 1.4):
+- [ ] Restore the backup (use your `$BACKUP_DIR` from §1.5):
   ```bash
-  cp /home/ubuntu/backups/sapphire_<timestamp>/.env_develop_kghm /data/kyg_data_forecast_tools/config/.env_develop_kghm
+  cp ${BACKUP_DIR}/.env_develop_${ORG_SLUG} ${ENV_FILE_PATH}
   ```
 
 ### 5.4 Update Image Tags
@@ -1057,7 +1157,71 @@ If you backed up your .env file before the update:
   ieasyhydroforecast_frontend_docker_image_tag=<previous-tag>
   ```
 
-### 5.5 Restart Services with Previous Version
+### 5.5 Restore database state
+
+Apply this section only if the forward path included `alembic upgrade head` (§2.4.6)
+or if data was corrupted by the update. Skip the schema-downgrade step if alembic
+was not run forward.
+
+#### 5.5.1 Restore from `pg_dump` (only if data corruption is suspected)
+
+The four Postgres DBs were backed up in §1.5 via `bin/backup_sapphire_db.sh` to
+`/var/backups/sapphire/pre_update_<timestamp>/`. Restore from those dumps using
+`bin/reset_sapphire_db.sh` — see `bash bin/reset_sapphire_db.sh --help` for flags.
+
+> **Caution**: `bin/reset_sapphire_db.sh` is destructive (drops and recreates
+> volumes). Run only when data corruption is confirmed; for schema-only rollback,
+> prefer `alembic downgrade` in 5.5.2 below.
+
+#### 5.5.2 Downgrade schema with alembic
+
+Use the revisions you recorded in `$BACKUP_DIR/alembic_pre_update.txt` (§2.4.6).
+Bring the microservices stack up briefly to run the downgrade:
+
+- [ ] Start the microservices stack (needed so `alembic` can connect to its DB):
+  ```bash
+  docker compose --env-file ${ENV_FILE_PATH} -f sapphire/docker-compose.yml up -d
+  curl -sf http://localhost:8000/health/ready && echo "READY"
+  ```
+
+- [ ] Downgrade preprocessing (replace `<captured-revision>` with the value from
+  `$BACKUP_DIR/alembic_pre_update.txt`):
+  ```bash
+  docker exec sapphire-preprocessing-api alembic downgrade <captured-revision>
+  ```
+
+- [ ] Downgrade postprocessing (same pattern):
+  ```bash
+  docker exec sapphire-postprocessing-api alembic downgrade <captured-revision>
+  ```
+
+> **Note**: downgrading preprocessing past `9f1e72108f01` drops 12 snow-stat
+> columns (`count`, `mean`, `std`, `min`, `max`, `q05`, `q25`, `q50`, `q75`,
+> `q95`, `previous`, `current`). No historical runoff data is lost, but the snow
+> dashboard write path will silently null out stat fields until the schema is
+> re-upgraded.
+
+### 5.6 Restore Luigi marker files
+
+If the rolled-back image expects an earlier marker state, restore from backup. If
+markers are not restored, tasks may silently short-circuit on stale completion
+markers from the failed forward run.
+
+- [ ] Restore markers from `$BACKUP_DIR/luigi_markers/`:
+  ```bash
+  cp ${BACKUP_DIR}/luigi_markers/*.marker ${DATA_DIR}/intermediate_data/luigi_markers/
+  ```
+
+### 5.7 Restart Services with Previous Version
+
+The microservices stack may still be up from §5.5.2; only Luigi and dashboards
+need to be (re)started.
+
+- [ ] Confirm microservices stack is running:
+  ```bash
+  curl -sf http://localhost:8000/health/ready && echo "READY"
+  ```
+  If not running, start it: `docker compose --env-file ${ENV_FILE_PATH} -f sapphire/docker-compose.yml up -d`.
 
 - [ ] Start Luigi daemon:
   ```bash
@@ -1071,12 +1235,10 @@ If you backed up your .env file before the update:
   until curl -fsS http://localhost:8082/ >/dev/null; do sleep 2; done
   ```
 
-- [ ] Start dashboards:
-  ```bash
-  docker compose -f bin/docker-compose-dashboards.yml --env-file /data/kyg_data_forecast_tools/config/.env_develop_kghm up -d
-  ```
+The dashboard was restarted as part of the microservices stack `up -d` above; no separate dashboard start is required.
 
-- [ ] Verify rollback was successful (repeat Section 3.2 verification steps)
+- [ ] Verify rollback was successful (repeat Section 3.2 verification steps,
+  including the probe suite and the four backend-service health checks)
 
 ---
 
@@ -1087,8 +1249,7 @@ Complete this summary checklist before considering the update complete.
 ### Services Running
 
 - [ ] Luigi daemon is running and accessible at port 8082
-- [ ] Pentad dashboard is running and accessible at port 5006
-- [ ] Decad dashboard is running and accessible at port 5007
+- [ ] Dashboard is running and accessible at port 5006
 - [ ] All containers show "healthy" status
 
 ### Crontabs Configured
@@ -1126,114 +1287,9 @@ Complete this summary checklist before considering the update complete.
 - [ ] Test email alerts are working (optional):
   ```bash
   # Trigger a test by temporarily stopping a dashboard
-  docker stop sapphire-frontend-forecast-pentad
+  docker stop sapphire-dashboard
   # Wait for alert, then restart
-  docker start sapphire-frontend-forecast-pentad
-  ```
-
----
-
-## 7. SERVER OS UPDATES (Periodic Maintenance)
-
-Periodically update the server operating system for security patches and stability.
-
-### 7.1 Pre-Update Checks
-
-- [ ] Check disk space (updates need space):
-  ```bash
-  df -h
-  ```
-  Ensure at least 2GB free on `/` and `/var`
-
-- [ ] Note current kernel version (for rollback reference):
-  ```bash
-  uname -r
-  ```
-
-- [ ] Check for held packages:
-  ```bash
-  apt-mark showhold
-  ```
-
-- [ ] Optionally stop SAPPHIRE services before reboot:
-  ```bash
-  cd /data/SAPPHIRE_Forecast_Tools
-  docker compose -f bin/docker-compose-dashboards.yml down
-  docker compose -f bin/docker-compose-luigi.yml down
-  ```
-
-### 7.2 Update Server
-
-- [ ] Update package lists:
-  ```bash
-  sudo apt update
-  ```
-
-- [ ] Upgrade installed packages:
-  ```bash
-  sudo apt upgrade
-  ```
-  Review changes before confirming. Note if kernel update is included.
-
-- [ ] Reboot if required (especially after kernel updates):
-  ```bash
-  sudo reboot
-  ```
-
-- [ ] After reboot, remove stale packages:
-  ```bash
-  sudo apt autoremove && sudo apt clean
-  ```
-
-### 7.3 Post-Reboot Verification
-
-- [ ] Verify SSH tunnel to iEasyHydro HF is running (if configured):
-  ```bash
-  sudo systemctl status ieasyhydro-tunnel.service
-  lsof -i :5555
-  curl -s http://localhost:5555/api/v1/ | head
-  ```
-
-- [ ] Verify Docker daemon is running:
-  ```bash
-  sudo systemctl status docker
-  docker ps
-  ```
-
-- [ ] Verify cron service is running:
-  ```bash
-  sudo systemctl status cron
-  ```
-
-- [ ] Verify time synchronization:
-  ```bash
-  timedatectl status
-  ```
-
-- [ ] Start SAPPHIRE services by running the crontab scripts (if stopped before reboot):
-  
-
-- [ ] Verify all SAPPHIRE containers are running:
-  ```bash
-  docker ps --filter "name=sapphire" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
-  ```
-
-- [ ] Check dashboards are accessible:
-  ```bash
-  curl -s -o /dev/null -w "%{http_code}" http://localhost:5006/forecast_dashboard
-  curl -s -o /dev/null -w "%{http_code}" http://localhost:5007/forecast_dashboard
-  ```
-
-### 7.4 Optional: Docker Maintenance
-
-- [ ] Prune unused Docker resources:
-  ```bash
-  docker system prune -f
-  ```
-
-- [ ] Check Docker disk usage:
-  ```bash
-  docker system df
+  docker start sapphire-dashboard
   ```
 
 ---
@@ -1254,7 +1310,7 @@ done
 curl -s http://localhost:8082/api/task_list | python3 -m json.tool | head -50
 
 # Check disk usage
-df -h /data /home/ubuntu/logs
+df -h /data ${LOG_DIR}
 
 # Check Docker disk usage
 docker system df
@@ -1262,5 +1318,4 @@ docker system df
 
 ---
 
-*Last updated: 2026-01-30*
-*Added Section 7: Server OS Updates*
+*Last updated: 2026-06-04*


### PR DESCRIPTION
## Summary

Docs-only promotion of two operator-facing checklists validated during the Tajik live-server deployment. Single commit, 2 files, +1436 / -469.

- **`doc/prod/first_deploy_checklist.md`** *(new, 912 lines)* — one-time server provisioning: SSH tunnel setup (autossh + systemd, Options A/B/C), first Docker Compose startup, `RunInitializeWorkflow`, historical-backfill entry point.
- **`doc/prod/update_deployment_checklist.md`** *(rewrite)* — adds operator session-variable block (`ORG_SLUG`, `DATA_DIR`, `ENV_FILE_PATH`, `LOG_DIR`); removes stale hardcoded `kghm` paths; removes duplicate iEH HF tunnel setup instructions (now in `first_deploy_checklist.md`); adds forward pointer to that doc.

## Why this is a new PR (not a rebase of #367)

The original PR #367 (`infra_promote_deployment_docs`) was reviewer-**blocked**: its cherry-pick base predated commit `07ed459` ("Add local historical backfill toolkit") on `maxat_sapphire_2`, so its diff silently REVERTED three `set -u` safety fixes and DELETED two new toolkit files:

| File | What #367 would do |
|---|---|
| `bin/utils/common_functions.sh` | revert `${ieasyhydroforecast_ssh_tunnel_pid:-}` guards (re-introduces cleanup crash) |
| `bin/yearly_runoff_hydrograph_aggregation.sh` | revert `set +u` / `set -u` around `read_configuration` (re-introduces cron-time crash; this was fixed in PR #369) |
| `bin/initialize_regenerate_hooks.sh` | revert tilde-expansion fix (re-introduces "file not found" on `~/...` env paths) |
| `bin/dev_local_backfill.sh` | DELETE the toolkit file added by `07ed459` |
| `bin/setup_historical_backfill_env.sh` | DELETE the toolkit file added by `07ed459` |

Plus #367's `doc/prod/historical_backfill_runbook.md` was a **shorter** version than what `07ed459` shipped on mainline — a documentation downgrade.

This rescued PR contains ONLY the 2 doc files that are uniquely valuable and safe. The runbook is intentionally untouched (mainline's version is more comprehensive). The 3 shell scripts are intentionally untouched (mainline's versions have the safety fixes). The 2 toolkit files are intentionally untouched (they exist on mainline via `07ed459`).

## Test plan

- [x] Branch base: `maxat_sapphire_2` at `1a55028` (post-#366; includes `07ed459`, #369, #366)
- [x] Diff scope verified: `git diff origin/maxat_sapphire_2..HEAD --name-only` shows exactly `doc/prod/first_deploy_checklist.md` and `doc/prod/update_deployment_checklist.md` — no `bin/` files, no runbook, no other docs
- [x] Pre-commit hooks all green (ruff / ruff format / integration tests / shellcheck — all fast-pathed since only markdown changed)
- [ ] Hydromet-sysadmin read-through of the new checklist content (reviewer)

## Coordination

- PR #367 is **superseded by this PR** and will be closed.
- PR #368 (`infra_promote_checklist_hardening`) currently stacks on #367; its 4 commits build on the `update_deployment_checklist.md` rewrite in this PR. Once this lands, #368's commits cherry-pick cleanly onto `maxat_sapphire_2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)