### PR TITLE
Mark INFRA-019 resolved (sapphire-api-client v0.5.0 re-pinned)

### DIFF
--- a/doc/plans/issues/mid_prio_gi_draft_infra_api_client_quarter_literal_consistency.md
+++ b/doc/plans/issues/mid_prio_gi_draft_infra_api_client_quarter_literal_consistency.md
@@ -1,6 +1,6 @@
 ## sapphire-api-client `horizon_type` Literals diverge — `quarter` missing on most write/read paths (INFRA-019)
 
-**Status**: Draft (2026-06-12)
+**Status**: Resolved 2026-06-12 — fixed upstream in `sapphire-api-client` v0.5.0 (`4fd543e`); pin bumped 0.4.0 → 0.5.0 across all consuming modules and landed on `maxat_sapphire_2` via PR #373. Upstream now exposes a single `HorizonTypeLiteral` source of truth in `validators.py` (includes `quarter`), with `VALID_HORIZONS = set(get_args(HorizonTypeLiteral))` derived from it so type hints and runtime validation cannot drift.
 **Module**: `sapphire-api-client` (external repo: `hydrosolutions/sapphire-api-client`) + every SAPPHIRE module that pins it
 **Priority**: **Medium** (hygiene / latent footgun — no current operational failure traces to it)
 **Labels**: `api-client`, `enum`, `consistency`, `tech-debt`, `cross-module`
@@ -39,6 +39,6 @@ The pinned `sapphire-api-client` (rev `7bd349172ef24576b654a7b78f38734de3f2e657`
 
 ## Acceptance criteria
 
-- [ ] All `horizon_type` Literals in the client match the server `HorizonType` value set (incl. `quarter`).
-- [ ] New client rev cut upstream and pin bumped across all consuming modules.
-- [ ] `SAPPHIRE_TEST_ENV=True bash run_tests.sh` green across affected modules after re-pin.
+- [x] All `horizon_type` Literals in the client match the server `HorizonType` value set (incl. `quarter`) — unified behind `HorizonTypeLiteral` in v0.5.0.
+- [x] New client rev cut upstream (v0.5.0, `4fd543e`) and pin bumped across all consuming modules (PR #373).
+- [x] `SAPPHIRE_TEST_ENV=True bash run_tests.sh` green across affected modules after re-pin (all 8 client-consuming modules pass; 40/40 CI checks green on #373).

--- a/doc/plans/module_issues.md
+++ b/doc/plans/module_issues.md
@@ -103,7 +103,7 @@ These are blocking decisions — work downstream cannot advance until they are r
 | **FD-002b** | Synthetic integration tests with fake data | fd | **Medium** | Open | — (plan file never created) | — |
 | **INFRA-017** | Document DB initialization for fresh deployments (`SAPPHIRE_SYNC_MODE=initial`) | infra | **Medium** | Draft | [`mid_prio_gi_draft_infra_initial_sync_docs.md`](issues/mid_prio_gi_draft_infra_initial_sync_docs.md) | — |
 | **INFRA-018** | Playwright integration tests fail at browser launch under macOS sandbox (verification noise + potential CI coverage gap) | infra | **Low** | Draft | [`low_prio_gi_draft_infra_playwright_sandbox_browser_launch.md`](issues/low_prio_gi_draft_infra_playwright_sandbox_browser_launch.md) | — |
-| **INFRA-019** | sapphire-api-client `horizon_type` Literals diverge — `quarter` missing on most paths (hygiene, deferred from PREPQ-008 D3) | infra | **Medium** | Draft | [`mid_prio_gi_draft_infra_api_client_quarter_literal_consistency.md`](issues/mid_prio_gi_draft_infra_api_client_quarter_literal_consistency.md) | — |
+| ~~**INFRA-019**~~ | ~~sapphire-api-client `horizon_type` Literals diverge — `quarter` missing on most paths (hygiene, deferred from PREPQ-008 D3)~~ | infra | | Complete | [`mid_prio_gi_draft_infra_api_client_quarter_literal_consistency.md`](issues/mid_prio_gi_draft_infra_api_client_quarter_literal_consistency.md) | Fixed in sapphire-api-client v0.5.0 (`4fd543e`); pin bumped via PR #373 (2026-06-12). |
 | ~~**P-006**~~ | ~~Move long-term schedule query into Luigi pipeline~~ | ~~pipeline~~ | | Complete | [`review_gi_draft_pipeline_lt_schedule_into_luigi.md`](issues/review_gi_draft_pipeline_lt_schedule_into_luigi.md) | — |
 
 ---


### PR DESCRIPTION
Doc-only: marks INFRA-019 Complete in the issue draft + module_issues index, now that the `horizon_type` Literal divergence is fixed upstream in sapphire-api-client v0.5.0 (`4fd543e`) and the pin was bumped across all modules via PR #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)