### PR TITLE
security: tier-1/2 low-risk services Dependabot bumps (idna, python-dotenv, pygments, requests)

### DIFF
--- a/doc/prod/dependabot_services_handoff_2026-06-17.md
+++ b/doc/prod/dependabot_services_handoff_2026-06-17.md
@@ -16,8 +16,26 @@ colleague review before merge.
 
 | Package | Bumped to | Severity | Services | Status |
 |---|---|---|---|---|
-| **urllib3** | 2.6.3 → **2.7.0** | high | postprocessing, preprocessing | ✅ done |
-| **Mako** | 1.3.10/1.3.11 → **1.3.12** | high | postprocessing, preprocessing | ✅ done |
+| **urllib3** | 2.6.3 → **2.7.0** | high | postprocessing, preprocessing | ✅ done (PR #378) |
+| **Mako** | 1.3.10/1.3.11 → **1.3.12** | high | postprocessing, preprocessing | ✅ done (PR #378) |
+| **idna** | 3.11 → **3.18** | medium | api-gateway, postprocessing, preprocessing | ✅ done (tier-1 PR) |
+| **python-dotenv** | 1.2.1 → **1.2.2** | medium | postprocessing | ✅ done (tier-1 PR) |
+| **Pygments** | 2.19.2 → **2.20.0** | low | postprocessing | ✅ done (tier-1 PR) |
+| **requests** | 2.32.5 → **2.34.2** | medium | postprocessing | ✅ done (tier-2 PR, lock+requirements) |
+
+## ⚠️ auth + user — needs owner action (stale lock blocks a clean bump)
+
+`auth` and `user` declare `alembic>=1.17.0` in `pyproject.toml`, but **alembic is
+missing from their committed `uv.lock`** (the lock is stale). Any `uv lock` run
+reconciles this and adds `alembic` + its sub-deps `mako`/`markupsafe`. Because
+that expands the change beyond the security bump and touches dependency
+resolution, the following were **deferred to you** rather than forced through:
+
+- **auth**: cryptography 46.0.7 → 48.0.1 (high), idna 3.11 → 3.15+
+- **user**: idna 3.11 → 3.15+
+
+Recommend: first reconcile the lock (commit the alembic addition deliberately),
+then the idna/cryptography bumps are clean lock-only changes.
 
 ## Remaining — recommended bumps (bump to the highest target to clear all stacked alerts)
 
@@ -25,7 +43,7 @@ colleague review before merge.
 |---|---|---|---|
 | **starlette** | **1.3.1** | high | api-gateway, auth, postprocessing, preprocessing, user |
 | **python-multipart** | **0.0.31** | high | api-gateway, auth, user |
-| **cryptography** | **48.0.1** | high | auth |
+| **pytest** (requirements.txt `==8.4.2`) | **9.0.3** | medium | postprocessing, preprocessing |
 | **idna** | **3.15** | medium | api-gateway, auth, postprocessing, preprocessing, user |
 | **requests** | **2.33.0** | medium | postprocessing |
 | **pytest** | **9.0.3** | medium | postprocessing, preprocessing |

--- a/sapphire/services/api-gateway/uv.lock
+++ b/sapphire/services/api-gateway/uv.lock
@@ -292,11 +292,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]

--- a/sapphire/services/postprocessing/requirements.txt
+++ b/sapphire/services/postprocessing/requirements.txt
@@ -9,4 +9,4 @@ pytest==8.4.2
 pytest-cov==6.0.0
 httpx==0.28.0
 pandas==2.3.3
-requests==2.33.0
+requests==2.34.2

--- a/sapphire/services/postprocessing/uv.lock
+++ b/sapphire/services/postprocessing/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1002,9 +1002,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]

--- a/sapphire/services/postprocessing/uv.lock
+++ b/sapphire/services/postprocessing/uv.lock
@@ -400,11 +400,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -879,11 +879,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -930,11 +930,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]

--- a/sapphire/services/preprocessing/uv.lock
+++ b/sapphire/services/preprocessing/uv.lock
@@ -416,11 +416,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Second batch of low-risk `sapphire/services/*` Dependabot fixes, crossing the colleague-owned boundary with explicit maintainer authorization. Follows #378. **@service-owner please review the service lockfile/requirements changes before merge.**

### Phase 1 — tier-1 transitive bumps (lock-only, none pinned in pyproject/requirements)
| Package | Bump | Services | Sev |
|---|---|---|---|
| idna | 3.11 → 3.18 | api-gateway, postprocessing, preprocessing | medium |
| python-dotenv | 1.2.1 → 1.2.2 | postprocessing | medium |
| pygments | 2.19.2 → 2.20.0 | postprocessing | low |

### Phase 2 — tier-2 (direct dep, lock + requirements reconciled)
| Package | Bump | Services | Sev |
|---|---|---|---|
| requests | 2.32.5 → 2.34.2 | postprocessing | medium |

`requirements.txt` `requests` line updated to match the lock (it had drifted to `==2.33.0` while the lock lagged at `2.32.5`). pyproject already allowed it (`requests>=2.32.0`), unchanged.

## Tests (run against synced venvs)
- service:api-gateway — 18 passed
- service:postprocessing — 110 passed (both phases)
- service:preprocessing — 110 passed

## ⚠️ Deferred to service owner: auth + user
Bumping idna/cryptography there forces a **stale-lock reconciliation** — both declare `alembic>=1.17.0` in pyproject but it's missing from the committed `uv.lock`, so `uv lock` adds alembic+mako+markupsafe. That's the owner's lock to fix; the cryptography-auth (high) + idna bumps should follow once reconciled. Details in `doc/prod/dependabot_services_handoff_2026-06-17.md`.

## Still deferred (risk/major): starlette (0.x→1.x), python-multipart (`requirements.txt ==0.0.22`), pytest (major 8→9 in requirements.txt), ecdsa (no fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)