### PR TITLE
PREPQ-008: degrade gracefully on long-horizon hydrograph API failures + remediation docs

### DIFF
--- a/apps/preprocessing_runoff/sync_long_horizon_hydrograph.py
+++ b/apps/preprocessing_runoff/sync_long_horizon_hydrograph.py
@@ -19,6 +19,7 @@ from collections.abc import Iterable
 from typing import Any
 
 import pandas as pd
+import requests
 
 _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 _IEHF_DIR = os.path.join(_SCRIPT_DIR, "..", "iEasyHydroForecast")
@@ -35,12 +36,29 @@ from setup_library import (
 )
 
 try:
-    from sapphire_api_client import SapphirePreprocessingClient
+    from sapphire_api_client import SapphireAPIError, SapphirePreprocessingClient
 
     SAPPHIRE_API_AVAILABLE = True
 except ImportError:
+    SapphireAPIError = None
     SapphirePreprocessingClient = None
     SAPPHIRE_API_AVAILABLE = False
+
+_API_READ_WRITE_ERRORS = (
+    requests.exceptions.ConnectionError,
+    requests.exceptions.Timeout,
+)
+if SapphireAPIError is not None:
+    _API_READ_WRITE_ERRORS = (SapphireAPIError, *_API_READ_WRITE_ERRORS)
+
+
+class _LongHorizonWriteResult(list):
+    def __init__(self, records: Iterable[dict[str, Any]] = ()) -> None:
+        super().__init__(records)
+        self.attempted_station_codes: list[str] = []
+        self.completed_station_codes: list[str] = []
+        self.failed_station_codes: list[str] = []
+
 
 logging.basicConfig(
     level=logging.INFO,
@@ -342,36 +360,62 @@ def write_long_horizon_hydrograph(
     today: dt.date,
 ) -> list[dict[str, Any]]:
     """Build and write monthly hydrograph records for all supplied stations."""
-    all_records = []
+    all_records = _LongHorizonWriteResult()
     for code in codes:
-        monthly_records = write_station_monthly_hydrograph(
-            code=str(code),
-            iehhf_sdk=iehhf_sdk,
-            client=client,
-            target_year=target_year,
-            today=today,
-        )
-        if not monthly_records:
-            logger.info("Skipping seasonal hydrograph for station %s without monthly records", code)
+        code_str = str(code)
+        all_records.attempted_station_codes.append(code_str)
+        try:
+            monthly_records = write_station_monthly_hydrograph(
+                code=code_str,
+                iehhf_sdk=iehhf_sdk,
+                client=client,
+                target_year=target_year,
+                today=today,
+            )
+            if not monthly_records:
+                all_records.attempted_station_codes.pop()
+                logger.info(
+                    "Skipping seasonal hydrograph for station %s without monthly records",
+                    code,
+                )
+                continue
+            all_records.extend(monthly_records)
+            all_records.append(
+                write_station_seasonal_hydrograph(
+                    code=code_str,
+                    monthly_records=monthly_records,
+                    client=client,
+                    target_year=target_year,
+                    today=today,
+                )
+            )
+            all_records.extend(
+                write_station_quarterly_hydrograph(
+                    code=code_str,
+                    monthly_records=monthly_records,
+                    client=client,
+                    target_year=target_year,
+                    today=today,
+                )
+            )
+            all_records.completed_station_codes.append(code_str)
+        except _API_READ_WRITE_ERRORS as exc:
+            all_records.failed_station_codes.append(code_str)
+            logger.warning(
+                "Long-horizon hydrograph API read/write failed for station %s; preserving "
+                "any records already written for this station and continuing. Error: %s: %s",
+                code_str,
+                type(exc).__name__,
+                exc,
+            )
             continue
-        all_records.extend(monthly_records)
-        all_records.append(
-            write_station_seasonal_hydrograph(
-                code=str(code),
-                monthly_records=monthly_records,
-                client=client,
-                target_year=target_year,
-                today=today,
-            )
-        )
-        all_records.extend(
-            write_station_quarterly_hydrograph(
-                code=str(code),
-                monthly_records=monthly_records,
-                client=client,
-                target_year=target_year,
-                today=today,
-            )
+
+    if all_records.failed_station_codes:
+        logger.warning(
+            "Long-horizon hydrograph API read/write failures for %d/%d attempted station(s): %s",
+            len(all_records.failed_station_codes),
+            len(all_records.attempted_station_codes),
+            ", ".join(all_records.failed_station_codes),
         )
     return all_records
 
@@ -453,6 +497,15 @@ def main() -> None:
             target_year=target_year,
             today=today,
         )
+        attempted_station_codes = getattr(records, "attempted_station_codes", [])
+        completed_station_codes = getattr(records, "completed_station_codes", [])
+        if len(completed_station_codes) == 0 and len(attempted_station_codes) > 0:
+            logger.error(
+                "All %d attempted station(s) had long-horizon hydrograph API read/write "
+                "failures; exiting 2 after preserving any successful partial writes.",
+                len(attempted_station_codes),
+            )
+            sys.exit(2)
         if not records:
             logger.error("No monthly hydrograph records produced - nothing to write.")
             sys.exit(2)

--- a/apps/preprocessing_runoff/test/test_sync_long_horizon_hydrograph.py
+++ b/apps/preprocessing_runoff/test/test_sync_long_horizon_hydrograph.py
@@ -558,3 +558,236 @@ def test_orchestrator_continues_after_skipped_station():
     assert len(client.write_hydrograph.call_args_list[0].args[0]) == 12
     assert len(client.write_hydrograph.call_args_list[1].args[0]) == 1
     assert len(client.write_hydrograph.call_args_list[2].args[0]) == 4
+
+
+def test_orchestrator_continues_after_quarterly_api_write_failure(caplog):
+    first_code = "19999"
+    second_code = "19998"
+    sdk = MagicMock()
+    sdk.get_norm_for_site.side_effect = [_norms(), _norms()]
+    client = MagicMock()
+    client.read_runoff.side_effect = [
+        _full_year_rows(2026, {month: 20.0 for month in range(1, 13)}),
+        _full_year_rows(2025, {month: 10.0 for month in range(1, 13)}),
+        _full_year_rows(2026, {month: 30.0 for month in range(1, 13)}),
+        _full_year_rows(2025, {month: 15.0 for month in range(1, 13)}),
+    ]
+    write_calls = []
+
+    def fail_third_write(_records):
+        write_calls.append(_records)
+        if len(write_calls) == 3:
+            raise sync_lhh.SapphireAPIError("quarter rejected", status_code=422)
+
+    client.write_hydrograph.side_effect = fail_third_write
+
+    with caplog.at_level(sync_lhh.logging.WARNING):
+        records = sync_lhh.write_long_horizon_hydrograph(
+            codes=[first_code, second_code],
+            iehhf_sdk=sdk,
+            client=client,
+            target_year=2026,
+            today=dt.date(2027, 1, 1),
+        )
+
+    assert client.write_hydrograph.call_count == 6
+    assert len(records) == 30
+    assert "Long-horizon hydrograph API read/write failed for station 19999" in caplog.text
+    assert "1/2 attempted station(s)" in caplog.text
+    assert records.attempted_station_codes == ["19999", "19998"]
+    assert records.completed_station_codes == ["19998"]
+    assert records.failed_station_codes == ["19999"]
+
+
+def test_orchestrator_preserves_monthly_when_seasonal_api_write_fails(caplog):
+    sdk = MagicMock()
+    sdk.get_norm_for_site.return_value = _norms()
+    client = MagicMock()
+    client.read_runoff.side_effect = [
+        _full_year_rows(2026, {month: 20.0 for month in range(1, 13)}),
+        _full_year_rows(2025, {month: 10.0 for month in range(1, 13)}),
+    ]
+    write_calls = []
+
+    def fail_second_write(_records):
+        write_calls.append(_records)
+        if len(write_calls) == 2:
+            raise sync_lhh.SapphireAPIError("season rejected", status_code=422)
+
+    client.write_hydrograph.side_effect = fail_second_write
+
+    with caplog.at_level(sync_lhh.logging.WARNING):
+        records = sync_lhh.write_long_horizon_hydrograph(
+            codes=["19999"],
+            iehhf_sdk=sdk,
+            client=client,
+            target_year=2026,
+            today=dt.date(2027, 1, 1),
+        )
+
+    assert len(records) == 12
+    assert client.write_hydrograph.call_count == 2
+    assert "Long-horizon hydrograph API read/write failed for station 19999" in caplog.text
+    assert records.attempted_station_codes == ["19999"]
+    assert records.completed_station_codes == []
+    assert records.failed_station_codes == ["19999"]
+
+
+def test_orchestrator_marks_read_runoff_failure_as_attempted_failed(caplog):
+    sdk = MagicMock()
+    sdk.get_norm_for_site.return_value = _norms()
+    client = MagicMock()
+    client.read_runoff.side_effect = sync_lhh.SapphireAPIError("runoff unavailable")
+
+    with caplog.at_level(sync_lhh.logging.WARNING):
+        records = sync_lhh.write_long_horizon_hydrograph(
+            codes=["19999"],
+            iehhf_sdk=sdk,
+            client=client,
+            target_year=2026,
+            today=dt.date(2027, 1, 1),
+        )
+
+    assert len(records) == 0
+    client.write_hydrograph.assert_not_called()
+    assert "Long-horizon hydrograph API read/write failed for station 19999" in caplog.text
+    assert "read/write" in caplog.text
+    assert records.attempted_station_codes == ["19999"]
+    assert records.completed_station_codes == []
+    assert records.failed_station_codes == ["19999"]
+
+
+def test_orchestrator_skip_has_metadata_but_no_attempt_completion_or_failure():
+    sdk = MagicMock()
+    sdk.get_norm_for_site.side_effect = ConnectionError("tunnel down")
+    client = MagicMock()
+
+    records = sync_lhh.write_long_horizon_hydrograph(
+        codes=["19999"],
+        iehhf_sdk=sdk,
+        client=client,
+        target_year=2026,
+        today=dt.date(2027, 1, 1),
+    )
+
+    assert isinstance(records, sync_lhh._LongHorizonWriteResult)
+    assert records == []
+    assert records.attempted_station_codes == []
+    assert records.completed_station_codes == []
+    assert records.failed_station_codes == []
+
+
+def _patch_main_dependencies(monkeypatch, records):
+    monkeypatch.setattr(sync_lhh.sys, "argv", ["sync_long_horizon_hydrograph.py"])
+    monkeypatch.setattr(sync_lhh.sl, "load_environment", MagicMock())
+    monkeypatch.setattr(sync_lhh, "IEasyHydroHFSDK", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(sync_lhh, "resolve_sdk_station_codes", MagicMock(return_value=["19999"]))
+    monkeypatch.setattr(sync_lhh, "_get_preprocessing_client", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        sync_lhh,
+        "write_long_horizon_hydrograph",
+        MagicMock(return_value=records),
+    )
+
+
+def test_main_exits_two_when_every_attempted_station_has_api_read_write_failure(
+    monkeypatch,
+    caplog,
+):
+    records = sync_lhh._LongHorizonWriteResult([{"code": "19999"}])
+    records.attempted_station_codes = ["19999"]
+    records.completed_station_codes = []
+    records.failed_station_codes = ["19999"]
+    _patch_main_dependencies(monkeypatch, records)
+
+    with caplog.at_level(sync_lhh.logging.ERROR), pytest.raises(SystemExit) as exc:
+        sync_lhh.main()
+
+    assert exc.value.code == 2
+    assert (
+        "All 1 attempted station(s) had long-horizon hydrograph API read/write failures"
+        in caplog.text
+    )
+
+
+def test_main_exits_zero_when_some_station_completes_after_api_read_write_failure(
+    monkeypatch,
+):
+    records = sync_lhh._LongHorizonWriteResult([{"code": "19999"}, {"code": "19998"}])
+    records.attempted_station_codes = ["19999", "19998"]
+    records.completed_station_codes = ["19998"]
+    records.failed_station_codes = ["19999"]
+    _patch_main_dependencies(monkeypatch, records)
+
+    with pytest.raises(SystemExit) as exc:
+        sync_lhh.main()
+
+    assert exc.value.code == 0
+
+
+def test_main_empty_records_path_when_no_station_attempted(monkeypatch, caplog):
+    records = sync_lhh._LongHorizonWriteResult()
+    records.attempted_station_codes = []
+    records.completed_station_codes = []
+    records.failed_station_codes = []
+    _patch_main_dependencies(monkeypatch, records)
+
+    with caplog.at_level(sync_lhh.logging.ERROR), pytest.raises(SystemExit) as exc:
+        sync_lhh.main()
+
+    assert exc.value.code == 2
+    assert "No monthly hydrograph records produced - nothing to write." in caplog.text
+    assert "All 0 attempted station(s)" not in caplog.text
+
+
+def test_orchestrator_does_not_catch_programming_errors():
+    sdk = MagicMock()
+    sdk.get_norm_for_site.return_value = _norms()
+    client = MagicMock()
+    client.read_runoff.side_effect = [
+        _full_year_rows(2026, {month: 20.0 for month in range(1, 13)}),
+        _full_year_rows(2025, {month: 10.0 for month in range(1, 13)}),
+    ]
+    write_calls = []
+
+    def fail_third_write(_records):
+        write_calls.append(_records)
+        if len(write_calls) == 3:
+            raise KeyError("bad record shape")
+
+    client.write_hydrograph.side_effect = fail_third_write
+
+    with pytest.raises(KeyError):
+        sync_lhh.write_long_horizon_hydrograph(
+            codes=["19999"],
+            iehhf_sdk=sdk,
+            client=client,
+            target_year=2026,
+            today=dt.date(2027, 1, 1),
+        )
+
+
+def test_build_quarterly_records_api_contract_fields():
+    records = sync_lhh.build_quarterly_records(
+        _monthly_records_for_season(target_year=2026),
+        TEST_CODE,
+        2026,
+    )
+    expected_fields = {
+        "horizon_type",
+        "code",
+        "date",
+        "day_of_year",
+        "horizon_value",
+        "horizon_in_year",
+        "norm",
+        "previous",
+        "current",
+    }
+
+    assert len(records) == 4
+    for record in records:
+        assert set(record) == expected_fields
+        assert record["horizon_type"] == "quarter"
+        assert record["code"] == TEST_CODE
+        assert record["horizon_value"] == record["horizon_in_year"]

--- a/doc/plans/issues/high_prio_gi_draft_runoff_quarter_horizon_type_rejected.md
+++ b/doc/plans/issues/high_prio_gi_draft_runoff_quarter_horizon_type_rejected.md
@@ -1,0 +1,112 @@
+## Long-horizon quarterly hydrograph write fails — API rejects `horizon_type="quarter"` (PREPQ-008)
+
+**Status**: Investigated & resolved 2026-06-12 — root cause confirmed and fix applied (see **Resolution update** below; the original analysis is retained for the record)
+**Module**: `apps/preprocessing_runoff` (writer) + `sapphire/services/preprocessing` (deployed schema/DB — colleague-managed) + `sapphire-api-client` (write-path Literals — external repo)
+**Priority**: **High** (deployment-blocking — the maintenance run aborts and the quarterly long-term norm hydrograph is never written)
+**Labels**: `preprocessing-runoff`, `long-horizon`, `enum`, `schema-drift`, `deployment-blocker`
+**Discovered**: 2026-06-12 during the `preprocessing_runoff (maintenance)` pipeline run.
+**Related**:
+- **MIG-003** ([`high_prio_gi_draft_migration_horizon_type_case_coercion.md`](high_prio_gi_draft_migration_horizon_type_case_coercion.md)) — same `horizon_type` enum-mismatch bug class.
+- **FD-015** (archived) — quarter/season long-horizon skill/hydrograph display; this is the upstream data source for the quarterly cards, so the dashboard quarterly view has no data wherever this write fails.
+- Source enum authority: `sapphire/services/preprocessing/app/models.py:6-14` (`HorizonType`, includes `QUARTER = "quarter"`).
+- Migration authority: `sapphire/services/preprocessing/alembic/versions/d4e5f6a7b8c9_add_quarter_to_horizontype.py` (adds `QUARTER` PG enum label; revises `9f1e72108f01`).
+
+---
+
+## Resolution update (2026-06-12)
+
+Investigation (`doc/plans/working/runoff_quarter_horizon_type_investigation_plan.md`) **refined
+the root cause**: it was **not** a stale image or an unapplied migration. On the local stack the
+preprocessing-api runs from a **bind mount** with source/DB already current (enum + migration
+present), but the `uvicorn` worker had started *before* the source gained `QUARTER` and runs
+without `--reload` — so it served a stale in-memory schema. `docker restart
+sapphire-preprocessing-api` cleared the 422 (confirmed: the live OpenAPI `HorizonType` enum now
+includes `quarter`).
+
+Work completed:
+- **Ops fix (local):** restart — done, verified.
+- **Defensive hardening (P1):** the writer now degrades gracefully on per-station API read/write
+  failures instead of aborting the whole run — branch `fix_runoff_long_horizon_degrade_gracefully`,
+  commit `8ef2b0b`.
+- **Collaborator remediation runbook:** `doc/prod/remediate_quarter_horizon_type_422.md` covers
+  local (bind-mount restart), servers (pull updated `mabesa/sapphire-preprocessing:latest`), and
+  the image-owner rebuild/push gate.
+- **Deferred follow-up:** api-client `quarter` Literal hygiene → INFRA-019.
+
+Server deployments (which pull `mabesa/sapphire-preprocessing:latest`) still need the
+image-owner rebuild+push sequence in the runbook before they are confirmed clear; the local
+bind-mount diagnosis does not by itself prove server state.
+
+---
+
+## Summary
+
+The long-horizon hydrograph writer emits records with `horizon_type="quarter"`, but the **deployed** preprocessing API rejected them with a `422` validation error whose accepted set is `'day', 'pentad', 'decade', 'month', 'season'` and `'year'` — **note: `quarter` is absent, but `year` is present**. The whole maintenance run aborts at batch 1/1, so the quarterly long-term norm hydrograph is never persisted for any station.
+
+This is **not a logic bug in the writer** — current source already supports `quarter` (enum value added in commit `2be58f7` "Add QUARTER to preprocessing HorizonType (match postprocessing)", plus Alembic migration `d4e5f6a7b8c9`). The defect is **schema/deployment drift**: the running preprocessing service image and/or its database predate that change, so the deployed FastAPI request schema does not yet accept `quarter`.
+
+---
+
+## Live evidence (2026-06-12)
+
+```
+--- preprocessing_runoff (maintenance) ---
+ERROR - Batch 1 failed: API request failed (422): [{'type': 'enum',
+  'loc': ['body', 'data', 0, 'horizon_type'],
+  'msg': "Input should be 'day', 'pentad', 'decade', 'month', 'season' or 'year'",
+  'input': 'quarter', ...}, ...]
+ERROR - Unexpected error during long-horizon monthly hydrograph ingestion:
+  Failed at batch 1/1: API request failed (422): ...
+  File ".../sync_long_horizon_hydrograph.py", line 449, in main
+    records = write_long_horizon_hydrograph(...)
+  File ".../sync_long_horizon_hydrograph.py", line 368, in write_long_horizon_hydrograph
+    write_station_quarterly_hydrograph(...)
+  File ".../sync_long_horizon_hydrograph.py", line 332, in write_station_quarterly_hydrograph
+    client.write_hydrograph(records)
+  sapphire_api_client.client.SapphireAPIError: Failed at batch 1/1: API request failed (422): ...
+```
+
+The `422` is FastAPI **request-body** validation, returned by the deployed service — i.e. the running image's Pydantic schema, not the local source.
+
+---
+
+## Root cause (to confirm during development)
+
+Three layers can each carry a stale `horizon_type` definition; the live `422` proves at least the deployed service is behind:
+
+1. **Writer** — `apps/preprocessing_runoff/sync_long_horizon_hydrograph.py:300` (`build_quarterly_records`) sets `"horizon_type": "quarter"`. This is correct against current source.
+2. **Deployed preprocessing service** — the running image rejects `quarter`. Source `models.py` already has `QUARTER`, so the deployed image predates commit `2be58f7`. **Suspected primary cause.**
+3. **Live preprocessing DB** — even with a fresh image, the PG `horizontype` enum needs the `QUARTER` label. Migration `d4e5f6a7b8c9_add_quarter_to_horizontype` (`ALTER TYPE horizontype ADD VALUE IF NOT EXISTS 'QUARTER' BEFORE 'SEASON'`) must be applied. Confirm whether `alembic upgrade head` reached this revision on the affected deployment.
+4. **`sapphire-api-client`** (pin `7bd349172ef24576b654a7b78f38734de3f2e657`) — the write-path Literals are **inconsistent**: `postprocessing_base.py:99` includes `quarter`, but `postprocessing.py:94` and `short_term.py:113` list only `day, pentad, decade, month, season, year` (no `quarter`). The hydrograph write path did not block client-side (the request reached the server), but this inconsistency should be reconciled so the client validates uniformly.
+
+---
+
+## Impact
+
+- Maintenance `preprocessing_runoff` run aborts (`main()` re-raises) at the quarterly batch.
+- Monthly and seasonal long-horizon records for the in-progress station may already be written before the abort, leaving a **partial** hydrograph (no quarterly rows) and no records at all for stations after the failure point.
+- Dashboard quarterly long-horizon cards (FD-015 territory) have no data on any deployment still running the stale image.
+
+---
+
+## Proposed fix direction (develop later)
+
+> Ownership note: `sapphire/services/` and the Alembic migration are colleague-managed — coordinate, do not edit directly. The `sapphire-api-client` is an external repo.
+
+1. **Diagnose the affected deployment**: capture the deployed `sapphire-preprocessing` image build SHA (does it include `2be58f7`?) and probe the live enum:
+   `SELECT enumlabel FROM pg_enum WHERE enumtypid='horizontype'::regtype ORDER BY enumsortorder;`
+2. **Rebuild + redeploy** the preprocessing service from source at/after `2be58f7`, and run `alembic upgrade head` so migration `d4e5f6a7b8c9` lands on the live preprocessing DB.
+3. **Reconcile the api-client Literals** to include `quarter` consistently across write paths, then re-pin (see [sapphire-api-client re-pin procedure] — touches ~17 files / 10 modules).
+4. **Decide error-handling policy** in `sync_long_horizon_hydrograph.py`: should a quarterly batch failure abort the entire maintenance run, or should the run degrade gracefully (monthly/seasonal already written) and surface the quarterly failure as a non-fatal warning? Current behavior aborts everything.
+5. **Add a regression test** (preprocessing_runoff) that a quarterly hydrograph record round-trips against the current schema, so writer ⇆ schema drift is caught in CI rather than in production.
+
+---
+
+## Acceptance criteria
+
+- [ ] Root cause confirmed (deployed image SHA + live `horizontype` enum labels documented).
+- [ ] Quarterly hydrograph records (`horizon_type="quarter"`) are accepted by the target deployment's API and persisted.
+- [ ] Maintenance `preprocessing_runoff` run completes without the `422` abort.
+- [ ] `sapphire-api-client` write-path Literals are consistent for `quarter` (or a decision recorded if intentionally divergent).
+- [ ] Regression test added and passing under `SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_runoff`.
+- [ ] Error-handling policy for partial long-horizon writes decided and implemented.

--- a/doc/plans/issues/mid_prio_gi_draft_infra_api_client_quarter_literal_consistency.md
+++ b/doc/plans/issues/mid_prio_gi_draft_infra_api_client_quarter_literal_consistency.md
@@ -1,0 +1,44 @@
+## sapphire-api-client `horizon_type` Literals diverge — `quarter` missing on most write/read paths (INFRA-019)
+
+**Status**: Draft (2026-06-12)
+**Module**: `sapphire-api-client` (external repo: `hydrosolutions/sapphire-api-client`) + every SAPPHIRE module that pins it
+**Priority**: **Medium** (hygiene / latent footgun — no current operational failure traces to it)
+**Labels**: `api-client`, `enum`, `consistency`, `tech-debt`, `cross-module`
+**Discovered**: 2026-06-12 while investigating PREPQ-008 (quarterly hydrograph `422`).
+**Related**:
+- **PREPQ-008** ([`high_prio_gi_draft_runoff_quarter_horizon_type_rejected.md`](high_prio_gi_draft_runoff_quarter_horizon_type_rejected.md)) — the investigation that surfaced this. PREPQ-008 was **not** caused by this divergence (the failing write path posts raw dicts and does not validate client-side), so this is filed separately as agreed (decision D3 = defer).
+- **MIG-003** ([`high_prio_gi_draft_migration_horizon_type_case_coercion.md`](high_prio_gi_draft_migration_horizon_type_case_coercion.md)) — sibling `horizon_type` consistency bug class.
+- sapphire-api-client re-pin procedure (memory: `sapphire_api_client_repin_procedure.md`) — bumping the pin touches ~17 files / 10 modules.
+
+---
+
+## Summary
+
+The pinned `sapphire-api-client` (rev `7bd349172ef24576b654a7b78f38734de3f2e657`) declares the `horizon_type` parameter as a `Literal[...]` on several methods, but the allowed value sets **disagree about `quarter`**. Most paths omit it; one includes it. The authoritative server-side enum (`sapphire/services/preprocessing/app/models.py` `HorizonType`) includes all of `day, pentad, decade, month, quarter, season, year`. The client should match.
+
+| File:line (under `sapphire_api_client/`) | Method | Includes `quarter`? |
+|---|---|---|
+| `postprocessing_base.py:99` | (base write) | **yes** |
+| `preprocessing.py:108` | `prepare_runoff_records` | no |
+| `preprocessing.py:213` | `prepare_hydrograph_records` | no |
+| `short_term.py:113` | (short-term write) | no |
+| `postprocessing.py:94` | (read) | no |
+
+## Why it matters (and why it is only Medium)
+
+- **Latent footgun**: any caller that *does* route through `prepare_hydrograph_records` / `prepare_runoff_records` (the validating helpers) with `horizon_type="quarter"` will be rejected **client-side** with a confusing `Literal` error, even against a correct server. Today the long-horizon writer bypasses these helpers (posts raw dicts), so no operational path currently trips it — hence Medium, not High.
+- **Inconsistency is a correctness hazard**: `quarter` is a first-class horizon in the server enum and in postprocessing; the client's read path (`postprocessing.py:94`) silently can't express it either.
+
+## Proposed fix direction (develop later)
+
+> The client is an **external repo** — changes happen upstream in `hydrosolutions/sapphire-api-client`, then the pin is bumped here. Coordinate; do not vendor-patch the installed `.venv` copy.
+
+1. Upstream: add `"quarter"` to the four diverging `Literal[...]`s so all `horizon_type` Literals equal the server `HorizonType` value set (`day, pentad, decade, month, quarter, season, year`). Consider deriving them from a single shared constant to prevent future drift.
+2. Cut a new client rev; re-pin across all consuming modules per the re-pin procedure (`uv lock --upgrade-package sapphire-api-client`) — ~17 files / 10 modules incl. transitive (forecast_dashboard, pipeline, preprocessing_station_forcing).
+3. Run the full suite per module after re-pin.
+
+## Acceptance criteria
+
+- [ ] All `horizon_type` Literals in the client match the server `HorizonType` value set (incl. `quarter`).
+- [ ] New client rev cut upstream and pin bumped across all consuming modules.
+- [ ] `SAPPHIRE_TEST_ENV=True bash run_tests.sh` green across affected modules after re-pin.

--- a/doc/plans/module_issues.md
+++ b/doc/plans/module_issues.md
@@ -103,6 +103,7 @@ These are blocking decisions — work downstream cannot advance until they are r
 | **FD-002b** | Synthetic integration tests with fake data | fd | **Medium** | Open | — (plan file never created) | — |
 | **INFRA-017** | Document DB initialization for fresh deployments (`SAPPHIRE_SYNC_MODE=initial`) | infra | **Medium** | Draft | [`mid_prio_gi_draft_infra_initial_sync_docs.md`](issues/mid_prio_gi_draft_infra_initial_sync_docs.md) | — |
 | **INFRA-018** | Playwright integration tests fail at browser launch under macOS sandbox (verification noise + potential CI coverage gap) | infra | **Low** | Draft | [`low_prio_gi_draft_infra_playwright_sandbox_browser_launch.md`](issues/low_prio_gi_draft_infra_playwright_sandbox_browser_launch.md) | — |
+| **INFRA-019** | sapphire-api-client `horizon_type` Literals diverge — `quarter` missing on most paths (hygiene, deferred from PREPQ-008 D3) | infra | **Medium** | Draft | [`mid_prio_gi_draft_infra_api_client_quarter_literal_consistency.md`](issues/mid_prio_gi_draft_infra_api_client_quarter_literal_consistency.md) | — |
 | ~~**P-006**~~ | ~~Move long-term schedule query into Luigi pipeline~~ | ~~pipeline~~ | | Complete | [`review_gi_draft_pipeline_lt_schedule_into_luigi.md`](issues/review_gi_draft_pipeline_lt_schedule_into_luigi.md) | — |
 
 ---
@@ -125,6 +126,7 @@ These are blocking decisions — work downstream cannot advance until they are r
 |----|-------|----------|--------|------|------------|
 | **PREPQ-004** | Swiss data source integration & module refactoring | **Low** | Blocked | [`low_prio_gi_PR-003_swiss_data_source_refactor.md`](issues/low_prio_gi_PR-003_swiss_data_source_refactor.md) | Swiss API docs unavailable |
 | **PREPQ-007** | External site data ingestion (manual sites via Google Sheets) | **High** | Code complete; deployment wiring + hardening landed; pending operator rollout | [`external_site_data_ingestion_plan.md`](external_site_data_ingestion_plan.md) | — |
+| **PREPQ-008** | Long-horizon quarterly hydrograph write fails — deployed API rejects `horizon_type="quarter"` (schema/deployment drift) | **High** | Draft | [`high_prio_gi_draft_runoff_quarter_horizon_type_rejected.md`](issues/high_prio_gi_draft_runoff_quarter_horizon_type_rejected.md) | Discovered 2026-06-12 in maintenance run; 422 abort. Source already has QUARTER (commit 2be58f7 + migration d4e5f6a7b8c9); deployed image/DB behind. Related: MIG-003, FD-015. |
 
 ### Linear Regression (`lr`)
 

--- a/doc/prod/remediate_quarter_horizon_type_422.md
+++ b/doc/prod/remediate_quarter_horizon_type_422.md
@@ -1,0 +1,206 @@
+# Remediation: `horizon_type="quarter"` rejected with HTTP 422 (PREPQ-008)
+
+**Audience**: deployment sysadmins (Tajik / Kyrgyz / Uzbek / ZRH), the services/image owner, and developers running local stacks.
+**Last updated**: 2026-06-12
+
+## Symptom
+
+The `preprocessing_runoff` maintenance run (long-horizon hydrograph ingestion) aborts with:
+
+```
+ERROR - Batch 1 failed: API request failed (422): [{'type': 'enum',
+  'loc': ['body', 'data', 0, 'horizon_type'],
+  'msg': "Input should be 'day', 'pentad', 'decade', 'month', 'season' or 'year'",
+  'input': 'quarter', ...}]
+```
+
+The accepted set advertised by the API is **missing `quarter`**. The writer
+(`sync_long_horizon_hydrograph.py`) correctly emits `horizon_type="quarter"`; the
+**deployed preprocessing API is behind the source**, which already supports it
+(enum value added in commit `2be58f7`; PG enum label added by Alembic migration
+`d4e5f6a7b8c9`).
+
+Effect: the whole maintenance run aborts, so the quarterly long-term norm hydrograph is
+never written (and the dashboard quarterly cards have no data).
+
+---
+
+## Step 1 — Detect (run on the affected deployment)
+
+Adjust container/service names and DB name to your compose project if they differ.
+
+**1a. What enum does the *running* API actually serve?** (the authoritative check)
+
+Run it *inside* the API container with `python3` (the image ships Python but not `curl`),
+and locate the enum by content rather than assuming its schema key name:
+
+```bash
+docker exec sapphire-preprocessing-api python3 -c "import json,urllib.request; \
+s=json.load(urllib.request.urlopen('http://localhost:8002/openapi.json'))['components']['schemas']; \
+[print(k,'=',v['enum'],'| quarter present:', 'quarter' in v['enum']) \
+ for k,v in s.items() if v.get('enum') and 'pentad' in v['enum']]"
+```
+
+(If the API port is published to the host, `curl -fsS http://localhost:8002/openapi.json`
+from the host works too.)
+
+- `quarter present: True` → the running API is fine; the 422 is something else.
+- `quarter present: False` → **affected**. Continue.
+
+**1b. Does the database enum have the label?**
+
+```bash
+PGUSER=$(docker exec sapphire-preprocessing-db printenv POSTGRES_USER)
+docker exec sapphire-preprocessing-db psql -U "$PGUSER" -d preprocessing_db -tAc \
+  "SELECT enumlabel FROM pg_enum WHERE enumtypid='horizontype'::regtype ORDER BY enumsortorder"
+```
+
+Expect `QUARTER` to appear (between `MONTH` and `SEASON`). If absent, the migration has
+not been applied.
+
+**1c. Is Alembic at/after the migration?**
+
+```bash
+docker exec sapphire-preprocessing-api alembic current   # expect d4e5f6a7b8c9 (or later)
+```
+
+**Probe the *same* service the writer hits.** `sync_long_horizon_hydrograph.py` writes via
+`SAPPHIRE_API_URL` (default the api-gateway on `:8000`), which routes to the preprocessing
+service. If your deployment runs more than one preprocessing instance, make sure Step 1a
+probes the instance behind that gateway — probing a different container can give a
+misleading result.
+
+**Interpreting the signals (mixed states):**
+
+| 1a (API serves `quarter`) | 1b (DB has `QUARTER`) | What it means → go to |
+|---|---|---|
+| No | Yes | API process/image is behind the DB → **Branch A** (bind mount) or **Branch B** (baked image) |
+| No | No | Both API and DB are behind → **Branch B**, and ensure the migration runs (auto on redeploy, or apply manually) |
+| Yes | No | API accepts `quarter` but the **write will still fail at the DB** with `invalid input value for enum horizontype` (a different error, not a 422) → apply the migration: `docker exec sapphire-preprocessing-api alembic upgrade head` |
+| Yes | Yes | Not this issue — investigate the specific 422 payload |
+
+---
+
+## Step 2 — Fix (pick the branch that matches your deployment)
+
+### Branch A — Local / dev stack running from a BIND MOUNT (stale worker)
+
+Symptom signature: source `models.py` and the DB enum are CORRECT (1b shows `QUARTER`,
+1c is at head), but 1a is missing `quarter`. The uvicorn worker started before the
+mounted source was updated and runs without `--reload`, so it holds the old schema in
+memory.
+
+```bash
+docker restart sapphire-preprocessing-api
+```
+
+Then re-run Step 1a — `quarter` should now appear. Done.
+
+### Branch B — Server running the promoted image `mabesa/sapphire-preprocessing:latest`
+
+All hydromet deployments (Tajik / Kyrgyz / Uzbek / ZRH) run the **pulled** image
+`mabesa/sapphire-preprocessing:latest` — they do not build locally.
+
+Because `latest` is a single moving tag, remediation is a **two-step sequence across two
+actors, in order**:
+
+1. **Image owner — FIRST (once, see Branch C):** build `mabesa/sapphire-preprocessing` from
+   source at/after commit `2be58f7` and push it to `:latest`. Until the registry's `latest`
+   is updated, a `docker compose pull` on a server just re-fetches the same stale image — so
+   this step must happen before any server pulls.
+2. **Each server — AFTER the new `latest` is pushed:**
+
+   ```bash
+   cd <deployment>/sapphire && docker compose pull preprocessing-api \
+     && docker compose up -d preprocessing-api
+   ```
+
+   This pulls the updated `latest` and recreates the container. If the image entrypoint runs
+   `alembic upgrade head` on start (verify for the build), the migration `d4e5f6a7b8c9` is
+   applied automatically; otherwise apply it explicitly:
+
+   ```bash
+   docker exec sapphire-preprocessing-api alembic upgrade head
+   ```
+
+3. **Verify on each server:** re-run Step 1a (API serves `quarter`) and Step 1b (DB enum has
+   `QUARTER`). Since the tag name never changes, confirm you actually pulled the new build by
+   comparing the image digest / created date before and after:
+
+   ```bash
+   docker image inspect mabesa/sapphire-preprocessing:latest --format '{{.Id}} {{.Created}}'
+   ```
+
+> `latest` carries no version information, so the tag alone cannot tell you whether a server
+> has the fix — always confirm with Step 1a plus the digest/created date, never the tag name.
+
+> Do not hand-edit the PG enum on a live DB. Use the Alembic migration
+> (`ALTER TYPE horizontype ADD VALUE IF NOT EXISTS 'QUARTER' BEFORE 'SEASON'`), which is
+> idempotent, so it is safe to re-run.
+
+### Branch C — Image owner (rebuild + push `latest`) — DO THIS FIRST
+
+Servers can only get the fix once `mabesa/sapphire-preprocessing:latest` in the registry
+points at a fixed build. Before pushing, confirm the image bakes in the fix:
+
+- Source includes commit `2be58f7` ("Add QUARTER to preprocessing HorizonType").
+- The migration file `sapphire/services/preprocessing/alembic/versions/d4e5f6a7b8c9_add_quarter_to_horizontype.py`
+  is present in the image.
+- Post-build smoke check: start the image and run Step 1a — the served enum must include
+  `quarter`.
+
+Then build and push `:latest`, and notify the deployment sysadmins to run Branch B step 2.
+(Note: `latest` is mutable and unversioned; when the canonical versioned tag — e.g.
+`:v1.0.0` — is adopted, prefer pinning servers to it so "which build is deployed" is
+unambiguous.)
+
+---
+
+## Step 3 — Verify the operational fix
+
+```bash
+# 1) API now accepts quarter (Step 1a shows it), and
+# 2) optionally re-run the maintenance job and confirm no 422:
+#    (needs the iEH HF tunnel + the deployment's env)
+cd apps/preprocessing_runoff && uv run python sync_long_horizon_hydrograph.py --target-year <year>
+
+# 3) confirm quarter rows landed (use a non-sensitive sample code such as 19999):
+PGUSER=$(docker exec sapphire-preprocessing-db printenv POSTGRES_USER)
+docker exec sapphire-preprocessing-db psql -U "$PGUSER" -d preprocessing_db -tAc \
+  "SELECT horizon_type, COUNT(*) FROM hydrographs WHERE horizon_type = 'QUARTER' GROUP BY horizon_type"
+```
+
+> The `horizontype` PG enum stores **UPPERCASE** labels (`DAY`, `PENTAD`, …, `QUARTER`,
+> `SEASON`, `YEAR`) — SQLAlchemy persists the enum *name*, not the lowercase `.value` the API
+> accepts. So raw SQL must compare against `'QUARTER'` (or `horizon_type::text = 'QUARTER'`);
+> a lowercase `'quarter'` literal raises `invalid input value for enum horizontype`. Same
+> gotcha as MIG-003.
+
+Re-runs are safe: hydrograph writes are idempotent upserts, so re-running completes any
+rows skipped by an earlier aborted run.
+
+---
+
+## Related defensive change (PREPQ-008 P1)
+
+Branch `fix_runoff_long_horizon_degrade_gracefully` (commit `8ef2b0b`) makes the writer
+**degrade gracefully**: a per-station API read/write failure now logs a WARNING and
+continues to the next station instead of aborting the whole run. Exit-code behavior after
+that lands:
+
+- **exit 0** — at least one station completed all its writes (partial per-station failures
+  are logged as warnings).
+- **exit 2** — every *attempted* station failed its API read/write (or there was nothing to
+  write). Check the logs to disambiguate.
+
+This hardening does **not** replace fixing the schema drift above — it only prevents one
+station's (or a systemic) failure from silently aborting the entire maintenance run.
+
+## References
+
+- Issue: `doc/plans/issues/high_prio_gi_draft_runoff_quarter_horizon_type_rejected.md` (PREPQ-008)
+- Investigation: `doc/plans/working/runoff_quarter_horizon_type_investigation_plan.md`
+- api-client `quarter` Literal hygiene follow-up: INFRA-019
+  (`doc/plans/issues/mid_prio_gi_draft_infra_api_client_quarter_literal_consistency.md`)
+- Same `horizon_type` enum-case gotcha in migration-toolkit SQL: MIG-003
+  (`doc/plans/issues/high_prio_gi_draft_migration_horizon_type_case_coercion.md`)


### PR DESCRIPTION
## What & why

The `preprocessing_runoff` long-horizon maintenance run aborted with a `422` when the
preprocessing API rejected `horizon_type="quarter"`. Root cause (investigated, confirmed):
**not** a code bug and **not** a stale image/migration — the local preprocessing-api's
`uvicorn` worker had started before the bind-mounted source gained `QUARTER` and runs without
`--reload`, so it served a stale in-memory schema. A `docker restart` cleared it (verified: the
live OpenAPI `HorizonType` enum now includes `quarter`).

This PR is the **defensive hardening + documentation** so a future API read/write failure
(schema drift or otherwise) does not silently abort the whole run, and so collaborators can
remediate across deployment types.

## Changes

**Code (`8ef2b0b`)** — `apps/preprocessing_runoff/sync_long_horizon_hydrograph.py`
- Per-station catch of API read/write errors (`SapphireAPIError` + `requests` connection/timeout
  only — never bare `Exception`, so programming bugs still surface as exit 3).
- One station's failure now warns and continues; records already written for that station are
  preserved. Tracks `attempted`/`completed`/`failed` station codes via a list-compatible result.
- `main()` exits `2` only when **every attempted station failed** (`completed == 0 and
  attempted > 0`); partial success is exit `0`; the no-station-attempted empty path is preserved.
- 9 new tests; full `preprocessing_runoff` suite green (346 passed, 2 pre-existing skips).

**Docs (`d4fe2a4`)**
- `doc/prod/remediate_quarter_horizon_type_422.md` — collaborator remediation runbook: detect via
  the running API's served enum, then branch by deployment type (local bind-mount restart;
  servers pulling an updated `mabesa/sapphire-preprocessing:latest`; image-owner rebuild/push gate).
- PREPQ-008 issue updated with confirmed root cause + resolution; INFRA-019 filed for the deferred
  api-client `quarter` Literal hygiene; `module_issues.md` indexed.

## Scope / boundaries
- No changes to `sapphire/services/`, the api-client, migrations, or pins.
- The actual operational fix is the **service restart / image refresh**, not this code — this PR
  only prevents a recurrence from aborting the run and documents remediation.

## Not yet done (why this is a draft)
Server deployments pull `mabesa/sapphire-preprocessing:latest`. They are only confirmed clear
after the **image owner rebuilds + pushes `:latest`** (from source ≥ commit `2be58f7`) and each
server pulls — see the runbook. Marking ready once that coordination is scheduled/confirmed.

Refs PREPQ-008, INFRA-019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)