### PR TITLE
INFRA-019: bump sapphire-api-client pin to v0.5.0 (quarter horizon_type Literal consistency)

### DIFF
--- a/apps/forecast_dashboard/uv.lock
+++ b/apps/forecast_dashboard/uv.lock
@@ -628,7 +628,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -1857,8 +1857,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.4.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
+version = "0.5.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b#4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/iEasyHydroForecast/pyproject.toml
+++ b/apps/iEasyHydroForecast/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # External SDK (brings in requests as transitive dependency)
     "ieasyhydro-sdk @ git+https://github.com/hydrosolutions/ieasyhydro-python-sdk@master",
     # SAPPHIRE API client for database-backed I/O
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@4fd543e852f1eb0c834d8ab649a849a0a56d4e9b",
 ]
 
 [project.optional-dependencies]

--- a/apps/iEasyHydroForecast/uv.lock
+++ b/apps/iEasyHydroForecast/uv.lock
@@ -190,7 +190,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -539,8 +539,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.4.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
+version = "0.5.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b#4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/linear_regression/pyproject.toml
+++ b/apps/linear_regression/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # External SDK (brings in requests as transitive dependency)
     "ieasyhydro-sdk @ git+https://github.com/hydrosolutions/ieasyhydro-python-sdk@master",
     # SAPPHIRE API client (for writing forecasts to postprocessing service)
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@4fd543e852f1eb0c834d8ab649a849a0a56d4e9b",
     # Local library dependency
     "iEasyHydroForecast @ file:///${PROJECT_ROOT}/../iEasyHydroForecast",
 ]

--- a/apps/linear_regression/uv.lock
+++ b/apps/linear_regression/uv.lock
@@ -175,7 +175,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -234,7 +234,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
     { name = "requests", specifier = ">=2.32.0" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
 ]
 provides-extras = ["dev"]
 
@@ -494,8 +494,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.4.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
+version = "0.5.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b#4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/long_term_forecasting/pyproject.toml
+++ b/apps/long_term_forecasting/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "requests>=2.32.0",
     "aiohttp>=3.13.4",
     "ieasyhydro-sdk @ git+https://github.com/hydrosolutions/ieasyhydro-python-sdk",
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@4fd543e852f1eb0c834d8ab649a849a0a56d4e9b",
     # Local library dependency
     "iEasyHydroForecast @ file:///${PROJECT_ROOT}/../iEasyHydroForecast",
     "lt-forecasting",

--- a/apps/long_term_forecasting/uv.lock
+++ b/apps/long_term_forecasting/uv.lock
@@ -676,7 +676,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -901,7 +901,7 @@ requires-dist = [
     { name = "pytorch-lightning", specifier = ">=2.5.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.32.0" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "scikit-learn", specifier = ">=1.4.0" },
     { name = "scipy", specifier = ">=1.15.0" },
     { name = "seaborn", specifier = ">=0.13.2" },
@@ -1869,8 +1869,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.4.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
+version = "0.5.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b#4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" }
 dependencies = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },

--- a/apps/machine_learning/pyproject.toml
+++ b/apps/machine_learning/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # Data Gateway client
     "sapphire-dg-client @ git+https://github.com/hydrosolutions/sapphire-dg-client.git@main",
     # SAPPHIRE API client (for writing forecasts to postprocessing service)
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@4fd543e852f1eb0c834d8ab649a849a0a56d4e9b",
     # Local library dependency
     "iEasyHydroForecast @ file:///${PROJECT_ROOT}/../iEasyHydroForecast",
     "pillow>=12.2.0",

--- a/apps/machine_learning/uv.lock
+++ b/apps/machine_learning/uv.lock
@@ -602,7 +602,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -799,7 +799,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytorch-lightning", specifier = ">=2.6.0" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "sapphire-dg-client", git = "https://github.com/hydrosolutions/sapphire-dg-client.git?rev=main" },
     { name = "suntime", specifier = ">=1.3.2" },
     { name = "torch", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cpu" },
@@ -1674,8 +1674,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.4.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
+version = "0.5.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b#4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/pipeline/uv.lock
+++ b/apps/pipeline/uv.lock
@@ -162,7 +162,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -569,8 +569,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.4.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
+version = "0.5.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b#4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/postprocessing_forecasts/pyproject.toml
+++ b/apps/postprocessing_forecasts/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # Scientific computing (GEV distribution for return period thresholds)
     "scipy>=1.11.0",
     # SAPPHIRE API client for database-backed I/O
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@4fd543e852f1eb0c834d8ab649a849a0a56d4e9b",
     # Local library dependency
     "iEasyHydroForecast @ file:///${PROJECT_ROOT}/../iEasyHydroForecast",
 ]

--- a/apps/postprocessing_forecasts/uv.lock
+++ b/apps/postprocessing_forecasts/uv.lock
@@ -161,7 +161,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -384,7 +384,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
     { name = "requests", specifier = ">=2.32.0" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "scipy", specifier = ">=1.11.0" },
 ]
 provides-extras = ["dev"]
@@ -461,8 +461,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.4.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
+version = "0.5.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b#4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/preprocessing_gateway/pyproject.toml
+++ b/apps/preprocessing_gateway/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # SAPPHIRE Data Gateway client (private repo - requires access)
     "sapphire-dg-client @ git+https://github.com/hydrosolutions/sapphire-dg-client.git@main",
     # SAPPHIRE API client (for writing to preprocessing service)
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@4fd543e852f1eb0c834d8ab649a849a0a56d4e9b",
     # Local library dependency
     "iEasyHydroForecast",
 ]

--- a/apps/preprocessing_gateway/uv.lock
+++ b/apps/preprocessing_gateway/uv.lock
@@ -148,7 +148,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -333,7 +333,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "sapphire-dg-client", git = "https://github.com/hydrosolutions/sapphire-dg-client.git?rev=main" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
     { name = "scipy", specifier = ">=1.14.0" },
@@ -424,8 +424,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.4.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
+version = "0.5.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b#4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/preprocessing_runoff/pyproject.toml
+++ b/apps/preprocessing_runoff/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     # External SDK (brings in requests as transitive dependency)
     "ieasyhydro-sdk @ git+https://github.com/hydrosolutions/ieasyhydro-python-sdk@master",
     # SAPPHIRE API client for database writes
-    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@7bd349172ef24576b654a7b78f38734de3f2e657",
+    "sapphire-api-client @ git+https://github.com/hydrosolutions/sapphire-api-client.git@4fd543e852f1eb0c834d8ab649a849a0a56d4e9b",
     # Local library dependency
     "iEasyHydroForecast @ file:///${PROJECT_ROOT}/../iEasyHydroForecast",
 ]

--- a/apps/preprocessing_runoff/uv.lock
+++ b/apps/preprocessing_runoff/uv.lock
@@ -330,7 +330,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -592,7 +592,7 @@ requires-dist = [
     { name = "pytz", specifier = ">=2024.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.32.0" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
 ]
 provides-extras = ["google-sheets", "dev"]
 
@@ -790,8 +790,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.4.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
+version = "0.5.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b#4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },

--- a/apps/preprocessing_station_forcing/uv.lock
+++ b/apps/preprocessing_station_forcing/uv.lock
@@ -161,7 +161,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2024.1" },
-    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657" },
+    { name = "sapphire-api-client", git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" },
     { name = "scikit-learn", specifier = ">=1.5.0" },
 ]
 provides-extras = ["dev"]
@@ -459,8 +459,8 @@ wheels = [
 
 [[package]]
 name = "sapphire-api-client"
-version = "0.4.0"
-source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=7bd349172ef24576b654a7b78f38734de3f2e657#7bd349172ef24576b654a7b78f38734de3f2e657" }
+version = "0.5.0"
+source = { git = "https://github.com/hydrosolutions/sapphire-api-client.git?rev=4fd543e852f1eb0c834d8ab649a849a0a56d4e9b#4fd543e852f1eb0c834d8ab649a849a0a56d4e9b" }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },


### PR DESCRIPTION
## What
Re-pin `sapphire-api-client` **0.4.0 (`7bd3491`) → 0.5.0 (`4fd543e`)** across the 7 pinning
modules, and regenerate the 10 affected `uv.lock` files.

## Why
Resolves **INFRA-019** (deferred from PREPQ-008 decision D3). v0.5.0 unifies the per-method
`horizon_type` `Literal` type hints behind a single `HorizonTypeLiteral` source of truth in
`validators.py` (now including `quarter`), with `VALID_HORIZONS = set(get_args(HorizonTypeLiteral))`
derived from it — so the static type hints and runtime validation can no longer drift apart.
Previously the Literals disagreed about `quarter` across `preprocessing.py`/`short_term.py`/
`postprocessing*.py`.

## Files (17)
- 7 × `pyproject.toml`: iEasyHydroForecast, linear_regression, long_term_forecasting,
  machine_learning, postprocessing_forecasts, preprocessing_gateway, preprocessing_runoff
- 10 × `uv.lock` (the 7 above + transitive: forecast_dashboard, pipeline,
  preprocessing_station_forcing)

## Verification
`SAPPHIRE_TEST_ENV=True bash run_tests.sh` — **all 8 client-consuming modules green on v0.5.0**
(iEasyHydroForecast, preprocessing_gateway, linear_regression, machine_learning,
postprocessing_forecasts, pipeline, long_term_forecasting, preprocessing_runoff). The
forecast_dashboard Playwright launch error (INFRA-018) and the broken validate_pipeline /
service:postprocessing venvs are pre-existing and unrelated to this bump.

Refs INFRA-019, PREPQ-008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)