### PR TITLE
Two-model EM: fix quarter/season persistence, per-issue-date seasonal EM, drop stored baselines

### DIFF
--- a/apps/forecast_dashboard/dashboard/bulletin_manager.py
+++ b/apps/forecast_dashboard/dashboard/bulletin_manager.py
@@ -1,11 +1,16 @@
 import calendar
+
 import pandas as pd
 import panel as pn
-
-from src.gettext_config import _
-from dashboard.logger import setup_logger
-from dashboard.utils import hydrate_month_hydrograph_stats, hydrate_season_hydrograph_stats, rehydrate_sites_hydrograph_stats
 from src import db  # _read_data, _save_data, _delete_data live here
+from src.gettext_config import _
+
+from dashboard.logger import setup_logger
+from dashboard.utils import (
+    hydrate_month_hydrograph_stats,
+    hydrate_season_hydrograph_stats,
+    rehydrate_sites_hydrograph_stats,
+)
 
 logger = setup_logger()
 
@@ -165,7 +170,7 @@ def _load_bulletin_from_api(horizon_type: str, forecast_year: int, forecast_hori
                 hydrate_month_hydrograph_stats(site, forecast_horizon, db)
                 site.get_monthly_forecast_attributes_for_site(_, site.forecasts, days_in_month)
                 if 'вдхр' in (site.punkt_name_ru or ''):
-                    q_df = db.get_long_forecasts_quarter(site.code, horizon_value=1)
+                    q_df = db.get_long_forecasts_quarter(site.code)
                     if "code" in q_df.columns and "date" in q_df.columns and not q_df.empty:
                         filtered_q = q_df[q_df["code"] == site.code]
                         if not filtered_q.empty:
@@ -183,7 +188,7 @@ def _load_bulletin_from_api(horizon_type: str, forecast_year: int, forecast_hori
                 else:
                     site.get_quarterly_forecast_attributes_for_site(_, pd.DataFrame(), 0)
             elif horizon_type == 'season':
-                s_df = db.get_long_forecasts_season(site.code)
+                s_df = db.get_long_forecasts_season(site.code, horizon_value=forecast_horizon)
                 if (
                     not s_df.empty
                     and "code" in s_df.columns
@@ -390,7 +395,7 @@ class BulletinManager:
             )
             # Populate quarterly attributes for reservoir sites
             if 'вдхр' in (selected_site.punkt_name_ru or ''):
-                q_df = db.get_long_forecasts_quarter(selected_site.code, horizon_value=1)
+                q_df = db.get_long_forecasts_quarter(selected_site.code)
                 if "code" in q_df.columns and "date" in q_df.columns and not q_df.empty:
                     filtered_q = q_df[q_df["code"] == selected_site.code]
                     if not filtered_q.empty:
@@ -492,7 +497,7 @@ class BulletinManager:
             )
             # Populate quarterly attributes for reservoir sites
             if 'вдхр' in (selected_site.punkt_name_ru or ''):
-                q_df = db.get_long_forecasts_quarter(selected_site.code, horizon_value=1)
+                q_df = db.get_long_forecasts_quarter(selected_site.code)
                 if "code" in q_df.columns and "date" in q_df.columns and not q_df.empty:
                     filtered_q = q_df[q_df["code"] == selected_site.code]
                     if not filtered_q.empty:

--- a/apps/forecast_dashboard/src/db.py
+++ b/apps/forecast_dashboard/src/db.py
@@ -6,11 +6,17 @@ from functools import wraps
 import numpy as np
 import pandas as pd
 import requests
-
+from dashboard.logger import setup_logger
 from src import processing
 from src.gettext_config import _
 from src.snow_window import snow_display_window
-from dashboard.logger import setup_logger
+
+from iEasyHydroForecast.long_term_horizon_resolver import (
+    quarter_horizon_value,
+    seasonal_config_name,
+    seasonal_horizon_value,
+    supported_long_term_modes,
+)
 
 logger = setup_logger()
 
@@ -36,6 +42,8 @@ SNOW_RENAME_MAP = {
     "q95": "95%",
 }
 
+SEASONAL_ISSUE_MONTHS = (1, 2, 3, 4)
+
 # Neural Ensemble config
 NE_BASE_MODELS = ["TFT", "TiDE", "TSMixer"]
 NE_QUANTILE_COLS = ["Q5", "Q25", "Q75", "Q95", "E[Q]"]
@@ -58,6 +66,40 @@ def _horizon_in_year_col(horizon: str) -> str:
 
 def _resolve_station(station) -> str:
     return station if isinstance(station, str) else station.value.split()[0]
+
+
+def _resolve_quarter_horizon_value(horizon_value: int | None = None) -> int:
+    if horizon_value is not None:
+        return int(horizon_value)
+    return quarter_horizon_value()
+
+
+def _supported_seasonal_issue_months() -> list[int]:
+    modes = set(supported_long_term_modes())
+    return [
+        issue_month
+        for issue_month in SEASONAL_ISSUE_MONTHS
+        if seasonal_config_name(issue_month) in modes
+    ]
+
+
+def _default_seasonal_issue_month(ref_date: date | None = None) -> int:
+    supported = _supported_seasonal_issue_months()
+    if not supported:
+        raise ValueError("No seasonal long-term modes are supported by this deployment.")
+
+    month = (ref_date or date.today()).month
+    eligible = [issue_month for issue_month in supported if issue_month <= month]
+    return max(eligible or supported)
+
+
+def _resolve_seasonal_horizon_value(
+    issue_month: int | None = None,
+    horizon_value: int | None = None,
+) -> int:
+    if horizon_value is not None:
+        return int(horizon_value)
+    return seasonal_horizon_value(issue_month or _default_seasonal_issue_month())
 
 
 def _timed(func):
@@ -597,12 +639,13 @@ def get_long_forecasts(station=None, horizon_value=1) -> pd.DataFrame:
 
 
 @_timed
-def get_long_forecasts_quarter(station=None, horizon_value=1) -> pd.DataFrame:
+def get_long_forecasts_quarter(station=None, horizon_value=None) -> pd.DataFrame:
     """Fetch long-term quarterly forecasts and reshape to match monthly format."""
     code = _resolve_station(station) if station else None
+    resolved_horizon_value = _resolve_quarter_horizon_value(horizon_value)
     params = {
         "horizon_type": "quarter",
-        "horizon_value": horizon_value,
+        "horizon_value": resolved_horizon_value,
         "start_date": f"{PREVIOUS_YEAR}-12-20",
         "end_date": f"{CURRENT_YEAR}-12-31",
         "limit": 1000,
@@ -645,11 +688,17 @@ def get_long_forecasts_quarter(station=None, horizon_value=1) -> pd.DataFrame:
 
 
 @_timed
-def get_long_forecasts_season(station=None) -> pd.DataFrame:
+def get_long_forecasts_season(
+    station=None,
+    issue_month: int | None = None,
+    horizon_value: int | None = None,
+) -> pd.DataFrame:
     """Fetch long-term seasonal forecasts and reshape to match monthly format."""
     code = _resolve_station(station) if station else None
+    resolved_horizon_value = _resolve_seasonal_horizon_value(issue_month, horizon_value)
     params = {
         "horizon_type": "season",
+        "horizon_value": resolved_horizon_value,
         "start_date": f"{PREVIOUS_YEAR}-12-20",
         "end_date": f"{CURRENT_YEAR}-12-31",
         "limit": 1000,
@@ -675,17 +724,23 @@ def get_long_forecasts_season(station=None) -> pd.DataFrame:
         "q05": "Q5", "q10": "Q10", "q25": "Q25",
         "q50": "Q50", "q75": "Q75", "q90": "Q90", "q95": "Q95",
     }, inplace=True)
+    df["season_in_year"] = pd.to_numeric(df["horizon_value"], errors="coerce").astype("Int64")
     df.drop(columns=["id", "horizon_type", "horizon_value"], inplace=True, errors="ignore")
     df["valid_from"] = pd.to_datetime(df["valid_from"])
     df["month_in_year"] = df["valid_from"].dt.month
-    df["season_in_year"] = 1
     df["Date"] = df["date"]
     df["year"] = df["date"].dt.year
-    # Keep only the latest-by-date row per (code, model_short)
-    if not df.empty and "date" in df.columns and "code" in df.columns and "model_short" in df.columns:
+    # Keep only the latest-by-date row per (code, season lead, model_short)
+    if (
+        not df.empty
+        and "date" in df.columns
+        and "code" in df.columns
+        and "season_in_year" in df.columns
+        and "model_short" in df.columns
+    ):
         df = (
             df.sort_values("date", ascending=False)
-              .drop_duplicates(subset=["code", "model_short"], keep="first")
+              .drop_duplicates(subset=["code", "season_in_year", "model_short"], keep="first")
               .reset_index(drop=True)
         )
     return _convert_na_to_nan(df.sort_values("Date"))
@@ -702,8 +757,11 @@ def get_data(
     snow_display_start_month: int = 1,
     snow_display_start_day: int = 1,
 ) -> dict:
-    add_labels = lambda df: processing.add_labels_to_hydrograph(df, all_stations)
-    i18n_models = lambda df: processing.internationalize_forecast_model_names(_, df)
+    def add_labels(df):
+        return processing.add_labels_to_hydrograph(df, all_stations)
+
+    def i18n_models(df):
+        return processing.internationalize_forecast_model_names(_, df)
 
     if horizon == "month":
         return _get_data_monthly(
@@ -803,23 +861,26 @@ def _get_data_monthly(
             suffixes=("", "_stats"),
         )
 
-    long_forecasts_quarter = i18n_models(add_labels(get_long_forecasts_quarter(station, horizon_value=1)))
-    quarter_forecast_stats = i18n_models(get_forecast_stats("quarter", station))
+    long_forecasts_quarter = pd.DataFrame()
+    quarter_forecast_stats = pd.DataFrame()
     quarter_hin = _horizon_in_year_col("quarter")
     quarter_merge_keys = ["code", quarter_hin, "model_short"]
-    can_merge_quarter = (
-        not long_forecasts_quarter.empty
-        and not quarter_forecast_stats.empty
-        and all(k in long_forecasts_quarter.columns for k in quarter_merge_keys)
-        and all(k in quarter_forecast_stats.columns for k in quarter_merge_keys)
-    )
-    if can_merge_quarter:
-        long_forecasts_quarter = long_forecasts_quarter.merge(
-            quarter_forecast_stats,
-            on=quarter_merge_keys,
-            how="left",
-            suffixes=("", "_stats"),
+    if "quarter" in supported_modes:
+        long_forecasts_quarter = i18n_models(add_labels(get_long_forecasts_quarter(station)))
+        quarter_forecast_stats = i18n_models(get_forecast_stats("quarter", station))
+        can_merge_quarter = (
+            not long_forecasts_quarter.empty
+            and not quarter_forecast_stats.empty
+            and all(k in long_forecasts_quarter.columns for k in quarter_merge_keys)
+            and all(k in quarter_forecast_stats.columns for k in quarter_merge_keys)
         )
+        if can_merge_quarter:
+            long_forecasts_quarter = long_forecasts_quarter.merge(
+                quarter_forecast_stats,
+                on=quarter_merge_keys,
+                how="left",
+                suffixes=("", "_stats"),
+            )
 
     data = {
         "hydrograph_day_all":   add_labels(get_hydrograph_day_all(station)),

--- a/apps/forecast_dashboard/src/db.py
+++ b/apps/forecast_dashboard/src/db.py
@@ -11,7 +11,7 @@ from src import processing
 from src.gettext_config import _
 from src.snow_window import snow_display_window
 
-from iEasyHydroForecast.long_term_horizon_resolver import (
+from long_term_horizon_resolver import (
     quarter_horizon_value,
     seasonal_config_name,
     seasonal_horizon_value,

--- a/apps/forecast_dashboard/tests/test_bulletin_header_date.py
+++ b/apps/forecast_dashboard/tests/test_bulletin_header_date.py
@@ -16,7 +16,6 @@ import types
 from unittest.mock import MagicMock
 
 import pandas as pd
-import pytest
 
 # ---------------------------------------------------------------------------
 # Bootstrap: mock heavy dashboard dependencies before importing the module.
@@ -95,6 +94,45 @@ def _make_forecasts_all(issue_date_str, valid_from_str):
             "date": [pd.Timestamp(issue_date_str)],
             "valid_from": [pd.Timestamp(valid_from_str)],
             "month_in_year": [pd.Timestamp(valid_from_str).month],
+        }
+    )
+
+
+def _make_site(code="19999", reservoir=True):
+    site = MagicMock()
+    site.code = code
+    site.station_label = f"{code} - Test"
+    site.basin_ru = "Test Basin"
+    site.punkt_name_ru = "Тест вдхр" if reservoir else "Тест"
+    return site
+
+
+def _make_bulletin_record(code="19999"):
+    return {
+        "code": code,
+        "model_type": "LR_Base",
+        "forecasted_discharge": 100.0,
+        "fc_lower": 90.0,
+        "fc_upper": 110.0,
+        "delta": 1.0,
+        "sdivsigma": 2.0,
+        "mae": 3.0,
+        "accuracy": 90.0,
+    }
+
+
+def _make_long_forecast_record(code="19999", lead=0):
+    return pd.DataFrame(
+        {
+            "code": [code],
+            "date": [pd.Timestamp("2026-04-22")],
+            "valid_from": [pd.Timestamp("2026-04-01")],
+            "valid_to": [pd.Timestamp("2026-09-30")],
+            "model_short": ["LR_Base"],
+            "forecasted_discharge": [100.0],
+            "Q25": [90.0],
+            "Q75": [110.0],
+            "season_in_year": [lead],
         }
     )
 
@@ -230,3 +268,37 @@ class TestResolveBulletinHeaderDate:
         result = resolve_bulletin_header_date("month", last_date, forecasts_all)
 
         assert result.month == 6
+
+
+class TestBulletinLongTermLeads:
+    def test_month_load_uses_resolved_quarter_default(self, monkeypatch):
+        site = _make_site()
+        fake_db = MagicMock()
+        fake_db._read_data.return_value = pd.DataFrame([_make_bulletin_record()])
+        fake_db.get_long_forecasts_quarter.return_value = _make_long_forecast_record()
+        monkeypatch.setattr(bulletin_manager, "db", fake_db)
+        monkeypatch.setattr(
+            bulletin_manager, "hydrate_month_hydrograph_stats", MagicMock()
+        )
+
+        bulletin_manager._load_bulletin_from_api("month", 2026, 4, [site])
+
+        fake_db.get_long_forecasts_quarter.assert_called_once_with(site.code)
+
+    def test_season_load_passes_saved_issue_lead(self, monkeypatch):
+        site = _make_site(reservoir=False)
+        fake_db = MagicMock()
+        fake_db._read_data.return_value = pd.DataFrame([_make_bulletin_record()])
+        fake_db.get_long_forecasts_season.return_value = _make_long_forecast_record(
+            lead=0
+        )
+        monkeypatch.setattr(bulletin_manager, "db", fake_db)
+        monkeypatch.setattr(
+            bulletin_manager, "hydrate_season_hydrograph_stats", MagicMock()
+        )
+
+        bulletin_manager._load_bulletin_from_api("season", 2026, 0, [site])
+
+        fake_db.get_long_forecasts_season.assert_called_once_with(
+            site.code, horizon_value=0
+        )

--- a/apps/forecast_dashboard/tests/test_db.py
+++ b/apps/forecast_dashboard/tests/test_db.py
@@ -3,6 +3,7 @@
 Tests pure helpers directly, and API-calling functions with mocked HTTP.
 """
 
+import json
 from datetime import date
 from unittest.mock import MagicMock
 
@@ -10,8 +11,35 @@ import numpy as np
 import pandas as pd
 import pytest
 import requests
-from src import db
-from src import vizualization
+from src import db, vizualization
+
+
+@pytest.fixture(autouse=True)
+def _long_term_resolver_env(monkeypatch, tmp_path):
+    config_dir = tmp_path / "long_term_configs"
+    config_dir.mkdir()
+    leads = {
+        "quarter": 1,
+        "seasonal_january": 3,
+        "seasonal_february": 2,
+        "seasonal_march": 1,
+        "seasonal_april": 0,
+    }
+    for name, lead in leads.items():
+        (config_dir / f"{name}.json").write_text(
+            json.dumps({"operational_month_lead_time": lead})
+        )
+
+    monkeypatch.setenv("ieasyforecast_configuration_path", str(tmp_path))
+    monkeypatch.setenv(
+        "ieasyhydroforecast_ml_long_term_configuration",
+        "long_term_configs",
+    )
+    monkeypatch.setenv(
+        "ieasyhydroforecast_ml_long_term_supported_modes",
+        ",".join(leads),
+    )
+    return config_dir
 
 # ── _convert_na_to_nan ─────────────────────────────────────────────────────
 
@@ -883,6 +911,36 @@ _SEASON_FORECAST_RECORD = {
 
 
 class TestGetLongForecastsQuarter:
+    @pytest.mark.parametrize(("lead", "expected_name"), [(0, "tajik"), (1, "kyrgyz")])
+    def test_default_horizon_value_comes_from_deployment_config(
+        self, lead, expected_name, monkeypatch, tmp_path
+    ):
+        config_dir = tmp_path / expected_name
+        config_dir.mkdir()
+        (config_dir / "quarter.json").write_text(
+            json.dumps({"operational_month_lead_time": lead})
+        )
+        monkeypatch.setenv("ieasyforecast_configuration_path", str(tmp_path))
+        monkeypatch.setenv(
+            "ieasyhydroforecast_ml_long_term_configuration",
+            expected_name,
+        )
+        monkeypatch.setenv(
+            "ieasyhydroforecast_ml_long_term_supported_modes",
+            "quarter",
+        )
+        seen_params = []
+
+        def mock_get(url, **kwargs):
+            seen_params.append(kwargs["params"])
+            return _make_mock_response([])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        db.get_long_forecasts_quarter(station="99001")
+
+        assert seen_params[0]["horizon_value"] == lead
+
     def test_renames_and_latest_dedup(self, monkeypatch):
         """Two rows same (code, model_short) — only latest date survives."""
         older = {**_QUARTER_FORECAST_RECORD, "date": "2026-03-01"}
@@ -961,16 +1019,19 @@ class TestGetLongForecastsSeason:
         assert result.empty
         assert "forecasted_discharge" in result.columns
 
-    def test_season_in_year_is_single_bucket(self, monkeypatch):
+    def test_season_in_year_comes_from_api_horizon_value(self, monkeypatch):
         def mock_get(url, **kwargs):
-            return _make_mock_response([_SEASON_FORECAST_RECORD_19999])
+            assert kwargs["params"]["horizon_value"] == 0
+            return _make_mock_response(
+                [{**_SEASON_FORECAST_RECORD_19999, "horizon_value": 0}]
+            )
 
         monkeypatch.setattr(requests, "get", mock_get)
 
-        result = db.get_long_forecasts_season(station="19999")
+        result = db.get_long_forecasts_season(station="19999", horizon_value=0)
 
         assert "season_in_year" in result.columns
-        assert result["season_in_year"].iloc[0] == 1
+        assert result["season_in_year"].iloc[0] == 0
 
     def test_empty_api_response_declares_season_key(self, monkeypatch):
         def mock_get(url, **kwargs):
@@ -1228,6 +1289,71 @@ class TestGetDataSeason:
         assert base["delta"] == 1.0
         assert sm["delta"] == 3.0
         assert sm["sdivsigma"] == 3.5
+
+    def test_all_four_season_leads_retain_their_own_skill(self, monkeypatch):
+        """Forecast rows for Jan/Feb/Mar/Apr issues keep per-lead skill metrics."""
+        leads = [3, 2, 1, 0]
+        forecasts = pd.DataFrame(
+            [
+                {
+                    "code": "19999",
+                    "date": pd.Timestamp(f"2026-0{4 - lead}-22"),
+                    "Date": pd.Timestamp(f"2026-0{4 - lead}-22"),
+                    "year": 2026,
+                    "model_short": "LR_Base",
+                    "model_long": "Linear regression base",
+                    "forecasted_discharge": 300.0 + lead,
+                    "flag": 0,
+                    "Q5": 270.0,
+                    "Q25": 280.0,
+                    "Q75": 320.0,
+                    "Q95": 330.0,
+                    "E[Q]": 300.0,
+                    "valid_from": pd.Timestamp("2026-04-01"),
+                    "month_in_year": 4,
+                    "season_in_year": lead,
+                }
+                for lead in leads
+            ]
+        )
+        skills = pd.DataFrame(
+            [
+                {
+                    "code": "19999",
+                    "season_in_year": lead,
+                    "model_short": "LR_Base",
+                    "model_long": "Linear regression base",
+                    "delta": float(lead) + 0.25,
+                    "sdivsigma": float(lead) + 0.5,
+                    "mae": float(lead) + 0.75,
+                    "accuracy": 90.0 + lead,
+                }
+                for lead in leads
+            ]
+        )
+
+        monkeypatch.setattr("src.db.get_long_forecasts_season", lambda station: forecasts)
+        monkeypatch.setattr("src.db.get_forecast_stats", lambda horizon, station: skills)
+        monkeypatch.setattr("src.db.get_hydrograph_day_all", lambda station: pd.DataFrame())
+        monkeypatch.setattr("src.db.get_rain", lambda station: pd.DataFrame())
+        monkeypatch.setattr("src.db.get_temp", lambda station: pd.DataFrame())
+        monkeypatch.setattr("src.db.get_snow_data", lambda *args, **kwargs: {})
+        self._patch_processing(monkeypatch)
+
+        data = db.get_data(
+            "season",
+            "19999",
+            pd.DataFrame({"code": ["19999"], "station_labels": ["Test River B"]}),
+        )
+
+        by_lead = data["forecasts_all"].set_index("season_in_year")
+        assert sorted(by_lead.index.tolist()) == [0, 1, 2, 3]
+        for lead in leads:
+            row = by_lead.loc[lead]
+            assert row["delta"] == float(lead) + 0.25
+            assert row["sdivsigma"] == float(lead) + 0.5
+            assert row["mae"] == float(lead) + 0.75
+            assert row["accuracy"] == 90.0 + lead
 
     def test_no_skill_metrics_still_returns_forecasts(self, monkeypatch):
         """Empty season skill metrics do not block forecast rows."""

--- a/apps/iEasyHydroForecast/long_term_horizon_resolver.py
+++ b/apps/iEasyHydroForecast/long_term_horizon_resolver.py
@@ -1,0 +1,115 @@
+"""Resolve long-term forecast horizon values from deployment configuration."""
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+CONFIG_ROOT_ENV = "ieasyforecast_configuration_path"
+LONG_TERM_CONFIG_DIR_ENV = "ieasyhydroforecast_ml_long_term_configuration"
+SUPPORTED_MODES_ENV = "ieasyhydroforecast_ml_long_term_supported_modes"
+
+QUARTER_CONFIG_NAME = "quarter"
+OPERATIONAL_MONTH_LEAD_TIME_FIELD = "operational_month_lead_time"
+
+_SEASONAL_CONFIG_NAMES_BY_ISSUE_MONTH = {
+    1: "seasonal_january",
+    2: "seasonal_february",
+    3: "seasonal_march",
+    4: "seasonal_april",
+}
+
+
+class LongTermHorizonResolverError(RuntimeError):
+    """Base error for long-term horizon resolution failures."""
+
+
+class UnsupportedLongTermModeError(LongTermHorizonResolverError):
+    """Raised when the deployment does not support the requested long-term mode."""
+
+
+def supported_long_term_modes() -> list[str]:
+    """Return deployment-supported long-term modes from the environment."""
+    raw_modes = _required_env(SUPPORTED_MODES_ENV)
+    return [mode.strip() for mode in raw_modes.split(",") if mode.strip()]
+
+
+def seasonal_config_name(issue_month: int) -> str:
+    """Return the seasonal config name for a supported issue month."""
+    try:
+        return _SEASONAL_CONFIG_NAMES_BY_ISSUE_MONTH[issue_month]
+    except KeyError as exc:
+        raise ValueError(
+            f"Seasonal issue month must be one of 1, 2, 3, or 4; got {issue_month!r}."
+        ) from exc
+
+
+def quarter_horizon_value() -> int:
+    """Return the configured operational month lead time for quarterly forecasts."""
+    return _horizon_value_for_mode(QUARTER_CONFIG_NAME)
+
+
+def seasonal_horizon_value(issue_month: int) -> int:
+    """Return the configured operational month lead time for a seasonal issue month."""
+    return _horizon_value_for_mode(seasonal_config_name(issue_month))
+
+
+def _horizon_value_for_mode(config_name: str) -> int:
+    _ensure_supported_mode(config_name)
+    config = _load_long_term_config(config_name)
+
+    if OPERATIONAL_MONTH_LEAD_TIME_FIELD not in config:
+        raise LongTermHorizonResolverError(
+            f"Long-term config '{config_name}' is missing required field "
+            f"'{OPERATIONAL_MONTH_LEAD_TIME_FIELD}'."
+        )
+
+    try:
+        return int(config[OPERATIONAL_MONTH_LEAD_TIME_FIELD])
+    except (TypeError, ValueError) as exc:
+        raise LongTermHorizonResolverError(
+            f"Long-term config '{config_name}' field "
+            f"'{OPERATIONAL_MONTH_LEAD_TIME_FIELD}' must be an integer."
+        ) from exc
+
+
+def _ensure_supported_mode(config_name: str) -> None:
+    modes = supported_long_term_modes()
+    if config_name not in modes:
+        raise UnsupportedLongTermModeError(
+            f"Long-term mode '{config_name}' is not supported by this deployment. "
+            f"Supported modes: {modes}."
+        )
+
+
+def _load_long_term_config(config_name: str) -> dict[str, Any]:
+    config_path = _long_term_config_path(config_name)
+    if not config_path.exists():
+        raise FileNotFoundError(f"Long-term config '{config_name}' not found: {config_path}")
+
+    try:
+        with config_path.open() as config_file:
+            config = json.load(config_file)
+    except json.JSONDecodeError as exc:
+        raise LongTermHorizonResolverError(
+            f"Long-term config '{config_name}' contains invalid JSON: {config_path}"
+        ) from exc
+
+    if not isinstance(config, dict):
+        raise LongTermHorizonResolverError(
+            f"Long-term config '{config_name}' must contain a JSON object: {config_path}"
+        )
+    return config
+
+
+def _long_term_config_path(config_name: str) -> Path:
+    config_root = Path(_required_env(CONFIG_ROOT_ENV))
+    long_term_config_dir = Path(_required_env(LONG_TERM_CONFIG_DIR_ENV))
+    return config_root / long_term_config_dir / f"{config_name}.json"
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        raise LongTermHorizonResolverError(f"Required environment variable '{name}' is not set.")
+    return value

--- a/apps/iEasyHydroForecast/pyproject.toml
+++ b/apps/iEasyHydroForecast/pyproject.toml
@@ -41,6 +41,7 @@ allow-direct-references = true
 include = [
     "__init__.py",
     "forecast_library.py",
+    "long_term_horizon_resolver.py",
     "setup_library.py",
     "tag_library.py",
 ]

--- a/apps/iEasyHydroForecast/tests/test_long_term_horizon_resolver.py
+++ b/apps/iEasyHydroForecast/tests/test_long_term_horizon_resolver.py
@@ -1,8 +1,7 @@
 import json
 
+import long_term_horizon_resolver as resolver
 import pytest
-
-from iEasyHydroForecast import long_term_horizon_resolver as resolver
 
 
 def _write_config(tmp_path, config_name: str, payload: dict) -> None:

--- a/apps/iEasyHydroForecast/tests/test_long_term_horizon_resolver.py
+++ b/apps/iEasyHydroForecast/tests/test_long_term_horizon_resolver.py
@@ -1,0 +1,122 @@
+import json
+
+import pytest
+
+from iEasyHydroForecast import long_term_horizon_resolver as resolver
+
+
+def _write_config(tmp_path, config_name: str, payload: dict) -> None:
+    config_dir = tmp_path / "config" / "long_term_configs"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / f"{config_name}.json").write_text(json.dumps(payload))
+
+
+def _set_long_term_env(monkeypatch, tmp_path, supported_modes: list[str]) -> None:
+    monkeypatch.setenv(resolver.CONFIG_ROOT_ENV, str(tmp_path / "config"))
+    monkeypatch.setenv(resolver.LONG_TERM_CONFIG_DIR_ENV, "long_term_configs")
+    monkeypatch.setenv(resolver.SUPPORTED_MODES_ENV, ",".join(supported_modes))
+
+
+@pytest.mark.parametrize("lead", [1, 0])
+def test_quarter_horizon_value_reads_configured_lead(monkeypatch, tmp_path, lead):
+    _set_long_term_env(monkeypatch, tmp_path, ["quarter"])
+    _write_config(tmp_path, "quarter", {"operational_month_lead_time": lead})
+
+    assert resolver.quarter_horizon_value() == lead
+
+
+@pytest.mark.parametrize(
+    ("issue_month", "config_name", "lead"),
+    [
+        (1, "seasonal_january", 3),
+        (2, "seasonal_february", 2),
+        (3, "seasonal_march", 1),
+        (4, "seasonal_april", 0),
+    ],
+)
+def test_seasonal_horizon_value_reads_issue_month_lead(
+    monkeypatch, tmp_path, issue_month, config_name, lead
+):
+    supported_modes = [
+        "seasonal_january",
+        "seasonal_february",
+        "seasonal_march",
+        "seasonal_april",
+    ]
+    _set_long_term_env(monkeypatch, tmp_path, supported_modes)
+    _write_config(tmp_path, config_name, {"operational_month_lead_time": lead})
+
+    assert resolver.seasonal_horizon_value(issue_month) == lead
+
+
+@pytest.mark.parametrize(
+    ("issue_month", "config_name"),
+    [
+        (1, "seasonal_january"),
+        (2, "seasonal_february"),
+        (3, "seasonal_march"),
+        (4, "seasonal_april"),
+    ],
+)
+def test_seasonal_config_name_maps_issue_month_to_config(issue_month, config_name):
+    assert resolver.seasonal_config_name(issue_month) == config_name
+
+
+def test_seasonal_config_name_rejects_unmapped_issue_month():
+    with pytest.raises(ValueError, match="Seasonal issue month"):
+        resolver.seasonal_config_name(5)
+
+
+@pytest.mark.parametrize("issue_month", [1, 2, 3])
+def test_seasonal_horizon_value_rejects_unsupported_issue(monkeypatch, tmp_path, issue_month):
+    _set_long_term_env(monkeypatch, tmp_path, ["seasonal_april"])
+    _write_config(tmp_path, "seasonal_april", {"operational_month_lead_time": 0})
+
+    with pytest.raises(resolver.UnsupportedLongTermModeError, match="not supported"):
+        resolver.seasonal_horizon_value(issue_month)
+
+
+def test_seasonal_horizon_value_allows_april_only_deployment(monkeypatch, tmp_path):
+    _set_long_term_env(monkeypatch, tmp_path, ["seasonal_april"])
+    _write_config(tmp_path, "seasonal_april", {"operational_month_lead_time": 0})
+
+    assert resolver.seasonal_horizon_value(4) == 0
+
+
+def test_quarter_horizon_value_raises_for_missing_config_file(monkeypatch, tmp_path):
+    _set_long_term_env(monkeypatch, tmp_path, ["quarter"])
+
+    with pytest.raises(FileNotFoundError, match="quarter"):
+        resolver.quarter_horizon_value()
+
+
+def test_quarter_horizon_value_raises_for_missing_lead_field(monkeypatch, tmp_path):
+    _set_long_term_env(monkeypatch, tmp_path, ["quarter"])
+    _write_config(tmp_path, "quarter", {"horizon_type": "quarter"})
+
+    with pytest.raises(resolver.LongTermHorizonResolverError, match="operational_month_lead_time"):
+        resolver.quarter_horizon_value()
+
+
+def test_quarter_horizon_value_raises_for_invalid_json(monkeypatch, tmp_path):
+    _set_long_term_env(monkeypatch, tmp_path, ["quarter"])
+    config_dir = tmp_path / "config" / "long_term_configs"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "quarter.json").write_text("{not-json")
+
+    with pytest.raises(resolver.LongTermHorizonResolverError, match="invalid JSON"):
+        resolver.quarter_horizon_value()
+
+
+def test_supported_long_term_modes_strips_empty_entries(monkeypatch, tmp_path):
+    _set_long_term_env(monkeypatch, tmp_path, [])
+    monkeypatch.setenv(
+        resolver.SUPPORTED_MODES_ENV,
+        " quarter, seasonal_april, , seasonal_january ",
+    )
+
+    assert resolver.supported_long_term_modes() == [
+        "quarter",
+        "seasonal_april",
+        "seasonal_january",
+    ]

--- a/apps/postprocessing_forecasts/postprocessing_maintenance_long_term.py
+++ b/apps/postprocessing_forecasts/postprocessing_maintenance_long_term.py
@@ -28,6 +28,12 @@ from src import data_reader, ensemble_calculator, file_writer, gap_detector
 from src import postprocessing_tools as pt
 from src.postprocessing_tools import TimingStats, timer
 
+from iEasyHydroForecast.long_term_horizon_resolver import (
+    seasonal_config_name,
+    seasonal_horizon_value,
+    supported_long_term_modes,
+)
+
 # region Logging
 logging.basicConfig(level=logging.DEBUG)
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
@@ -53,6 +59,18 @@ logger.addHandler(console_handler)
 # endregion
 
 timing_stats = TimingStats()
+
+
+def _supported_seasonal_issue_leads() -> list[int]:
+    """Return unique supported seasonal issue leads for this deployment."""
+    modes = set(supported_long_term_modes())
+    leads = []
+    for issue_month in (1, 2, 3, 4):
+        if seasonal_config_name(issue_month) in modes:
+            lead = seasonal_horizon_value(issue_month)
+            if lead not in leads:
+                leads.append(lead)
+    return leads
 
 
 def _read_station_codes():
@@ -300,7 +318,20 @@ def postprocessing_maintenance_long_term():
         with timer(timing_stats, "seasonal gap-fill"):
             logger.info("\n\n------ Seasonal gap-fill --------------------------")
             lookback_s = int(os.getenv("POSTPROCESSING_GAPFILL_WINDOW_SEASONS", "1"))
-            s_combined = data_reader.read_seasonal_combined_forecasts(codes=codes)
+            seasonal_issue_leads = _supported_seasonal_issue_leads()
+            s_combined_frames = []
+            for issue_lead in seasonal_issue_leads:
+                combined_for_lead = data_reader.read_seasonal_combined_forecasts(
+                    codes=codes,
+                    horizon_value=issue_lead,
+                )
+                if not combined_for_lead.empty:
+                    s_combined_frames.append(combined_for_lead)
+            s_combined = (
+                pd.concat(s_combined_frames, ignore_index=True)
+                if s_combined_frames
+                else pd.DataFrame()
+            )
             if not s_combined.empty:
                 s_gaps = gap_detector.detect_missing_seasonal_ensembles(
                     s_combined,
@@ -310,11 +341,40 @@ def postprocessing_maintenance_long_term():
                 if not s_gaps.empty:
                     s_skill = data_reader.read_skill_metrics("season", codes=codes)
                     if not s_skill.empty:
-                        s_years = s_gaps["season_year"].unique()
-                        s_fc = data_reader.read_seasonal_forecasts(
-                            codes,
-                            int(s_years.min()),
-                            int(s_years.max()),
+                        s_fc_frames = []
+                        for issue_lead, lead_gaps in s_gaps.groupby("season_in_year"):
+                            s_years = lead_gaps["season_year"].unique()
+                            fc_for_lead = data_reader.read_seasonal_forecasts(
+                                codes,
+                                int(s_years.min()),
+                                int(s_years.max()),
+                                horizon_value=int(issue_lead),
+                            )
+                            if fc_for_lead.empty:
+                                continue
+
+                            lead_gap_set = set(
+                                lead_gaps[["season_year", "season_in_year", "code"]]
+                                .drop_duplicates()
+                                .itertuples(index=False, name=None)
+                            )
+                            fc_for_lead = fc_for_lead[
+                                fc_for_lead.apply(
+                                    lambda r, _gap_set=lead_gap_set: (
+                                        r["season_year"],
+                                        r["season_in_year"],
+                                        str(r["code"]),
+                                    )
+                                    in _gap_set,
+                                    axis=1,
+                                )
+                            ].copy()
+                            if not fc_for_lead.empty:
+                                s_fc_frames.append(fc_for_lead)
+                        s_fc = (
+                            pd.concat(s_fc_frames, ignore_index=True)
+                            if s_fc_frames
+                            else pd.DataFrame()
                         )
                         if not s_fc.empty:
                             s_joint = ensemble_calculator.create_seasonal_ensemble_forecasts(
@@ -327,6 +387,28 @@ def postprocessing_maintenance_long_term():
                                 "Naive Mean",
                             }
                             s_new = s_joint[s_joint["model_short"].isin(s_ens_models)].copy()
+                            s_gap_keys = set(
+                                s_gaps[
+                                    [
+                                        "season_year",
+                                        "season_in_year",
+                                        "code",
+                                        "model_short",
+                                    ]
+                                ].itertuples(index=False, name=None)
+                            )
+                            s_new = s_new[
+                                s_new.apply(
+                                    lambda r: (
+                                        r["season_year"],
+                                        r["season_in_year"],
+                                        str(r["code"]),
+                                        r["model_short"],
+                                    )
+                                    in s_gap_keys,
+                                    axis=1,
+                                )
+                            ]
                             s_merged = pd.concat(
                                 [s_combined, s_new],
                                 ignore_index=True,

--- a/apps/postprocessing_forecasts/postprocessing_maintenance_long_term.py
+++ b/apps/postprocessing_forecasts/postprocessing_maintenance_long_term.py
@@ -24,15 +24,14 @@ forecast_dir = os.path.join(script_dir, "..", "iEasyHydroForecast")
 sys.path.append(forecast_dir)
 
 import setup_library as sl
-from src import data_reader, ensemble_calculator, file_writer, gap_detector
-from src import postprocessing_tools as pt
-from src.postprocessing_tools import TimingStats, timer
-
-from iEasyHydroForecast.long_term_horizon_resolver import (
+from long_term_horizon_resolver import (
     seasonal_config_name,
     seasonal_horizon_value,
     supported_long_term_modes,
 )
+from src import data_reader, ensemble_calculator, file_writer, gap_detector
+from src import postprocessing_tools as pt
+from src.postprocessing_tools import TimingStats, timer
 
 # region Logging
 logging.basicConfig(level=logging.DEBUG)

--- a/apps/postprocessing_forecasts/postprocessing_maintenance_long_term.py
+++ b/apps/postprocessing_forecasts/postprocessing_maintenance_long_term.py
@@ -333,6 +333,7 @@ def postprocessing_maintenance_long_term():
                             )
                             s_dedup = [
                                 "season_year",
+                                "season_in_year",
                                 "code",
                                 "model_short",
                             ]

--- a/apps/postprocessing_forecasts/postprocessing_operational_long_term.py
+++ b/apps/postprocessing_forecasts/postprocessing_operational_long_term.py
@@ -26,6 +26,12 @@ from src import data_reader, ensemble_calculator, file_writer
 from src import postprocessing_tools as pt
 from src.postprocessing_tools import TimingStats, timer
 
+from iEasyHydroForecast.long_term_horizon_resolver import (
+    seasonal_config_name,
+    seasonal_horizon_value,
+    supported_long_term_modes,
+)
+
 # region Logging
 logging.basicConfig(level=logging.DEBUG)
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
@@ -51,6 +57,16 @@ logger.addHandler(console_handler)
 # endregion
 
 timing_stats = TimingStats()
+
+
+def _seasonal_issue_leads_for_date(forecast_date: dt.date) -> list[int]:
+    """Return supported seasonal issue leads relevant to this run date."""
+    issue_month = forecast_date.month
+    if issue_month not in (1, 2, 3, 4):
+        return []
+    if seasonal_config_name(issue_month) not in supported_long_term_modes():
+        return []
+    return [seasonal_horizon_value(issue_month)]
 
 
 def _read_station_codes():
@@ -188,16 +204,39 @@ def postprocessing_operational_long_term():
             logger.info("\n\n------ Seasonal ensemble processing --------------")
             seasonal_skill = data_reader.read_skill_metrics("season", codes=codes)
             if not seasonal_skill.empty:
-                seasonal_fc = data_reader.read_latest_seasonal_forecasts(
-                    codes,
-                    forecast_date=forecast_date,
+                seasonal_frames = []
+                seasonal_existing = []
+                for issue_lead in _seasonal_issue_leads_for_date(forecast_date):
+                    seasonal_fc_for_lead = data_reader.read_latest_seasonal_forecasts(
+                        codes,
+                        forecast_date=forecast_date,
+                        horizon_value=issue_lead,
+                    )
+                    if not seasonal_fc_for_lead.empty:
+                        seasonal_frames.append(seasonal_fc_for_lead)
+
+                    existing_for_lead = data_reader.read_seasonal_combined_forecasts(
+                        codes=codes,
+                        horizon_value=issue_lead,
+                    )
+                    if not existing_for_lead.empty:
+                        seasonal_existing.append(existing_for_lead)
+
+                seasonal_fc = (
+                    pd.concat(seasonal_frames, ignore_index=True)
+                    if seasonal_frames
+                    else pd.DataFrame()
                 )
                 if not seasonal_fc.empty:
                     seasonal_joint = ensemble_calculator.create_seasonal_ensemble_forecasts(
                         seasonal_fc,
                         seasonal_skill,
                     )
-                    existing_s = data_reader.read_seasonal_combined_forecasts(codes=codes)
+                    existing_s = (
+                        pd.concat(seasonal_existing, ignore_index=True)
+                        if seasonal_existing
+                        else pd.DataFrame()
+                    )
                     if not existing_s.empty:
                         seasonal_joint = pd.concat(
                             [existing_s, seasonal_joint],

--- a/apps/postprocessing_forecasts/postprocessing_operational_long_term.py
+++ b/apps/postprocessing_forecasts/postprocessing_operational_long_term.py
@@ -203,7 +203,7 @@ def postprocessing_operational_long_term():
                             [existing_s, seasonal_joint],
                             ignore_index=True,
                         )
-                        dedup = ["season_year", "code", "model_short"]
+                        dedup = ["season_year", "season_in_year", "code", "model_short"]
                         available = [c for c in dedup if c in seasonal_joint.columns]
                         seasonal_joint = seasonal_joint.drop_duplicates(
                             subset=available,

--- a/apps/postprocessing_forecasts/postprocessing_operational_long_term.py
+++ b/apps/postprocessing_forecasts/postprocessing_operational_long_term.py
@@ -22,15 +22,14 @@ forecast_dir = os.path.join(script_dir, "..", "iEasyHydroForecast")
 sys.path.append(forecast_dir)
 
 import setup_library as sl
-from src import data_reader, ensemble_calculator, file_writer
-from src import postprocessing_tools as pt
-from src.postprocessing_tools import TimingStats, timer
-
-from iEasyHydroForecast.long_term_horizon_resolver import (
+from long_term_horizon_resolver import (
     seasonal_config_name,
     seasonal_horizon_value,
     supported_long_term_modes,
 )
+from src import data_reader, ensemble_calculator, file_writer
+from src import postprocessing_tools as pt
+from src.postprocessing_tools import TimingStats, timer
 
 # region Logging
 logging.basicConfig(level=logging.DEBUG)

--- a/apps/postprocessing_forecasts/recalculate_skill_metrics.py
+++ b/apps/postprocessing_forecasts/recalculate_skill_metrics.py
@@ -33,16 +33,15 @@ sys.path.append(forecast_dir)
 
 import setup_library as sl
 import tag_library as tl
-from src import data_reader, file_writer, skill_metrics
-from src import postprocessing_tools as pt
-from src.horizon_config import ShortTermHorizonConfig
-from src.postprocessing_tools import TimingStats, timer
-
-from iEasyHydroForecast.long_term_horizon_resolver import (
+from long_term_horizon_resolver import (
     seasonal_config_name,
     seasonal_horizon_value,
     supported_long_term_modes,
 )
+from src import data_reader, file_writer, skill_metrics
+from src import postprocessing_tools as pt
+from src.horizon_config import ShortTermHorizonConfig
+from src.postprocessing_tools import TimingStats, timer
 
 # region Logging
 logging.basicConfig(level=logging.DEBUG)

--- a/apps/postprocessing_forecasts/recalculate_skill_metrics.py
+++ b/apps/postprocessing_forecasts/recalculate_skill_metrics.py
@@ -24,6 +24,8 @@ import os
 import sys
 from logging.handlers import TimedRotatingFileHandler
 
+import pandas as pd
+
 # Local libraries
 script_dir = os.path.dirname(os.path.abspath(__file__))
 forecast_dir = os.path.join(script_dir, "..", "iEasyHydroForecast")
@@ -35,6 +37,12 @@ from src import data_reader, file_writer, skill_metrics
 from src import postprocessing_tools as pt
 from src.horizon_config import ShortTermHorizonConfig
 from src.postprocessing_tools import TimingStats, timer
+
+from iEasyHydroForecast.long_term_horizon_resolver import (
+    seasonal_config_name,
+    seasonal_horizon_value,
+    supported_long_term_modes,
+)
 
 # region Logging
 logging.basicConfig(level=logging.DEBUG)
@@ -92,6 +100,18 @@ VALID_MODES = [
     "SEASONAL",
     "ALL",
 ]
+
+
+def _supported_seasonal_issue_leads() -> list[int]:
+    """Return unique supported seasonal issue leads for this deployment."""
+    modes = set(supported_long_term_modes())
+    leads = []
+    for issue_month in (1, 2, 3, 4):
+        if seasonal_config_name(issue_month) in modes:
+            lead = seasonal_horizon_value(issue_month)
+            if lead not in leads:
+                leads.append(lead)
+    return leads
 
 
 def _read_station_codes(config):
@@ -343,7 +363,21 @@ def recalculate_skill_metrics():
             with timer(timing_stats, "reading seasonal data"):
                 logger.info("\n\n------ Reading seasonal data (aggregated from monthly) -------")
                 seasonal_obs = data_reader.read_seasonal_observations(codes, start_year, end_year)
-                seasonal_fc = data_reader.read_seasonal_forecasts(codes, start_year, end_year)
+                seasonal_frames = []
+                for issue_lead in _supported_seasonal_issue_leads():
+                    seasonal_fc_for_lead = data_reader.read_seasonal_forecasts(
+                        codes,
+                        start_year,
+                        end_year,
+                        horizon_value=issue_lead,
+                    )
+                    if not seasonal_fc_for_lead.empty:
+                        seasonal_frames.append(seasonal_fc_for_lead)
+                seasonal_fc = (
+                    pd.concat(seasonal_frames, ignore_index=True)
+                    if seasonal_frames
+                    else pd.DataFrame()
+                )
 
             with timer(timing_stats, "calculating skill metrics seasonal"):
                 logger.info("\n\n------ Calculating skill metrics seasonal ------")

--- a/apps/postprocessing_forecasts/src/api_writer.py
+++ b/apps/postprocessing_forecasts/src/api_writer.py
@@ -13,8 +13,7 @@ import os
 
 import pandas as pd
 import tag_library as tl
-
-from iEasyHydroForecast.long_term_horizon_resolver import quarter_horizon_value
+from long_term_horizon_resolver import quarter_horizon_value
 
 logger = logging.getLogger(__name__)
 

--- a/apps/postprocessing_forecasts/src/api_writer.py
+++ b/apps/postprocessing_forecasts/src/api_writer.py
@@ -14,6 +14,8 @@ import os
 import pandas as pd
 import tag_library as tl
 
+from iEasyHydroForecast.long_term_horizon_resolver import quarter_horizon_value
+
 logger = logging.getLogger(__name__)
 
 # Map uppercased model_short to API model_type format.
@@ -1005,7 +1007,14 @@ def _write_aggregated_forecasts_to_api(
         if horizon_type == "quarter":
             nan_check_cols = [c for c in ["year", "quarter_in_year"] if c in data.columns]
         else:  # season
-            nan_check_cols = ["season_year"] if "season_year" in data.columns else ["year"]
+            nan_check_cols = [
+                c
+                for c in [
+                    "season_year" if "season_year" in data.columns else "year",
+                    period_col,
+                ]
+                if c in data.columns
+            ]
 
         if nan_check_cols:
             data_before_nan_drop = data  # keep reference for diagnostics
@@ -1048,7 +1057,7 @@ def _write_aggregated_forecasts_to_api(
                 valid_from = f"{year}-{start_month:02d}-01"
                 last_day = calendar.monthrange(year, end_month)[1]
                 valid_to = f"{year}-{end_month:02d}-{last_day:02d}"
-                horizon_value = quarter
+                horizon_value = quarter_horizon_value()
             else:  # season
                 season_year = int(row.get("season_year", row.get("year")))
                 season_months = get_season_months()
@@ -1064,7 +1073,7 @@ def _write_aggregated_forecasts_to_api(
                     end_year = season_year + 1
                     last_day = calendar.monthrange(end_year, end_m)[1]
                     valid_to = f"{end_year}-{end_m:02d}-{last_day:02d}"
-                horizon_value = 1
+                horizon_value = int(row[period_col])
 
             # Use existing valid_from/valid_to if present
             if pd.notna(row.get("valid_from")):
@@ -1072,11 +1081,15 @@ def _write_aggregated_forecasts_to_api(
             if pd.notna(row.get("valid_to")):
                 valid_to = str(row["valid_to"])[:10]
 
+            record_date = valid_from
+            if horizon_type == "season" and pd.notna(row.get("date")):
+                record_date = str(row["date"])[:10]
+
             record = {
                 "horizon_type": horizon_type,
                 "horizon_value": horizon_value,
                 "code": code,
-                "date": valid_from,
+                "date": record_date,
                 "model_type": model_type,
                 "valid_from": valid_from,
                 "valid_to": valid_to,

--- a/apps/postprocessing_forecasts/src/data_reader.py
+++ b/apps/postprocessing_forecasts/src/data_reader.py
@@ -14,6 +14,10 @@ import os
 
 import pandas as pd
 from long_term_horizon_resolver import quarter_horizon_value
+from src.model_names import (
+    AGGREGATED_SUPPORTED_MODELS,
+    canonical_model_short_series,
+)
 from src.postprocessing_tools import count_quantile_crossings
 
 logger = logging.getLogger(__name__)
@@ -30,11 +34,6 @@ try:
 except ImportError:
     SAPPHIRE_API_AVAILABLE = False
 
-
-# Ensemble model names may already be present in stored quarter/season
-# rows. Keep them in reader output; only deprecated raw models are filtered.
-_ENSEMBLE_MODELS = frozenset({"EM", "Skilled Mean", "Naive Mean"})
-_AGGREGATED_SUPPORTED_RAW_MODELS = frozenset({"LR_Base", "LR_SM"})
 
 _SEASONAL_FC_COLS = [
     "code",
@@ -78,8 +77,8 @@ def _filter_supported_aggregated_forecast_models(df: pd.DataFrame) -> pd.DataFra
     if df.empty or "model_short" not in df.columns:
         return df
 
-    allowed = _AGGREGATED_SUPPORTED_RAW_MODELS | _ENSEMBLE_MODELS
-    return df[df["model_short"].isin(allowed)].copy()
+    model_keys = canonical_model_short_series(df["model_short"])
+    return df[model_keys.isin(AGGREGATED_SUPPORTED_MODELS)].copy()
 
 
 def read_skill_metrics(

--- a/apps/postprocessing_forecasts/src/data_reader.py
+++ b/apps/postprocessing_forecasts/src/data_reader.py
@@ -38,6 +38,8 @@ _SEASONAL_FC_COLS = [
     "code",
     "season_year",
     "season_in_year",
+    "horizon_value",
+    "date",
     "model_short",
     "q05",
     "q10",
@@ -1028,6 +1030,7 @@ def _read_long_forecasts_api(
     start_year: int,
     end_year: int,
     horizon_type: str = "month",
+    horizon_value: int | None = None,
 ) -> pd.DataFrame:
     """Read long-term forecasts from postprocessing API with pagination.
 
@@ -1038,6 +1041,8 @@ def _read_long_forecasts_api(
         horizon_type: Horizon type filter passed to the API (e.g. ``"month"``
             or ``"season"``). Defaults to ``"month"`` to preserve existing
             behaviour for all current callers.
+        horizon_value: Optional lead/horizon-value filter. When omitted, the
+            request is unchanged.
     """
     if not SAPPHIRE_API_AVAILABLE:
         logger.debug("sapphire-api-client not installed, skipping")
@@ -1064,14 +1069,17 @@ def _read_long_forecasts_api(
             skip = 0
             batch_size = 1000
             while True:
-                df_batch = client.read_long_term_forecasts(
-                    horizon_type=horizon_type,
-                    code=code,
-                    start_date=start_date,
-                    end_date=end_date,
-                    skip=skip,
-                    limit=batch_size,
-                )
+                kwargs = {
+                    "horizon_type": horizon_type,
+                    "code": code,
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "skip": skip,
+                    "limit": batch_size,
+                }
+                if horizon_value is not None:
+                    kwargs["horizon_value"] = horizon_value
+                df_batch = client.read_long_term_forecasts(**kwargs)
                 if df_batch is None or df_batch.empty:
                     break
                 all_records.append(df_batch)
@@ -2711,8 +2719,8 @@ def read_seasonal_forecasts(
 
     Returns:
         DataFrame with columns: [code, season_year, season_in_year,
-        model_short, q05-q95, forecasted_discharge, valid_from,
-        valid_to].
+        horizon_value, date, model_short, q05-q95,
+        forecasted_discharge, valid_from, valid_to].
     """
     empty = pd.DataFrame(
         columns=[
@@ -2741,9 +2749,10 @@ def read_seasonal_forecasts(
 
     # Select canonical output columns
     df = df[[c for c in _SEASONAL_FC_COLS if c in df.columns]]
+    df = _deduplicate_seasonal_forecasts(df)
 
     # Normalize valid_from/valid_to to strings for consistency
-    for col in ("valid_from", "valid_to"):
+    for col in ("valid_from", "valid_to", "date"):
         if col in df.columns:
             df[col] = df[col].astype(str)
 
@@ -2884,9 +2893,10 @@ def read_latest_seasonal_forecasts(
 
     # Select canonical output columns
     df = df[[c for c in _SEASONAL_FC_COLS if c in df.columns]]
+    df = _deduplicate_seasonal_forecasts(df)
 
     # Normalize valid_from/valid_to to strings
-    for col in ("valid_from", "valid_to"):
+    for col in ("valid_from", "valid_to", "date"):
         if col in df.columns:
             df[col] = df[col].astype(str)
 
@@ -2956,6 +2966,7 @@ def read_seasonal_combined_forecasts(
 def _read_long_combined_forecasts_api(
     horizon_type: str,
     codes: list[str] | None = None,
+    horizon_value: int | None = None,
 ) -> pd.DataFrame | None:
     """Read long-term combined forecasts from API for a given horizon type.
 
@@ -2985,12 +2996,15 @@ def _read_long_combined_forecasts_api(
             for code in codes:
                 skip = 0
                 while True:
-                    df_batch = client.read_long_term_forecasts(
-                        horizon_type=horizon_type,
-                        code=code,
-                        skip=skip,
-                        limit=batch_size,
-                    )
+                    kwargs = {
+                        "horizon_type": horizon_type,
+                        "code": code,
+                        "skip": skip,
+                        "limit": batch_size,
+                    }
+                    if horizon_value is not None:
+                        kwargs["horizon_value"] = horizon_value
+                    df_batch = client.read_long_term_forecasts(**kwargs)
                     if df_batch is None or df_batch.empty:
                         break
                     frames.append(df_batch)
@@ -3004,9 +3018,14 @@ def _read_long_combined_forecasts_api(
             all_records = []
             skip = 0
             while True:
-                df_batch = client.read_long_term_forecasts(
-                    horizon_type=horizon_type, skip=skip, limit=batch_size
-                )
+                kwargs = {
+                    "horizon_type": horizon_type,
+                    "skip": skip,
+                    "limit": batch_size,
+                }
+                if horizon_value is not None:
+                    kwargs["horizon_value"] = horizon_value
+                df_batch = client.read_long_term_forecasts(**kwargs)
                 if df_batch is None or df_batch.empty:
                     break
                 all_records.append(df_batch)
@@ -3061,7 +3080,13 @@ def _normalize_combined_forecasts(
             lambda r: get_season_year(r["valid_from"].year, r["valid_from"].month),
             axis=1,
         )
-        df["season_in_year"] = 1
+        if "horizon_value" in df.columns:
+            lead = pd.to_numeric(df["horizon_value"], errors="coerce")
+            df["season_in_year"] = lead.astype("Int64") if lead.isna().any() else lead.astype(int)
+        else:
+            df["season_in_year"] = 1
+        if "date" in df.columns:
+            df["date"] = pd.to_datetime(df["date"], errors="coerce")
 
     # Add forecasted_discharge from q/q50
     if "forecasted_discharge" not in df.columns:
@@ -3074,9 +3099,22 @@ def _normalize_combined_forecasts(
     drop_cols = [
         "id",
         "horizon_type",
-        "horizon_value",
         "model_type_description",
     ]
+    if horizon_type != "season":
+        drop_cols.append("horizon_value")
     df = df.drop(columns=[c for c in drop_cols if c in df.columns], errors="ignore")
 
     return df
+
+
+def _deduplicate_seasonal_forecasts(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop duplicate seasonal issue/model rows without folding leads."""
+    if df.empty:
+        return df
+
+    dedup_cols = ["code", "season_year", "season_in_year", "date", "model_short"]
+    available = [c for c in dedup_cols if c in df.columns]
+    if len(available) < 4:
+        return df
+    return df.drop_duplicates(subset=available, keep="last")

--- a/apps/postprocessing_forecasts/src/data_reader.py
+++ b/apps/postprocessing_forecasts/src/data_reader.py
@@ -31,9 +31,10 @@ except ImportError:
     SAPPHIRE_API_AVAILABLE = False
 
 
-# Ensemble model names to filter from raw API reads (these are derived,
-# not raw model output).
+# Ensemble model names may already be present in stored quarter/season
+# rows. Keep them in reader output; only deprecated raw models are filtered.
 _ENSEMBLE_MODELS = frozenset({"EM", "Skilled Mean", "Naive Mean"})
+_AGGREGATED_SUPPORTED_RAW_MODELS = frozenset({"LR_Base", "LR_SM"})
 
 _SEASONAL_FC_COLS = [
     "code",
@@ -70,6 +71,15 @@ _QUARTERLY_FC_COLS = [
     "valid_from",
     "valid_to",
 ]
+
+
+def _filter_supported_aggregated_forecast_models(df: pd.DataFrame) -> pd.DataFrame:
+    """Keep supported quarter/season raw models plus existing ensemble rows."""
+    if df.empty or "model_short" not in df.columns:
+        return df
+
+    allowed = _AGGREGATED_SUPPORTED_RAW_MODELS | _ENSEMBLE_MODELS
+    return df[df["model_short"].isin(allowed)].copy()
 
 
 def read_skill_metrics(
@@ -2632,9 +2642,9 @@ def read_quarterly_forecasts(
        (``horizon_type="quarter"``).
 
     When a model appears in both sources for the same quarter, the
-    direct quarterly forecast takes precedence.  Ensemble models
-    (EM, Skilled Mean, Naive Mean) are filtered out of the direct
-    path — only raw model output is returned.
+    direct quarterly forecast takes precedence.  Raw model rows are
+    restricted to the supported two-model set (LR_Base, LR_SM) after
+    combining monthly-aggregated and direct quarterly sources.
 
     Args:
         codes: Station codes to read.
@@ -2672,9 +2682,6 @@ def read_quarterly_forecasts(
     )
     if raw_q is not None and not raw_q.empty:
         direct = _normalize_combined_forecasts(raw_q, "quarter")
-        # Filter out ensemble models — only raw model output
-        if "model_short" in direct.columns:
-            direct = direct[~direct["model_short"].isin(_ENSEMBLE_MODELS)].copy()
     else:
         direct = pd.DataFrame()
 
@@ -2694,6 +2701,10 @@ def read_quarterly_forecasts(
         available = [c for c in dedup_cols if c in combined.columns]
         combined = combined.drop_duplicates(subset=available, keep="last")
 
+    if combined.empty:
+        return pd.DataFrame(columns=empty_cols)
+
+    combined = _filter_supported_aggregated_forecast_models(combined)
     if combined.empty:
         return pd.DataFrame(columns=empty_cols)
 
@@ -2717,8 +2728,8 @@ def read_seasonal_forecasts(
     """Read seasonal forecasts directly from the API.
 
     Reads forecasts stored with horizon_type="season" in the
-    postprocessing API.  Ensemble models (EM, Skilled Mean,
-    Naive Mean) are filtered out — only raw model output is returned.
+    postprocessing API. Raw model rows are restricted to the supported
+    two-model set (LR_Base, LR_SM); existing ensemble rows are kept.
 
     Args:
         codes: Station codes to read.
@@ -2755,10 +2766,7 @@ def read_seasonal_forecasts(
     if df.empty:
         return empty
 
-    # Filter out ensemble models — only raw model output
-    if "model_short" in df.columns:
-        df = df[~df["model_short"].isin(_ENSEMBLE_MODELS)].copy()
-
+    df = _filter_supported_aggregated_forecast_models(df)
     if df.empty:
         return empty
 
@@ -2790,6 +2798,8 @@ def read_latest_quarterly_forecasts(
     2. Direct quarterly forecasts from the API.
 
     When a model appears in both sources, the direct forecast wins.
+    Raw model rows are restricted to LR_Base and LR_SM after combining
+    the two sources; existing ensemble rows are kept.
 
     Args:
         codes: Station codes to read.
@@ -2828,8 +2838,6 @@ def read_latest_quarterly_forecasts(
     )
     if raw_q is not None and not raw_q.empty:
         direct = _normalize_combined_forecasts(raw_q, "quarter")
-        if "model_short" in direct.columns:
-            direct = direct[~direct["model_short"].isin(_ENSEMBLE_MODELS)].copy()
     else:
         direct = pd.DataFrame()
 
@@ -2848,6 +2856,10 @@ def read_latest_quarterly_forecasts(
         available = [c for c in dedup_cols if c in combined.columns]
         combined = combined.drop_duplicates(subset=available, keep="last")
 
+    if combined.empty:
+        return pd.DataFrame(columns=_QUARTERLY_FC_COLS)
+
+    combined = _filter_supported_aggregated_forecast_models(combined)
     if combined.empty:
         return pd.DataFrame(columns=_QUARTERLY_FC_COLS)
 
@@ -2883,6 +2895,8 @@ def read_latest_seasonal_forecasts(
     """Read the most recent seasonal forecasts directly from the API.
 
     Uses a wide lookback (~200 days) to capture cross-year seasons.
+    Raw model rows are restricted to LR_Base and LR_SM; existing
+    ensemble rows are kept.
 
     Args:
         codes: Station codes to read.
@@ -2913,10 +2927,7 @@ def read_latest_seasonal_forecasts(
     if df.empty:
         return pd.DataFrame(columns=_SEASONAL_FC_COLS)
 
-    # Filter out ensemble models — only raw model output
-    if "model_short" in df.columns:
-        df = df[~df["model_short"].isin(_ENSEMBLE_MODELS)].copy()
-
+    df = _filter_supported_aggregated_forecast_models(df)
     if df.empty:
         return pd.DataFrame(columns=_SEASONAL_FC_COLS)
 

--- a/apps/postprocessing_forecasts/src/data_reader.py
+++ b/apps/postprocessing_forecasts/src/data_reader.py
@@ -15,6 +15,8 @@ import os
 import pandas as pd
 from src.postprocessing_tools import count_quantile_crossings
 
+from iEasyHydroForecast.long_term_horizon_resolver import quarter_horizon_value
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -2662,7 +2664,13 @@ def read_quarterly_forecasts(
         aggregated = pd.DataFrame()
 
     # Source 2: direct quarterly forecasts from API
-    raw_q = _read_long_forecasts_api(codes, start_year, end_year, horizon_type="quarter")
+    raw_q = _read_long_forecasts_api(
+        codes,
+        start_year,
+        end_year,
+        horizon_type="quarter",
+        horizon_value=quarter_horizon_value(),
+    )
     if raw_q is not None and not raw_q.empty:
         direct = _normalize_combined_forecasts(raw_q, "quarter")
         # Filter out ensemble models — only raw model output
@@ -2705,6 +2713,7 @@ def read_seasonal_forecasts(
     codes: list[str],
     start_year: int,
     end_year: int,
+    horizon_value: int | None = None,
 ) -> pd.DataFrame:
     """Read seasonal forecasts directly from the API.
 
@@ -2716,6 +2725,7 @@ def read_seasonal_forecasts(
         codes: Station codes to read.
         start_year: First year (inclusive).
         end_year: Last year (inclusive).
+        horizon_value: Optional seasonal issue lead to read.
 
     Returns:
         DataFrame with columns: [code, season_year, season_in_year,
@@ -2731,7 +2741,13 @@ def read_seasonal_forecasts(
         ]
     )
 
-    raw = _read_long_forecasts_api(codes, start_year, end_year, horizon_type="season")
+    raw = _read_long_forecasts_api(
+        codes,
+        start_year,
+        end_year,
+        horizon_type="season",
+        horizon_value=horizon_value,
+    )
     if raw is None or raw.empty:
         logger.info("No seasonal forecast data from API for %d-%d", start_year, end_year)
         return empty
@@ -2804,7 +2820,13 @@ def read_latest_quarterly_forecasts(
         aggregated = pd.DataFrame()
 
     # Source 2: direct quarterly forecasts from API
-    raw_q = _read_long_forecasts_api(codes, start_year, end_year, horizon_type="quarter")
+    raw_q = _read_long_forecasts_api(
+        codes,
+        start_year,
+        end_year,
+        horizon_type="quarter",
+        horizon_value=quarter_horizon_value(),
+    )
     if raw_q is not None and not raw_q.empty:
         direct = _normalize_combined_forecasts(raw_q, "quarter")
         if "model_short" in direct.columns:
@@ -2857,6 +2879,7 @@ def read_latest_quarterly_forecasts(
 def read_latest_seasonal_forecasts(
     codes: list[str],
     forecast_date: dt.date | None = None,
+    horizon_value: int | None = None,
 ) -> pd.DataFrame:
     """Read the most recent seasonal forecasts directly from the API.
 
@@ -2865,6 +2888,7 @@ def read_latest_seasonal_forecasts(
     Args:
         codes: Station codes to read.
         forecast_date: Reference date for lookback window.
+        horizon_value: Optional seasonal issue lead to read.
 
     Returns:
         DataFrame with seasonal forecasts for the most recent season.
@@ -2875,7 +2899,13 @@ def read_latest_seasonal_forecasts(
     start_year = start_date.year
     end_year = today.year
 
-    raw = _read_long_forecasts_api(codes, start_year, end_year, horizon_type="season")
+    raw = _read_long_forecasts_api(
+        codes,
+        start_year,
+        end_year,
+        horizon_type="season",
+        horizon_value=horizon_value,
+    )
     if raw is None or raw.empty:
         logger.warning("No recent seasonal forecast data from API")
         return pd.DataFrame(columns=_SEASONAL_FC_COLS)
@@ -2932,7 +2962,11 @@ def read_quarterly_combined_forecasts(
     Returns:
         DataFrame with combined quarterly forecasts, or empty DataFrame.
     """
-    df = _read_long_combined_forecasts_api("quarter", codes)
+    df = _read_long_combined_forecasts_api(
+        "quarter",
+        codes,
+        horizon_value=quarter_horizon_value(),
+    )
     if df is not None and not df.empty:
         logger.info("Read %d quarterly combined forecast rows from API", len(df))
         return df
@@ -2942,6 +2976,7 @@ def read_quarterly_combined_forecasts(
 
 def read_seasonal_combined_forecasts(
     codes: list[str] | None = None,
+    horizon_value: int | None = None,
 ) -> pd.DataFrame:
     """Read seasonal combined forecasts from API.
 
@@ -2951,11 +2986,12 @@ def read_seasonal_combined_forecasts(
         codes: Optional list of station codes to filter. When provided,
             only forecasts for those codes are returned. When None,
             all codes are returned.
+        horizon_value: Optional seasonal issue lead to read.
 
     Returns:
         DataFrame with combined seasonal forecasts, or empty DataFrame.
     """
-    df = _read_long_combined_forecasts_api("season", codes)
+    df = _read_long_combined_forecasts_api("season", codes, horizon_value=horizon_value)
     if df is not None and not df.empty:
         logger.info("Read %d seasonal combined forecast rows from API", len(df))
         return df

--- a/apps/postprocessing_forecasts/src/data_reader.py
+++ b/apps/postprocessing_forecasts/src/data_reader.py
@@ -13,9 +13,8 @@ import logging
 import os
 
 import pandas as pd
+from long_term_horizon_resolver import quarter_horizon_value
 from src.postprocessing_tools import count_quantile_crossings
-
-from iEasyHydroForecast.long_term_horizon_resolver import quarter_horizon_value
 
 logger = logging.getLogger(__name__)
 

--- a/apps/postprocessing_forecasts/src/ensemble_calculator.py
+++ b/apps/postprocessing_forecasts/src/ensemble_calculator.py
@@ -554,7 +554,7 @@ def create_seasonal_ensemble_forecasts(
         forecasts,
         skill_stats,
         period_col="season_in_year",
-        time_group_cols=["season_year", "code"],
+        time_group_cols=["season_year", "season_in_year", "code"],
     )
 
 
@@ -571,7 +571,6 @@ def _create_aggregated_ensemble_forecasts(
     """
     from src.skill_metrics import (
         _QUANTILE_COLS,
-        _append_to_joint,
         filter_for_highly_skilled_forecasts,
     )
 
@@ -636,7 +635,7 @@ def _create_aggregated_ensemble_forecasts(
 
         if not em_avg.empty:
             em_avg["flag"] = 0
-            joint = _append_to_joint(joint, em_avg)
+            joint = _append_aggregated_to_joint(joint, em_avg)
 
     # --- Skilled Mean (1/MAE weighted) ---
     joint = _add_skilled_mean_aggregated_ens(
@@ -669,8 +668,6 @@ def _add_skilled_mean_aggregated_ens(
     time_group_cols,
 ):
     """Add Skilled Mean rows for quarterly/seasonal ensemble creation."""
-    from src.skill_metrics import _append_to_joint
-
     filtered = skill_filtered[~skill_filtered["model_short"].isin(baselines)].copy()
     if filtered.empty:
         return joint
@@ -733,7 +730,7 @@ def _add_skilled_mean_aggregated_ens(
 
     if not sm_avg.empty:
         sm_avg["flag"] = 0
-        joint = _append_to_joint(joint, sm_avg)
+        joint = _append_aggregated_to_joint(joint, sm_avg)
 
     return joint
 
@@ -746,8 +743,6 @@ def _add_naive_mean_aggregated_ens(
     time_group_cols,
 ):
     """Add Naive Mean rows for quarterly/seasonal ensemble creation."""
-    from src.skill_metrics import _append_to_joint
-
     pool = joint[~joint["model_short"].isin(baselines)].copy()
     pool = pool.dropna(subset=["forecasted_discharge"]).copy()
     if pool.empty:
@@ -777,6 +772,22 @@ def _add_naive_mean_aggregated_ens(
 
     if not naive_avg.empty:
         naive_avg["flag"] = 0
-        joint = _append_to_joint(joint, naive_avg)
+        joint = _append_aggregated_to_joint(joint, naive_avg)
 
     return joint
+
+
+def _append_aggregated_to_joint(
+    joint_forecasts: pd.DataFrame,
+    ensemble_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Append quarter/season ensemble rows without dropping period keys."""
+    if ensemble_df.empty:
+        return joint_forecasts
+    if "composition" not in joint_forecasts.columns:
+        joint_forecasts = joint_forecasts.copy()
+        joint_forecasts["composition"] = ""
+    cols = [c for c in ensemble_df.columns if c in joint_forecasts.columns]
+    if not cols:
+        return joint_forecasts
+    return pd.concat([joint_forecasts, ensemble_df[cols]], ignore_index=True)

--- a/apps/postprocessing_forecasts/src/ensemble_calculator.py
+++ b/apps/postprocessing_forecasts/src/ensemble_calculator.py
@@ -555,7 +555,10 @@ def create_seasonal_ensemble_forecasts(
         forecasts,
         skill_stats,
         period_col="season_in_year",
-        time_group_cols=["season_year", "season_in_year", "code"],
+        # Group by `date` so each (re-)issued seasonal forecast forms its own
+        # ensemble (one EM per issue = clean 2-model mean) rather than
+        # collapsing distinct issue dates into one blended row.
+        time_group_cols=["season_year", "season_in_year", "code", "date"],
     )
 
 
@@ -590,6 +593,11 @@ def _create_aggregated_ensemble_forecasts(
     joint = forecasts.copy()
     baselines = {"EM", "Naive Mean", "Skilled Mean"}
 
+    # Restrict grouping to columns actually present. Seasonal callers pass
+    # `date` (one ensemble per issue date); date-less frames fall back to
+    # period-level grouping unchanged.
+    time_group_cols = [c for c in time_group_cols if c in joint.columns]
+
     # --- EM (two-LR average; not skill-gated for quarter/season) ---
     skill_filtered = filter_for_highly_skilled_forecasts(skill_stats)
 
@@ -620,7 +628,7 @@ def _create_aggregated_ensemble_forecasts(
             if qcol in qualifying.columns:
                 em_agg[qcol] = "mean"
         for dcol in ("valid_from", "valid_to", "date"):
-            if dcol in qualifying.columns:
+            if dcol in qualifying.columns and dcol not in time_group_cols:
                 em_agg[dcol] = "first"
 
         em_avg = qualifying.groupby(time_group_cols).agg(em_agg).reset_index()
@@ -716,7 +724,7 @@ def _add_skilled_mean_aggregated_ens(
         if qcol in pool.columns:
             sm_agg[qcol] = (qcol, lambda x, _c=qcol: _weighted_mean(x, _c))
     for dcol in ("valid_from", "valid_to", "date"):
-        if dcol in pool.columns:
+        if dcol in pool.columns and dcol not in time_group_cols:
             sm_agg[dcol] = (dcol, "first")
 
     sm_avg = pool.groupby(time_group_cols).agg(**sm_agg).reset_index()
@@ -757,7 +765,7 @@ def _add_naive_mean_aggregated_ens(
         if qcol in pool.columns:
             naive_agg[qcol] = "mean"
     for dcol in ("valid_from", "valid_to", "date"):
-        if dcol in pool.columns:
+        if dcol in pool.columns and dcol not in time_group_cols:
             naive_agg[dcol] = "first"
 
     naive_avg = pool.groupby(time_group_cols).agg(naive_agg).reset_index()

--- a/apps/postprocessing_forecasts/src/ensemble_calculator.py
+++ b/apps/postprocessing_forecasts/src/ensemble_calculator.py
@@ -9,11 +9,10 @@ import logging
 
 import numpy as np
 import pandas as pd
+from src.model_names import AGGREGATED_EM_RAW_MODELS, canonical_model_short_series
 from src.postprocessing_tools import enforce_quantile_monotonicity, forecast_target_date
 
 logger = logging.getLogger(__name__)
-
-_AGGREGATED_EM_RAW_MODELS = frozenset({"LR_Base", "LR_SM"})
 
 
 # ---------------------------------------------------------------------------
@@ -604,7 +603,8 @@ def _create_aggregated_ensemble_forecasts(
     if "code" in skill_filtered.columns:
         skill_filtered["code"] = skill_filtered["code"].astype(str)
 
-    qualifying = joint[joint["model_short"].isin(_AGGREGATED_EM_RAW_MODELS)].copy()
+    model_keys = canonical_model_short_series(joint["model_short"])
+    qualifying = joint[model_keys.isin(AGGREGATED_EM_RAW_MODELS)].copy()
     qualifying = qualifying.dropna(subset=["forecasted_discharge"]).copy()
 
     n_models = qualifying["model_short"].nunique()

--- a/apps/postprocessing_forecasts/src/ensemble_calculator.py
+++ b/apps/postprocessing_forecasts/src/ensemble_calculator.py
@@ -13,6 +13,8 @@ from src.postprocessing_tools import enforce_quantile_monotonicity, forecast_tar
 
 logger = logging.getLogger(__name__)
 
+_AGGREGATED_EM_RAW_MODELS = frozenset({"LR_Base", "LR_SM"})
+
 
 # ---------------------------------------------------------------------------
 # Helper functions
@@ -589,26 +591,23 @@ def _create_aggregated_ensemble_forecasts(
     joint = forecasts.copy()
     baselines = {"EM", "Naive Mean", "Skilled Mean"}
 
-    # --- EM (threshold-filtered average) ---
+    # --- EM (two-LR average; not skill-gated for quarter/season) ---
     skill_filtered = filter_for_highly_skilled_forecasts(skill_stats)
-    merge_keys = [period_col, "code", "model_short"]
 
     # Normalize types for merge
-    for df in (joint, skill_filtered):
-        if period_col in df.columns:
-            df[period_col] = pd.to_numeric(df[period_col], errors="coerce")
-        if "code" in df.columns:
-            df["code"] = df["code"].astype(str)
+    if period_col in joint.columns:
+        joint[period_col] = pd.to_numeric(joint[period_col], errors="coerce")
+    if "code" in joint.columns:
+        joint["code"] = joint["code"].astype(str)
+    if period_col in skill_filtered.columns:
+        skill_filtered[period_col] = pd.to_numeric(skill_filtered[period_col], errors="coerce")
+    if "code" in skill_filtered.columns:
+        skill_filtered["code"] = skill_filtered["code"].astype(str)
 
-    qualifying = joint.merge(
-        skill_filtered[merge_keys].drop_duplicates(),
-        on=merge_keys,
-        how="inner",
-    )
-    qualifying = qualifying[~qualifying["model_short"].isin(baselines)].copy()
+    qualifying = joint[joint["model_short"].isin(_AGGREGATED_EM_RAW_MODELS)].copy()
     qualifying = qualifying.dropna(subset=["forecasted_discharge"]).copy()
 
-    n_models = joint[~joint["model_short"].isin(baselines)]["model_short"].nunique()
+    n_models = qualifying["model_short"].nunique()
 
     if n_models > 1 and not qualifying.empty:
         em_agg = {

--- a/apps/postprocessing_forecasts/src/ensemble_calculator.py
+++ b/apps/postprocessing_forecasts/src/ensemble_calculator.py
@@ -593,6 +593,14 @@ def _create_aggregated_ensemble_forecasts(
     joint = forecasts.copy()
     baselines = {"EM", "Naive Mean", "Skilled Mean"}
 
+    # Drop any pre-existing aggregated ensembles so operational generation
+    # matches the maintenance recalc: regenerate EM / Naive Mean / Skilled Mean
+    # from the raw models rather than re-emitting stored copies, which would
+    # duplicate the long_forecasts unique key on write. Other ensembles
+    # (e.g. NE) are left untouched.
+    if "model_short" in joint.columns:
+        joint = joint[~joint["model_short"].isin(baselines)].copy()
+
     # Restrict grouping to columns actually present. Seasonal callers pass
     # `date` (one ensemble per issue date); date-less frames fall back to
     # period-level grouping unchanged.

--- a/apps/postprocessing_forecasts/src/gap_detector.py
+++ b/apps/postprocessing_forecasts/src/gap_detector.py
@@ -452,13 +452,13 @@ def detect_missing_seasonal_ensembles(
     if ensemble_models is None:
         ensemble_models = {"EM"}
 
-    cols = ["season_year", "code", "model_short"]
+    cols = ["season_year", "season_in_year", "code", "model_short"]
     empty = pd.DataFrame(columns=cols)
 
     if combined_forecasts.empty:
         return empty
 
-    required = {"season_year", "code", "model_short"}
+    required = {"season_year", "season_in_year", "code", "model_short"}
     if not required.issubset(combined_forecasts.columns):
         logger.warning(
             "Seasonal combined forecasts missing columns: %s",
@@ -468,8 +468,10 @@ def detect_missing_seasonal_ensembles(
 
     df = combined_forecasts.copy()
     df["season_year"] = pd.to_numeric(df["season_year"], errors="coerce")
-    df = df.dropna(subset=["season_year"])
+    df["season_in_year"] = pd.to_numeric(df["season_in_year"], errors="coerce")
+    df = df.dropna(subset=["season_year", "season_in_year"])
     df["season_year"] = df["season_year"].astype(int)
+    df["season_in_year"] = df["season_in_year"].astype(int)
 
     if df.empty:
         return empty
@@ -482,21 +484,20 @@ def detect_missing_seasonal_ensembles(
     if recent.empty:
         return empty
 
-    all_pairs = recent[["season_year", "code"]].drop_duplicates()
+    key_cols = ["season_year", "season_in_year", "code"]
+    all_pairs = recent[key_cols].drop_duplicates()
 
     missing_parts = []
     for model in sorted(ensemble_models):
-        model_pairs = recent[recent["model_short"] == model][
-            ["season_year", "code"]
-        ].drop_duplicates()
+        model_pairs = recent[recent["model_short"] == model][key_cols].drop_duplicates()
 
         merged = all_pairs.merge(
             model_pairs,
-            on=["season_year", "code"],
+            on=key_cols,
             how="left",
             indicator=True,
         )
-        gaps = merged[merged["_merge"] == "left_only"][["season_year", "code"]].copy()
+        gaps = merged[merged["_merge"] == "left_only"][key_cols].copy()
         if not gaps.empty:
             gaps["model_short"] = model
             missing_parts.append(gaps)

--- a/apps/postprocessing_forecasts/src/model_names.py
+++ b/apps/postprocessing_forecasts/src/model_names.py
@@ -1,0 +1,36 @@
+"""Model-name normalization helpers for postprocessing forecast labels."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+_MODEL_ALIASES = {
+    "EM": "ENSEMBLE_MEAN",
+    "ENSEMBLE_MEAN": "ENSEMBLE_MEAN",
+    "NAIVE_MEAN": "NAIVE_MEAN",
+    "SKILLED_MEAN": "SKILLED_MEAN",
+}
+
+AGGREGATED_EM_RAW_MODELS = frozenset({"LR_BASE", "LR_SM"})
+AGGREGATED_ENSEMBLE_MODELS = frozenset({"ENSEMBLE_MEAN", "NAIVE_MEAN", "SKILLED_MEAN"})
+AGGREGATED_SUPPORTED_MODELS = AGGREGATED_EM_RAW_MODELS | AGGREGATED_ENSEMBLE_MODELS
+
+
+def canonical_model_short(model_short: object) -> str:
+    """Return a case-insensitive canonical model identifier."""
+    if pd.isna(model_short):
+        return ""
+    key = str(model_short).strip().upper().replace(" ", "_")
+    return _MODEL_ALIASES.get(key, key)
+
+
+def canonical_model_short_series(model_shorts: pd.Series) -> pd.Series:
+    """Vectorized canonical model identifiers for model_short columns."""
+    return (
+        model_shorts.astype("string")
+        .str.strip()
+        .str.upper()
+        .str.replace(" ", "_", regex=False)
+        .replace(_MODEL_ALIASES)
+        .fillna("")
+    )

--- a/apps/postprocessing_forecasts/src/skill_metrics.py
+++ b/apps/postprocessing_forecasts/src/skill_metrics.py
@@ -11,11 +11,10 @@ from contextlib import contextmanager
 
 import numpy as np
 import pandas as pd
+from src.model_names import AGGREGATED_EM_RAW_MODELS, canonical_model_short_series
 from src.postprocessing_tools import enforce_quantile_monotonicity, forecast_target_date
 
 logger = logging.getLogger(__name__)
-
-_AGGREGATED_EM_RAW_MODELS = frozenset({"LR_Base", "LR_SM"})
 
 
 # ---------------------------------------------------------------------------
@@ -2201,7 +2200,8 @@ def _calculate_aggregated_skill_metrics(
     # --- 4. Ensemble Mean (EM) ---
     joint_forecasts = forecasts.copy()
 
-    em_merged = merged[merged["model_short"].isin(_AGGREGATED_EM_RAW_MODELS)].copy()
+    model_keys = canonical_model_short_series(merged["model_short"])
+    em_merged = merged[model_keys.isin(AGGREGATED_EM_RAW_MODELS)].copy()
     em_merged = em_merged.dropna(subset=["forecasted_discharge"]).copy()
 
     n_models = em_merged["model_short"].nunique()

--- a/apps/postprocessing_forecasts/src/skill_metrics.py
+++ b/apps/postprocessing_forecasts/src/skill_metrics.py
@@ -1073,6 +1073,11 @@ _QUANTILE_COLS = ["q05", "q10", "q25", "q50", "q75", "q90", "q95"]
 _QUANTILE_LEVELS = np.array([0.05, 0.10, 0.25, 0.50, 0.75, 0.90, 0.95])
 
 # Columns carried through when appending ensemble rows to joint_forecasts
+# Aggregated ensemble model rows the recalc regenerates from the raw models.
+# Pre-existing copies of these must be dropped from recalc input so they are
+# neither scored as raw models nor written twice (duplicate-key collision).
+_AGGREGATED_BASELINES = ("EM", "Naive Mean", "Skilled Mean")
+
 _ENSEMBLE_JOINT_COLS = (
     [
         "code",
@@ -2133,6 +2138,16 @@ def _calculate_aggregated_skill_metrics(
 
     if observations.empty or forecasts.empty:
         return empty_stats, empty_joint, timing_stats
+
+    # The recalc regenerates EM / Naive Mean / Skilled Mean from the raw
+    # models. Drop any pre-existing copies in the source so we neither score
+    # them as raw models nor emit a duplicate write-key when the freshly
+    # computed ensemble collides with a stored one. Other ensemble types
+    # (e.g. NE) are left untouched.
+    if "model_short" in forecasts.columns:
+        forecasts = forecasts[~forecasts["model_short"].isin(_AGGREGATED_BASELINES)].copy()
+        if forecasts.empty:
+            return empty_stats, empty_joint, timing_stats
 
     # --- 1. Merge forecasts with observations ---
     # Build the set of observation columns we need, ensuring no duplicates.

--- a/apps/postprocessing_forecasts/src/skill_metrics.py
+++ b/apps/postprocessing_forecasts/src/skill_metrics.py
@@ -1079,6 +1079,12 @@ _ENSEMBLE_JOINT_COLS = (
         "year",
         "month",
         "month_in_year",
+        # Aggregated (quarter/season) period keys — required so EM/Naive/
+        # Skilled Mean rows keep their period column on append. Without
+        # these the write-side NaN guard drops every ensemble row.
+        "quarter_in_year",
+        "season_year",
+        "season_in_year",
         "forecasted_discharge",
         "model_short",
         "composition",
@@ -2083,7 +2089,11 @@ def calculate_seasonal_skill_metrics(
         observations,
         forecasts,
         period_col="season_in_year",
-        time_group_cols=["season_year", "season_in_year", "code"],
+        # Seasonal forecasts at a given lead can be (re-)issued on several
+        # dates; group by `date` so each issue forms its own ensemble (one
+        # EM per issue = clean 2-model mean) instead of collapsing distinct
+        # issue dates into a single blended row.
+        time_group_cols=["season_year", "season_in_year", "code", "date"],
         merge_cols=["code", "season_year"],
         timing_stats=timing_stats,
     )
@@ -2152,6 +2162,12 @@ def _calculate_aggregated_skill_metrics(
     if merged.empty:
         return empty_stats, empty_joint, timing_stats
 
+    # Restrict the ensemble grouping to columns actually present. Seasonal
+    # callers pass `date` so each issue date forms its own ensemble; date-less
+    # frames (quarter, legacy CSV) fall back to period-level grouping
+    # unchanged.
+    time_group_cols = [c for c in time_group_cols if c in merged.columns]
+
     # --- 2. Point metrics per group ---
     skill_stats = (
         merged.groupby(metric_group_cols)[["discharge_avg", "forecasted_discharge", "delta"]]
@@ -2216,7 +2232,7 @@ def _calculate_aggregated_skill_metrics(
             if qcol in em_merged.columns:
                 em_agg_dict[qcol] = "mean"
         for dcol in ("valid_from", "valid_to", "date"):
-            if dcol in em_merged.columns:
+            if dcol in em_merged.columns and dcol not in time_group_cols:
                 em_agg_dict[dcol] = "first"
 
         em_avg = em_merged.groupby(time_group_cols).agg(em_agg_dict).reset_index()
@@ -2348,7 +2364,7 @@ def _add_naive_mean_aggregated(
         if qcol in pool.columns:
             agg_dict[qcol] = "mean"
     for dcol in ("valid_from", "valid_to", "date"):
-        if dcol in pool.columns:
+        if dcol in pool.columns and dcol not in time_group_cols:
             agg_dict[dcol] = "first"
 
     naive_avg = pool.groupby(time_group_cols).agg(agg_dict).reset_index()
@@ -2495,7 +2511,7 @@ def _add_skilled_mean_aggregated(
             lambda x, _c=qcol: _weighted_mean_col(x, _c),
         )
     for dcol in ("valid_from", "valid_to", "date"):
-        if dcol in sm_merged.columns:
+        if dcol in sm_merged.columns and dcol not in time_group_cols:
             sm_agg_dict[dcol] = (dcol, "first")
 
     sm_avg = sm_merged.groupby(time_group_cols).agg(**sm_agg_dict).reset_index()

--- a/apps/postprocessing_forecasts/src/skill_metrics.py
+++ b/apps/postprocessing_forecasts/src/skill_metrics.py
@@ -15,6 +15,8 @@ from src.postprocessing_tools import enforce_quantile_monotonicity, forecast_tar
 
 logger = logging.getLogger(__name__)
 
+_AGGREGATED_EM_RAW_MODELS = frozenset({"LR_Base", "LR_SM"})
+
 
 # ---------------------------------------------------------------------------
 # Metric registry — single source of truth for all point metrics
@@ -2199,19 +2201,11 @@ def _calculate_aggregated_skill_metrics(
     # --- 4. Ensemble Mean (EM) ---
     joint_forecasts = forecasts.copy()
 
-    skill_stats_filtered = filter_for_highly_skilled_forecasts(skill_stats)
+    em_merged = merged[merged["model_short"].isin(_AGGREGATED_EM_RAW_MODELS)].copy()
+    em_merged = em_merged.dropna(subset=["forecasted_discharge"]).copy()
 
-    skilled_merged = merged.merge(
-        skill_stats_filtered[metric_group_cols].drop_duplicates(),
-        on=metric_group_cols,
-        how="inner",
-    )
-    baselines = {"EM", "Naive Mean", "Skilled Mean"}
-    skilled_merged = skilled_merged[~skilled_merged["model_short"].isin(baselines)].copy()
-    skilled_merged = skilled_merged.dropna(subset=["forecasted_discharge"]).copy()
-
-    n_models = forecasts["model_short"].nunique()
-    if n_models > 1 and not skilled_merged.empty:
+    n_models = em_merged["model_short"].nunique()
+    if n_models > 1 and not em_merged.empty:
         em_agg_dict = {
             "forecasted_discharge": "mean",
             "model_short": composition_agg,
@@ -2219,13 +2213,13 @@ def _calculate_aggregated_skill_metrics(
         if period_col not in time_group_cols:
             em_agg_dict[period_col] = "first"
         for qcol in _QUANTILE_COLS:
-            if qcol in skilled_merged.columns:
+            if qcol in em_merged.columns:
                 em_agg_dict[qcol] = "mean"
         for dcol in ("valid_from", "valid_to", "date"):
-            if dcol in skilled_merged.columns:
+            if dcol in em_merged.columns:
                 em_agg_dict[dcol] = "first"
 
-        em_avg = skilled_merged.groupby(time_group_cols).agg(em_agg_dict).reset_index()
+        em_avg = em_merged.groupby(time_group_cols).agg(em_agg_dict).reset_index()
         em_avg = enforce_quantile_monotonicity(
             em_avg, [c for c in _QUANTILE_COLS if c in em_avg.columns]
         )

--- a/apps/postprocessing_forecasts/src/skill_metrics.py
+++ b/apps/postprocessing_forecasts/src/skill_metrics.py
@@ -2064,8 +2064,9 @@ def calculate_seasonal_skill_metrics(
 ) -> tuple:
     """Calculate seasonal skill metrics for long-term forecasts.
 
-    Same pattern as quarterly but grouped by season_year.
-    season_in_year is always 1 (single season per year).
+    Same pattern as quarterly but grouped by season_year. For seasonal
+    forecasts, season_in_year carries the issue lead (Jan/Feb/Mar/Apr =
+    3/2/1/0) while observations are shared by target season.
 
     Args:
         observations: [code, season_year, season_in_year,
@@ -2081,7 +2082,7 @@ def calculate_seasonal_skill_metrics(
         observations,
         forecasts,
         period_col="season_in_year",
-        time_group_cols=["season_year", "code"],
+        time_group_cols=["season_year", "season_in_year", "code"],
         merge_cols=["code", "season_year"],
         timing_stats=timing_stats,
     )

--- a/apps/postprocessing_forecasts/tests/test_aggregated_nan_guard.py
+++ b/apps/postprocessing_forecasts/tests/test_aggregated_nan_guard.py
@@ -6,6 +6,7 @@ dropped before writing to the API, with a WARNING logged for the
 dropped count and sample codes.
 """
 
+import json
 import logging
 import os
 import sys
@@ -31,8 +32,15 @@ class TestAggregatedNanGuardQuarterly:
     """NaN guard tests for quarterly ensemble API writer."""
 
     @pytest.fixture(autouse=True)
-    def _mock_api(self, monkeypatch):
+    def _mock_api(self, monkeypatch, tmp_path):
         monkeypatch.setenv("SAPPHIRE_API_ENABLED", "true")
+        config_dir = tmp_path / "long_term"
+        config_dir.mkdir()
+        (config_dir / "quarter.json").write_text(json.dumps({"operational_month_lead_time": 1}))
+        monkeypatch.setenv("ieasyforecast_configuration_path", str(tmp_path))
+        monkeypatch.setenv("ieasyforecast_config_file_station_selection", "missing.json")
+        monkeypatch.setenv("ieasyhydroforecast_ml_long_term_configuration", "long_term")
+        monkeypatch.setenv("ieasyhydroforecast_ml_long_term_supported_modes", "quarter")
         self.mock_client = MagicMock()
         self.mock_client.readiness_check.return_value = True
         self.mock_client.write_long_forecasts.return_value = 2

--- a/apps/postprocessing_forecasts/tests/test_maintenance_long_term.py
+++ b/apps/postprocessing_forecasts/tests/test_maintenance_long_term.py
@@ -102,6 +102,7 @@ def _import_module(mocks_dict):
     )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    module._supported_seasonal_issue_leads = MagicMock(return_value=[])
     return module
 
 
@@ -349,6 +350,152 @@ class TestMaintenanceLongTerm:
             em_rows = saved_df[saved_df["model_short"] == "EM"]
             assert len(em_rows) == 1
             assert em_rows.iloc[0]["forecasted_discharge"] == 105.0
+
+    def test_seasonal_gap_fill_processes_single_missing_issue_without_collapsing_leads(
+        self,
+        combined_with_models,
+        gap_tuples,
+        forecasts_for_gaps,
+        ensemble_result,
+        skill_stats,
+    ):
+        """Seasonal gap-fill reads and fills only the missing issue lead."""
+        mock_sl = MagicMock()
+        mock_data_reader = MagicMock()
+        mock_gap_detector = MagicMock()
+        mock_ensemble_calc = MagicMock()
+        mock_file_writer = MagicMock()
+        mock_pt = MagicMock()
+        mock_pt.TimingStats.return_value.summary.return_value = ([], 0)
+
+        mock_sl.load_environment.return_value = None
+        mock_data_reader.read_monthly_combined_forecasts.return_value = combined_with_models
+        mock_gap_detector.detect_missing_monthly_ensembles.return_value = gap_tuples
+        mock_data_reader.read_monthly_forecasts.return_value = forecasts_for_gaps
+        mock_data_reader.read_quarterly_combined_forecasts.return_value = pd.DataFrame()
+        mock_file_writer.save_monthly_forecast_data.return_value = None
+        mock_file_writer.save_seasonal_forecast_data.return_value = None
+
+        seasonal_combined_by_lead = {
+            3: pd.DataFrame(
+                {
+                    "season_year": [2024],
+                    "season_in_year": [3],
+                    "code": ["10001"],
+                    "model_short": ["EM"],
+                    "forecasted_discharge": [103.0],
+                }
+            ),
+            2: pd.DataFrame(
+                {
+                    "season_year": [2024],
+                    "season_in_year": [2],
+                    "code": ["10001"],
+                    "model_short": ["LR"],
+                    "forecasted_discharge": [102.0],
+                }
+            ),
+            1: pd.DataFrame(
+                {
+                    "season_year": [2024],
+                    "season_in_year": [1],
+                    "code": ["10001"],
+                    "model_short": ["EM"],
+                    "forecasted_discharge": [101.0],
+                }
+            ),
+            0: pd.DataFrame(
+                {
+                    "season_year": [2024],
+                    "season_in_year": [0],
+                    "code": ["10001"],
+                    "model_short": ["EM"],
+                    "forecasted_discharge": [100.0],
+                }
+            ),
+        }
+
+        def read_skill_metrics(horizon_type, codes=None):
+            if horizon_type == "season":
+                return pd.DataFrame(
+                    {
+                        "season_in_year": [2],
+                        "code": ["10001"],
+                        "model_short": ["LR"],
+                        "sdivsigma": [0.3],
+                        "nse": [0.8],
+                    }
+                )
+            return skill_stats
+
+        def read_seasonal_combined_forecasts(codes=None, horizon_value=None):
+            return seasonal_combined_by_lead[horizon_value]
+
+        mock_data_reader.read_skill_metrics.side_effect = read_skill_metrics
+        mock_data_reader.read_seasonal_combined_forecasts.side_effect = (
+            read_seasonal_combined_forecasts
+        )
+        mock_gap_detector.detect_missing_seasonal_ensembles.return_value = pd.DataFrame(
+            {
+                "season_year": [2024],
+                "season_in_year": [2],
+                "code": ["10001"],
+                "model_short": ["EM"],
+            }
+        )
+        mock_data_reader.read_seasonal_forecasts.return_value = pd.DataFrame(
+            {
+                "season_year": [2024],
+                "season_in_year": [2],
+                "code": ["10001"],
+                "model_short": ["LR"],
+                "q50": [102.0],
+            }
+        )
+        mock_ensemble_calc.create_monthly_ensemble_forecasts.return_value = ensemble_result
+        mock_ensemble_calc.create_seasonal_ensemble_forecasts.return_value = pd.DataFrame(
+            {
+                "season_year": [2024, 2024],
+                "season_in_year": [2, 3],
+                "code": ["10001", "10001"],
+                "model_short": ["EM", "EM"],
+                "forecasted_discharge": [102.0, 999.0],
+            }
+        )
+
+        with patch.dict(sys.modules, {}):
+            module = _import_module(
+                {
+                    "sl": mock_sl,
+                    "data_reader": mock_data_reader,
+                    "gap_detector": mock_gap_detector,
+                    "ensemble_calc": mock_ensemble_calc,
+                    "file_writer": mock_file_writer,
+                    "pt": mock_pt,
+                }
+            )
+            module._read_station_codes = MagicMock(return_value=["10001"])
+            module._supported_seasonal_issue_leads = MagicMock(return_value=[3, 2, 1, 0])
+
+            with pytest.raises(SystemExit) as exc_info:
+                module.postprocessing_maintenance_long_term()
+
+            assert exc_info.value.code == 0
+            assert [
+                call.kwargs["horizon_value"]
+                for call in mock_data_reader.read_seasonal_combined_forecasts.call_args_list
+            ] == [3, 2, 1, 0]
+            mock_data_reader.read_seasonal_forecasts.assert_called_once()
+            assert mock_data_reader.read_seasonal_forecasts.call_args.kwargs["horizon_value"] == 2
+
+            saved = mock_file_writer.save_seasonal_forecast_data.call_args.args[0]
+            assert set(saved["season_in_year"]) == {0, 1, 2, 3}
+            filled = saved[(saved["season_in_year"] == 2) & (saved["model_short"] == "EM")]
+            assert len(filled) == 1
+            assert filled.iloc[0]["forecasted_discharge"] == 102.0
+            assert not (
+                (saved["season_in_year"] == 3) & (saved["forecasted_discharge"] == 999.0)
+            ).any()
 
     def test_deduplication_works(
         self,

--- a/apps/postprocessing_forecasts/tests/test_monthly_workflow_integration.py
+++ b/apps/postprocessing_forecasts/tests/test_monthly_workflow_integration.py
@@ -277,6 +277,10 @@ def monthly_integration_env(tmp_path):
     # Create directories
     (tmp_path / "logs").mkdir(exist_ok=True)
     os.makedirs(os.path.join(data_dir, "forecast_logs"), exist_ok=True)
+    long_term_config_dir = os.path.join(config_dst, "long_term")
+    os.makedirs(long_term_config_dir, exist_ok=True)
+    with open(os.path.join(long_term_config_dir, "quarter.json"), "w") as f:
+        f.write('{"operational_month_lead_time": 1}')
 
     env_overrides = {
         "ieasyforecast_intermediate_data_path": data_dir,
@@ -312,6 +316,8 @@ def monthly_integration_env(tmp_path):
         "ieasyforecast_hydrograph_day_file": "hydrograph_day.csv",
         "SAPPHIRE_RECALC_START_YEAR": "2021",
         "SAPPHIRE_RECALC_END_YEAR": "2025",
+        "ieasyhydroforecast_ml_long_term_configuration": "long_term",
+        "ieasyhydroforecast_ml_long_term_supported_modes": "quarter",
     }
     with patch.dict(os.environ, env_overrides):
         yield tmp_path, data_dir
@@ -595,6 +601,10 @@ class TestMonthlyAllModeIntegration:
                 with (
                     patch.object(dr, "_read_daily_runoff_api", return_value=daily),
                     patch.object(dr, "_read_long_forecasts_api", return_value=forecasts),
+                    patch.object(dr, "read_quarterly_observations", return_value=pd.DataFrame()),
+                    patch.object(dr, "read_quarterly_forecasts", return_value=pd.DataFrame()),
+                    patch.object(dr, "read_seasonal_observations", return_value=pd.DataFrame()),
+                    patch.object(dr, "read_seasonal_forecasts", return_value=pd.DataFrame()),
                 ):
                     module, spec = _import_recalc()
                     with patch("os.getcwd", return_value=str(tmp_path)):
@@ -661,6 +671,10 @@ class TestMonthlyAllModeIntegration:
                 with (
                     patch.object(dr, "_read_daily_runoff_api", return_value=daily),
                     patch.object(dr, "_read_long_forecasts_api", return_value=forecasts),
+                    patch.object(dr, "read_quarterly_observations", return_value=pd.DataFrame()),
+                    patch.object(dr, "read_quarterly_forecasts", return_value=pd.DataFrame()),
+                    patch.object(dr, "read_seasonal_observations", return_value=pd.DataFrame()),
+                    patch.object(dr, "read_seasonal_forecasts", return_value=pd.DataFrame()),
                 ):
                     module, spec = _import_recalc()
                     with patch("os.getcwd", return_value=str(tmp_path)):

--- a/apps/postprocessing_forecasts/tests/test_quarterly_api_writer.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_api_writer.py
@@ -3,6 +3,7 @@
 Phase 4b Step 5.
 """
 
+import json
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -18,6 +19,17 @@ from src.api_writer import (
     _write_seasonal_ensemble_to_api,
     _write_skill_metrics_to_api,
 )
+
+
+def _write_quarter_config(tmp_path, monkeypatch, lead):
+    config_dir = tmp_path / "long_term"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / "quarter.json").write_text(json.dumps({"operational_month_lead_time": lead}))
+    monkeypatch.setenv("ieasyforecast_configuration_path", str(tmp_path))
+    monkeypatch.setenv("ieasyforecast_config_file_station_selection", "missing.json")
+    monkeypatch.setenv("ieasyhydroforecast_ml_long_term_configuration", "long_term")
+    monkeypatch.setenv("ieasyhydroforecast_ml_long_term_supported_modes", "quarter")
+
 
 # ===================================================================
 # Horizon mapping
@@ -189,8 +201,9 @@ class TestSkillMetricsQuarterSeason:
 
 class TestQuarterlyEnsembleWriter:
     @pytest.fixture(autouse=True)
-    def _mock_api(self, monkeypatch):
+    def _mock_api(self, monkeypatch, tmp_path):
         monkeypatch.setenv("SAPPHIRE_API_ENABLED", "true")
+        _write_quarter_config(tmp_path, monkeypatch, lead=1)
         self.mock_client = MagicMock()
         self.mock_client.readiness_check.return_value = True
         self.mock_client.write_long_forecasts.return_value = 2
@@ -234,7 +247,35 @@ class TestQuarterlyEnsembleWriter:
         records = self.mock_client.write_long_forecasts.call_args[0][0]
         assert records[0]["valid_from"] == "2025-04-01"
         assert records[0]["valid_to"] == "2025-06-30"
-        assert records[0]["horizon_value"] == 2
+        assert records[0]["horizon_value"] == 1
+
+    @pytest.mark.parametrize("lead", [1, 0])
+    def test_horizon_value_uses_resolver_config_lead(self, monkeypatch, tmp_path, lead):
+        _write_quarter_config(tmp_path, monkeypatch, lead=lead)
+        data = pd.DataFrame(
+            {
+                "code": ["PP4_Q_SENTINEL", "PP4_Q_SENTINEL"],
+                "year": [2025, 2025],
+                "quarter_in_year": [1, 2],
+                "model_short": ["EM", "EM"],
+                "forecasted_discharge": [100.0, 110.0],
+            }
+        )
+        self.mock_client.write_long_forecasts.return_value = 2
+
+        with (
+            patch("src.api_writer.SAPPHIRE_API_AVAILABLE", True),
+            patch("src.api_writer._get_postprocessing_client", return_value=self.mock_client),
+        ):
+            result = _write_quarterly_ensemble_to_api(data)
+
+        assert result is True
+        records = self.mock_client.write_long_forecasts.call_args[0][0]
+        assert {record["horizon_value"] for record in records} == {lead}
+        assert {record["valid_from"] for record in records} == {
+            "2025-01-01",
+            "2025-04-01",
+        }
 
     def test_empty_data_returns_false(self):
         result = _write_quarterly_ensemble_to_api(pd.DataFrame())
@@ -275,6 +316,48 @@ class TestSeasonalEnsembleWriter:
         records = self.mock_client.write_long_forecasts.call_args[0][0]
         assert records[0]["horizon_type"] == "season"
         assert records[0]["horizon_value"] == 1
+
+    def test_four_issue_rows_keep_lead_date_and_target_season(self):
+        data = pd.DataFrame(
+            {
+                "code": ["PP4_S_SENTINEL"] * 4,
+                "season_year": [2025] * 4,
+                "season_in_year": [3, 2, 1, 0],
+                "date": [
+                    "2025-01-01",
+                    "2025-02-01",
+                    "2025-03-01",
+                    "2025-04-01",
+                ],
+                "model_short": ["EM", "Naive Mean", "Skilled Mean", "EM"],
+                "forecasted_discharge": [100.0, 110.0, 120.0, 130.0],
+            }
+        )
+        self.mock_client.write_long_forecasts.return_value = 4
+
+        with (
+            patch("src.api_writer.SAPPHIRE_API_AVAILABLE", True),
+            patch("src.api_writer._get_postprocessing_client", return_value=self.mock_client),
+        ):
+            result = _write_seasonal_ensemble_to_api(data)
+
+        assert result is True
+        records = self.mock_client.write_long_forecasts.call_args[0][0]
+        natural_keys = {
+            (
+                record["horizon_value"],
+                record["date"],
+                record["valid_from"],
+                record["valid_to"],
+            )
+            for record in records
+        }
+        assert natural_keys == {
+            (3, "2025-01-01", "2025-04-01", "2025-09-30"),
+            (2, "2025-02-01", "2025-04-01", "2025-09-30"),
+            (1, "2025-03-01", "2025-04-01", "2025-09-30"),
+            (0, "2025-04-01", "2025-04-01", "2025-09-30"),
+        }
 
     def test_valid_from_valid_to_default_season(self):
         """Default season Apr-Sep → valid_from=Apr 1, valid_to=Sep 30."""

--- a/apps/postprocessing_forecasts/tests/test_quarterly_api_writer.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_api_writer.py
@@ -146,6 +146,41 @@ class TestSkillMetricsQuarterSeason:
         records = self.mock_client.write_skill_metrics.call_args[0][0]
         assert records[0]["date"] == "2025-04-01"
 
+    def test_season_skill_records_keep_each_lead(self, monkeypatch):
+        """Seasonal skill uses season_in_year as API horizon_in_year."""
+        monkeypatch.setenv("SAPPHIRE_SEASON_START_MONTH", "4")
+        monkeypatch.setenv("SAPPHIRE_SEASON_END_MONTH", "9")
+        self.mock_client.write_skill_metrics.return_value = 4
+        data = pd.DataFrame(
+            {
+                "season_in_year": [3, 2, 1, 0],
+                "code": ["PP3_SENTINEL"] * 4,
+                "model_short": ["LR"] * 4,
+                "sdivsigma": [1.5, 1.0, 0.5, 0.0],
+                "nse": [-2.3, -0.5, 0.6, 1.0],
+                "delta": [5.0] * 4,
+                "accuracy": [0.0, 0.0, 0.0, 1.0],
+                "mae": [30.0, 20.0, 10.0, 0.0],
+                "n_pairs": [3] * 4,
+            }
+        )
+        with (
+            patch("src.api_writer.SAPPHIRE_API_AVAILABLE", True),
+            patch("src.api_writer._get_postprocessing_client", return_value=self.mock_client),
+        ):
+            result = _write_skill_metrics_to_api(data, "season", 2025)
+
+        assert result is True
+        records = self.mock_client.write_skill_metrics.call_args[0][0]
+        assert len(records) == 4
+        assert {record["horizon_in_year"] for record in records} == {0, 1, 2, 3}
+        assert {record["date"] for record in records} == {"2025-04-01"}
+        upsert_keys = {
+            (record["code"], record["model_type"], record["date"], record["horizon_in_year"])
+            for record in records
+        }
+        assert len(upsert_keys) == 4
+
 
 # ===================================================================
 # Quarterly ensemble writer

--- a/apps/postprocessing_forecasts/tests/test_quarterly_data_reader.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_data_reader.py
@@ -15,6 +15,17 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from src import data_reader
 
+DEPRECATED_MODEL_FORMS = [
+    "GBT",
+    "LR_SM_DT",
+    "LR_SM_ROF",
+    "MC_ALD",
+    "SM_GBT",
+    "SM_GBT_LR",
+    "SM_GBT_NORM",
+    "SM_GBT_Norm",
+]
+
 
 @pytest.fixture(autouse=True)
 def long_term_horizon_config(monkeypatch, tmp_path):
@@ -279,6 +290,52 @@ class TestReadQuarterlyForecasts:
         assert set(result["model_short"]) == {"LR_Base", "LR_SM", "EM"}
         assert not {"GBT", "SM_GBT_Norm"} & set(result["model_short"])
 
+    def test_filter_accepts_db_form_lr_and_ensemble_names(self):
+        direct_api = pd.DataFrame(
+            {
+                "code": ["S1"] * 8,
+                "valid_from": pd.to_datetime(["2024-01-01"] * 8),
+                "valid_to": ["2024-03-31"] * 8,
+                "model_type": [
+                    "LR_BASE",
+                    "LR_SM",
+                    "ENSEMBLE_MEAN",
+                    "NAIVE_MEAN",
+                    "SKILLED_MEAN",
+                    "GBT",
+                    "LR_SM_DT",
+                    "SM_GBT_NORM",
+                ],
+                "q05": [10, 15, 12, 13, 14, 900, 901, 902],
+                "q10": [15, 20, 17, 18, 19, 925, 926, 927],
+                "q25": [20, 25, 22, 23, 24, 950, 951, 952],
+                "q50": [30, 35, 32, 33, 34, 1000, 1001, 1002],
+                "q75": [40, 45, 42, 43, 44, 1050, 1051, 1052],
+                "q90": [50, 55, 52, 53, 54, 1075, 1076, 1077],
+                "q95": [60, 65, 62, 63, 64, 1100, 1101, 1102],
+            }
+        )
+
+        def mock_read_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
+            if horizon_type == "quarter":
+                return direct_api
+            return pd.DataFrame()
+
+        with (
+            patch.object(data_reader, "read_monthly_forecasts", return_value=pd.DataFrame()),
+            patch.object(data_reader, "_read_long_forecasts_api", side_effect=mock_read_api),
+        ):
+            result = data_reader.read_quarterly_forecasts(["S1"], 2024, 2024)
+
+        assert set(result["model_short"]) == {
+            "LR_BASE",
+            "LR_SM",
+            "ENSEMBLE_MEAN",
+            "NAIVE_MEAN",
+            "SKILLED_MEAN",
+        }
+        assert not set(DEPRECATED_MODEL_FORMS) & set(result["model_short"])
+
     def test_monthly_reader_keeps_deprecated_models(self):
         raw_api = pd.DataFrame(
             {
@@ -352,6 +409,44 @@ class TestReadSeasonalForecasts:
             result = data_reader.read_seasonal_forecasts(["S1"], 2024, 2024)
         assert set(result["model_short"]) == {"LR_Base", "LR_SM", "EM", "Skilled Mean"}
         assert "GBT" not in set(result["model_short"])
+
+    def test_db_form_deprecated_models_filtered_and_ensemble_rows_kept(self):
+        raw_api = pd.DataFrame(
+            {
+                "code": ["S1"] * 8,
+                "valid_from": pd.to_datetime(["2024-04-01"] * 8),
+                "valid_to": ["2024-09-30"] * 8,
+                "model_type": [
+                    "LR_BASE",
+                    "LR_SM",
+                    "ENSEMBLE_MEAN",
+                    "NAIVE_MEAN",
+                    "SKILLED_MEAN",
+                    "GBT",
+                    "LR_SM_ROF",
+                    "SM_GBT_NORM",
+                ],
+                "q50": [30, 35, 40, 41, 42, 999, 998, 997],
+                "q05": [10, 15, 20, 21, 22, 900, 899, 898],
+                "q10": [15, 20, 25, 26, 27, 925, 924, 923],
+                "q25": [20, 25, 30, 31, 32, 950, 949, 948],
+                "q75": [40, 45, 50, 51, 52, 1050, 1049, 1048],
+                "q90": [50, 55, 60, 61, 62, 1075, 1074, 1073],
+                "q95": [60, 65, 70, 71, 72, 1100, 1099, 1098],
+            }
+        )
+
+        with patch.object(data_reader, "_read_long_forecasts_api", return_value=raw_api):
+            result = data_reader.read_seasonal_forecasts(["S1"], 2024, 2024)
+
+        assert set(result["model_short"]) == {
+            "LR_BASE",
+            "LR_SM",
+            "ENSEMBLE_MEAN",
+            "NAIVE_MEAN",
+            "SKILLED_MEAN",
+        }
+        assert not set(DEPRECATED_MODEL_FORMS) & set(result["model_short"])
 
     def test_preserves_four_issue_dates_and_leads(self):
         """Jan-Apr issue rows for one target season survive distinctly."""
@@ -512,6 +607,53 @@ class TestReadLatestQuarterlyForecasts:
         assert set(result["model_short"]) == {"LR_Base", "LR_SM"}
         assert not {"GBT", "LR_SM_DT"} & set(result["model_short"])
 
+    def test_latest_accepts_db_form_lr_and_ensemble_names(self):
+        import datetime as dt
+
+        raw_quarter = pd.DataFrame(
+            {
+                "code": ["S1"] * 8,
+                "valid_from": pd.to_datetime(["2024-04-01"] * 8),
+                "valid_to": pd.to_datetime(["2024-06-30"] * 8),
+                "model_type": [
+                    "LR_BASE",
+                    "LR_SM",
+                    "ENSEMBLE_MEAN",
+                    "NAIVE_MEAN",
+                    "SKILLED_MEAN",
+                    "MC_ALD",
+                    "SM_GBT",
+                    "SM_GBT_LR",
+                ],
+                "q50": [50, 60, 55, 56, 57, 1000, 1001, 1002],
+                "q05": [30, 40, 35, 36, 37, 900, 901, 902],
+                "q10": [35, 45, 40, 41, 42, 925, 926, 927],
+                "q25": [40, 50, 45, 46, 47, 950, 951, 952],
+                "q75": [60, 70, 65, 66, 67, 1050, 1051, 1052],
+                "q90": [70, 80, 75, 76, 77, 1075, 1076, 1077],
+                "q95": [80, 90, 85, 86, 87, 1100, 1101, 1102],
+            }
+        )
+
+        def mock_read_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
+            if horizon_type == "quarter":
+                return raw_quarter
+            return pd.DataFrame()
+
+        with patch.object(data_reader, "_read_long_forecasts_api", side_effect=mock_read_api):
+            result = data_reader.read_latest_quarterly_forecasts(
+                ["S1"], forecast_date=dt.date(2024, 7, 1)
+            )
+
+        assert set(result["model_short"]) == {
+            "LR_BASE",
+            "LR_SM",
+            "ENSEMBLE_MEAN",
+            "NAIVE_MEAN",
+            "SKILLED_MEAN",
+        }
+        assert not set(DEPRECATED_MODEL_FORMS) & set(result["model_short"])
+
 
 class TestReadLatestSeasonalForecasts:
     def test_returns_latest_season(self):
@@ -587,6 +729,53 @@ class TestReadLatestSeasonalForecasts:
             )
         assert set(result["model_short"]) == {"LR_Base", "EM"}
         assert "GBT" not in set(result["model_short"])
+
+    def test_latest_accepts_db_form_lr_and_ensemble_names(self):
+        import datetime as dt
+
+        raw_api = pd.DataFrame(
+            {
+                "code": ["S1"] * 8,
+                "valid_from": pd.to_datetime(["2024-04-01"] * 8),
+                "valid_to": ["2024-09-30"] * 8,
+                "model_type": [
+                    "LR_BASE",
+                    "LR_SM",
+                    "ENSEMBLE_MEAN",
+                    "NAIVE_MEAN",
+                    "SKILLED_MEAN",
+                    "GBT",
+                    "LR_SM_DT",
+                    "SM_GBT_NORM",
+                ],
+                "q05": [10, 15, 20, 21, 22, 900, 901, 902],
+                "q10": [15, 20, 25, 26, 27, 925, 926, 927],
+                "q25": [20, 25, 30, 31, 32, 950, 951, 952],
+                "q50": [30, 35, 40, 41, 42, 1000, 1001, 1002],
+                "q75": [40, 45, 50, 51, 52, 1050, 1051, 1052],
+                "q90": [50, 55, 60, 61, 62, 1075, 1076, 1077],
+                "q95": [60, 65, 70, 71, 72, 1100, 1101, 1102],
+            }
+        )
+
+        def mock_read_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
+            if horizon_type == "season":
+                return raw_api
+            return pd.DataFrame()
+
+        with patch.object(data_reader, "_read_long_forecasts_api", side_effect=mock_read_api):
+            result = data_reader.read_latest_seasonal_forecasts(
+                ["S1"], forecast_date=dt.date(2024, 10, 1)
+            )
+
+        assert set(result["model_short"]) == {
+            "LR_BASE",
+            "LR_SM",
+            "ENSEMBLE_MEAN",
+            "NAIVE_MEAN",
+            "SKILLED_MEAN",
+        }
+        assert not set(DEPRECATED_MODEL_FORMS) & set(result["model_short"])
 
     def test_empty_api_returns_empty(self):
         def mock_read_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):

--- a/apps/postprocessing_forecasts/tests/test_quarterly_data_reader.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_data_reader.py
@@ -5,7 +5,7 @@ Phase 4b Step 2.
 
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -240,6 +240,42 @@ class TestReadSeasonalForecasts:
         assert len(result) == 1
         assert result.iloc[0]["model_short"] == "LR"
 
+    def test_preserves_four_issue_dates_and_leads(self):
+        """Jan-Apr issue rows for one target season survive distinctly."""
+        raw_api = pd.DataFrame(
+            {
+                "code": ["19999"] * 4,
+                "date": pd.to_datetime(["2024-01-01", "2024-02-01", "2024-03-01", "2024-04-01"]),
+                "horizon_value": [3, 2, 1, 0],
+                "valid_from": pd.to_datetime(["2024-04-01"] * 4),
+                "valid_to": ["2024-09-30"] * 4,
+                "model_type": ["LR"] * 4,
+                "q50": [30, 31, 32, 33],
+                "q05": [10, 11, 12, 13],
+                "q10": [15, 16, 17, 18],
+                "q25": [20, 21, 22, 23],
+                "q75": [40, 41, 42, 43],
+                "q90": [50, 51, 52, 53],
+                "q95": [60, 61, 62, 63],
+            }
+        )
+
+        with patch.object(data_reader, "_read_long_forecasts_api", return_value=raw_api):
+            result = data_reader.read_seasonal_forecasts(["19999"], 2024, 2024)
+
+        assert len(result) == 4
+        assert set(result["season_year"]) == {2024}
+        assert set(result["season_in_year"]) == {0, 1, 2, 3}
+        assert set(result["horizon_value"]) == {0, 1, 2, 3}
+        assert "date" in result.columns
+        by_issue = {row["date"][:10]: int(row["season_in_year"]) for _, row in result.iterrows()}
+        assert by_issue == {
+            "2024-01-01": 3,
+            "2024-02-01": 2,
+            "2024-03-01": 1,
+            "2024-04-01": 0,
+        }
+
 
 # ===================================================================
 # Latest quarterly/seasonal forecasts
@@ -382,6 +418,46 @@ class TestReadLatestSeasonalForecasts:
             result = data_reader.read_latest_seasonal_forecasts(["S1"])
         assert result.empty
 
+    def test_latest_deduplicates_without_folding_four_issues(self):
+        """Duplicate issue rows are removed, but all four leads remain."""
+        import datetime as dt
+
+        raw_api = pd.DataFrame(
+            {
+                "code": ["19999"] * 5,
+                "date": pd.to_datetime(
+                    [
+                        "2024-01-01",
+                        "2024-01-01",
+                        "2024-02-01",
+                        "2024-03-01",
+                        "2024-04-01",
+                    ]
+                ),
+                "horizon_value": [3, 3, 2, 1, 0],
+                "valid_from": pd.to_datetime(["2024-04-01"] * 5),
+                "valid_to": ["2024-09-30"] * 5,
+                "model_type": ["LR"] * 5,
+                "q50": [30, 30, 31, 32, 33],
+                "q05": [10, 10, 11, 12, 13],
+                "q10": [15, 15, 16, 17, 18],
+                "q25": [20, 20, 21, 22, 23],
+                "q75": [40, 40, 41, 42, 43],
+                "q90": [50, 50, 51, 52, 53],
+                "q95": [60, 60, 61, 62, 63],
+            }
+        )
+
+        with patch.object(data_reader, "_read_long_forecasts_api", return_value=raw_api):
+            result = data_reader.read_latest_seasonal_forecasts(
+                ["19999"], forecast_date=dt.date(2024, 10, 1)
+            )
+
+        assert len(result) == 4
+        assert set(result["season_in_year"]) == {0, 1, 2, 3}
+        identity_cols = ["code", "season_year", "season_in_year", "date", "model_short"]
+        assert result[identity_cols].duplicated().sum() == 0
+
 
 # ===================================================================
 # Combined forecasts from API
@@ -414,3 +490,114 @@ class TestReadSeasonalCombinedForecasts:
         with patch.object(data_reader, "_read_long_combined_forecasts_api", return_value=None):
             result = data_reader.read_seasonal_combined_forecasts()
         assert result.empty
+
+
+class TestLongTermApiHorizonValue:
+    def test_read_long_forecasts_api_forwards_horizon_value_when_provided(self):
+        mock_client = MagicMock()
+        mock_client.readiness_check.return_value = True
+        mock_client.read_long_term_forecasts.return_value = pd.DataFrame()
+
+        with (
+            patch.object(data_reader, "SAPPHIRE_API_AVAILABLE", True),
+            patch.dict(os.environ, {"SAPPHIRE_API_ENABLED": "true"}),
+            patch.object(
+                data_reader,
+                "SapphirePostprocessingClient",
+                return_value=mock_client,
+            ),
+        ):
+            data_reader._read_long_forecasts_api(
+                ["19999"],
+                2024,
+                2024,
+                horizon_type="season",
+                horizon_value=3,
+            )
+
+        kwargs = mock_client.read_long_term_forecasts.call_args.kwargs
+        assert kwargs["horizon_type"] == "season"
+        assert kwargs["code"] == "19999"
+        assert kwargs["horizon_value"] == 3
+
+    def test_read_long_forecasts_api_omits_horizon_value_by_default(self):
+        mock_client = MagicMock()
+        mock_client.readiness_check.return_value = True
+        mock_client.read_long_term_forecasts.return_value = pd.DataFrame()
+
+        with (
+            patch.object(data_reader, "SAPPHIRE_API_AVAILABLE", True),
+            patch.dict(os.environ, {"SAPPHIRE_API_ENABLED": "true"}),
+            patch.object(
+                data_reader,
+                "SapphirePostprocessingClient",
+                return_value=mock_client,
+            ),
+        ):
+            data_reader._read_long_forecasts_api(["19999"], 2024, 2024)
+
+        assert "horizon_value" not in mock_client.read_long_term_forecasts.call_args.kwargs
+
+    def test_read_long_combined_forecasts_api_forwards_horizon_value_when_provided(self):
+        mock_client = MagicMock()
+        mock_client.readiness_check.return_value = True
+        mock_client.read_long_term_forecasts.return_value = pd.DataFrame()
+
+        with (
+            patch.object(data_reader, "SAPPHIRE_API_AVAILABLE", True),
+            patch.dict(os.environ, {"SAPPHIRE_API_ENABLED": "true"}),
+            patch.object(
+                data_reader,
+                "SapphirePostprocessingClient",
+                return_value=mock_client,
+            ),
+        ):
+            data_reader._read_long_combined_forecasts_api(
+                "season",
+                codes=["19999"],
+                horizon_value=2,
+            )
+
+        kwargs = mock_client.read_long_term_forecasts.call_args.kwargs
+        assert kwargs["horizon_type"] == "season"
+        assert kwargs["code"] == "19999"
+        assert kwargs["horizon_value"] == 2
+
+    def test_read_long_combined_forecasts_api_omits_horizon_value_by_default(self):
+        mock_client = MagicMock()
+        mock_client.readiness_check.return_value = True
+        mock_client.read_long_term_forecasts.return_value = pd.DataFrame()
+
+        with (
+            patch.object(data_reader, "SAPPHIRE_API_AVAILABLE", True),
+            patch.dict(os.environ, {"SAPPHIRE_API_ENABLED": "true"}),
+            patch.object(
+                data_reader,
+                "SapphirePostprocessingClient",
+                return_value=mock_client,
+            ),
+        ):
+            data_reader._read_long_combined_forecasts_api("season", codes=["19999"])
+
+        assert "horizon_value" not in mock_client.read_long_term_forecasts.call_args.kwargs
+
+
+class TestCombinedForecastNormalization:
+    def test_quarter_normalization_still_drops_raw_horizon_value(self):
+        raw_api = pd.DataFrame(
+            {
+                "code": ["19999"],
+                "horizon_value": [1],
+                "valid_from": pd.to_datetime(["2024-01-01"]),
+                "valid_to": ["2024-03-31"],
+                "model_type": ["LR"],
+                "q50": [30],
+            }
+        )
+
+        result = data_reader._normalize_combined_forecasts(raw_api, "quarter")
+
+        assert result.iloc[0]["year"] == 2024
+        assert result.iloc[0]["quarter_in_year"] == 1
+        assert result.iloc[0]["model_short"] == "LR"
+        assert "horizon_value" not in result.columns

--- a/apps/postprocessing_forecasts/tests/test_quarterly_data_reader.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_data_reader.py
@@ -127,7 +127,7 @@ class TestReadQuarterlyForecasts:
                 "code": ["S1"] * 3,
                 "year": [2024] * 3,
                 "month": [1, 2, 3],
-                "model_short": ["M1"] * 3,
+                "model_short": ["LR_Base"] * 3,
                 "q05": [10, 20, 30],
                 "q10": [15, 25, 35],
                 "q25": [20, 30, 40],
@@ -189,7 +189,7 @@ class TestReadQuarterlyForecasts:
                 "code": ["S1"] * 3,
                 "year": [2024] * 3,
                 "month": [1, 2, 3],
-                "model_short": ["M1"] * 3,
+                "model_short": ["LR_Base"] * 3,
                 "q05": [10, 20, 30],
                 "q10": [15, 25, 35],
                 "q25": [20, 30, 40],
@@ -205,7 +205,7 @@ class TestReadQuarterlyForecasts:
                 "code": ["S1"],
                 "valid_from": pd.to_datetime(["2024-01-01"]),
                 "valid_to": ["2024-03-31"],
-                "model_type": ["M1"],
+                "model_type": ["LR_Base"],
                 "q05": [99],
                 "q10": [99],
                 "q25": [99],
@@ -227,9 +227,72 @@ class TestReadQuarterlyForecasts:
         ):
             result = data_reader.read_quarterly_forecasts(["S1"], 2024, 2024)
         # Direct wins: q50 should be 99, not the aggregated mean
-        m1_rows = result[result["model_short"] == "M1"]
-        assert len(m1_rows) == 1
-        assert m1_rows.iloc[0]["q50"] == 99
+        lr_base_rows = result[result["model_short"] == "LR_Base"]
+        assert len(lr_base_rows) == 1
+        assert lr_base_rows.iloc[0]["q50"] == 99
+
+    def test_filters_deprecated_models_after_combining_sources(self):
+        """Quarterly reader keeps LR raw models and ensembles, dropping deprecated rows."""
+        monthly = pd.DataFrame(
+            {
+                "code": ["S1"] * 6,
+                "year": [2024] * 6,
+                "month": [1, 2, 3, 1, 2, 3],
+                "model_short": ["LR_Base"] * 3 + ["GBT"] * 3,
+                "q05": [10, 20, 30, 900, 900, 900],
+                "q10": [15, 25, 35, 925, 925, 925],
+                "q25": [20, 30, 40, 950, 950, 950],
+                "q50": [30, 40, 50, 1000, 1000, 1000],
+                "q75": [40, 50, 60, 1050, 1050, 1050],
+                "q90": [50, 60, 70, 1075, 1075, 1075],
+                "q95": [60, 70, 80, 1100, 1100, 1100],
+                "forecasted_discharge": [30, 40, 50, 1000, 1000, 1000],
+            }
+        )
+        direct_api = pd.DataFrame(
+            {
+                "code": ["S1", "S1", "S1"],
+                "valid_from": pd.to_datetime(["2024-01-01"] * 3),
+                "valid_to": ["2024-03-31"] * 3,
+                "model_type": ["LR_SM", "SM_GBT_Norm", "EM"],
+                "q05": [15, 900, 12],
+                "q10": [20, 925, 17],
+                "q25": [25, 950, 22],
+                "q50": [35, 1000, 32],
+                "q75": [45, 1050, 42],
+                "q90": [55, 1075, 52],
+                "q95": [65, 1100, 62],
+            }
+        )
+
+        def mock_read_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
+            if horizon_type == "quarter":
+                return direct_api
+            return pd.DataFrame()
+
+        with (
+            patch.object(data_reader, "read_monthly_forecasts", return_value=monthly),
+            patch.object(data_reader, "_read_long_forecasts_api", side_effect=mock_read_api),
+        ):
+            result = data_reader.read_quarterly_forecasts(["S1"], 2024, 2024)
+
+        assert set(result["model_short"]) == {"LR_Base", "LR_SM", "EM"}
+        assert not {"GBT", "SM_GBT_Norm"} & set(result["model_short"])
+
+    def test_monthly_reader_keeps_deprecated_models(self):
+        raw_api = pd.DataFrame(
+            {
+                "code": ["S1", "S1"],
+                "valid_from": pd.to_datetime(["2024-01-01", "2024-01-01"]),
+                "valid_to": ["2024-01-31", "2024-01-31"],
+                "model_type": ["LR_Base", "GBT"],
+                "q50": [30, 999],
+            }
+        )
+        with patch.object(data_reader, "_read_long_forecasts_api", return_value=raw_api):
+            result = data_reader.read_monthly_forecasts(["S1"], 2024, 2024)
+
+        assert set(result["model_short"]) == {"LR_Base", "GBT"}
 
 
 # ===================================================================
@@ -245,7 +308,7 @@ class TestReadSeasonalForecasts:
                 "code": ["S1", "S1"],
                 "valid_from": pd.to_datetime(["2024-04-01", "2024-04-01"]),
                 "valid_to": ["2024-09-30", "2024-09-30"],
-                "model_type": ["LR", "TFT"],
+                "model_type": ["LR_Base", "LR_SM"],
                 "q05": [10, 15],
                 "q10": [15, 20],
                 "q25": [20, 25],
@@ -261,35 +324,34 @@ class TestReadSeasonalForecasts:
         assert "season_year" in result.columns
         assert "season_in_year" in result.columns
         assert "model_short" in result.columns
-        # Ensemble models should be filtered out
-        assert not result["model_short"].isin({"EM", "Skilled Mean", "Naive Mean"}).any()
+        assert set(result["model_short"]) == {"LR_Base", "LR_SM"}
 
     def test_empty_api_returns_empty(self):
         with patch.object(data_reader, "_read_long_forecasts_api", return_value=pd.DataFrame()):
             result = data_reader.read_seasonal_forecasts(["S1"], 2024, 2024)
         assert result.empty
 
-    def test_ensemble_models_filtered(self):
-        """Ensemble rows from API are excluded."""
+    def test_deprecated_models_filtered_and_ensemble_rows_kept(self):
+        """Deprecated raw rows are excluded; stored ensemble rows are retained."""
         raw_api = pd.DataFrame(
             {
-                "code": ["S1", "S1", "S1"],
-                "valid_from": pd.to_datetime(["2024-04-01"] * 3),
-                "valid_to": ["2024-09-30"] * 3,
-                "model_type": ["LR", "EM", "Skilled Mean"],
-                "q50": [30, 40, 50],
-                "q05": [10, 20, 30],
-                "q10": [15, 25, 35],
-                "q25": [20, 30, 40],
-                "q75": [40, 50, 60],
-                "q90": [50, 60, 70],
-                "q95": [60, 70, 80],
+                "code": ["S1"] * 5,
+                "valid_from": pd.to_datetime(["2024-04-01"] * 5),
+                "valid_to": ["2024-09-30"] * 5,
+                "model_type": ["LR_Base", "LR_SM", "GBT", "EM", "Skilled Mean"],
+                "q50": [30, 35, 999, 40, 50],
+                "q05": [10, 15, 900, 20, 30],
+                "q10": [15, 20, 925, 25, 35],
+                "q25": [20, 25, 950, 30, 40],
+                "q75": [40, 45, 1050, 50, 60],
+                "q90": [50, 55, 1075, 60, 70],
+                "q95": [60, 65, 1100, 70, 80],
             }
         )
         with patch.object(data_reader, "_read_long_forecasts_api", return_value=raw_api):
             result = data_reader.read_seasonal_forecasts(["S1"], 2024, 2024)
-        assert len(result) == 1
-        assert result.iloc[0]["model_short"] == "LR"
+        assert set(result["model_short"]) == {"LR_Base", "LR_SM", "EM", "Skilled Mean"}
+        assert "GBT" not in set(result["model_short"])
 
     def test_preserves_four_issue_dates_and_leads(self):
         """Jan-Apr issue rows for one target season survive distinctly."""
@@ -300,7 +362,7 @@ class TestReadSeasonalForecasts:
                 "horizon_value": [3, 2, 1, 0],
                 "valid_from": pd.to_datetime(["2024-04-01"] * 4),
                 "valid_to": ["2024-09-30"] * 4,
-                "model_type": ["LR"] * 4,
+                "model_type": ["LR_Base"] * 4,
                 "q50": [30, 31, 32, 33],
                 "q05": [10, 11, 12, 13],
                 "q10": [15, 16, 17, 18],
@@ -364,7 +426,7 @@ class TestReadLatestQuarterlyForecasts:
                         "2024-06-30",
                     ]
                 ),
-                "model_type": ["M1"] * 6,
+                "model_type": ["LR_Base"] * 6,
                 "q50": [100, 110, 120, 50, 60, 70],
                 "q05": [80, 90, 100, 30, 40, 50],
                 "q10": [85, 95, 105, 35, 45, 55],
@@ -403,6 +465,53 @@ class TestReadLatestQuarterlyForecasts:
             result = data_reader.read_latest_quarterly_forecasts(["S1"])
         assert result.empty
 
+    def test_latest_filters_deprecated_models_after_combining_sources(self):
+        import datetime as dt
+
+        raw_monthly = pd.DataFrame(
+            {
+                "code": ["S1"] * 6,
+                "valid_from": pd.to_datetime(["2024-04-01", "2024-05-01", "2024-06-01"] * 2),
+                "valid_to": pd.to_datetime(["2024-04-30", "2024-05-31", "2024-06-30"] * 2),
+                "model_type": ["LR_Base"] * 3 + ["GBT"] * 3,
+                "q50": [50, 60, 70, 1000, 1000, 1000],
+                "q05": [30, 40, 50, 900, 900, 900],
+                "q10": [35, 45, 55, 925, 925, 925],
+                "q25": [40, 50, 60, 950, 950, 950],
+                "q75": [60, 70, 80, 1050, 1050, 1050],
+                "q90": [70, 80, 90, 1075, 1075, 1075],
+                "q95": [80, 90, 100, 1100, 1100, 1100],
+            }
+        )
+        raw_quarter = pd.DataFrame(
+            {
+                "code": ["S1", "S1"],
+                "valid_from": pd.to_datetime(["2024-04-01", "2024-04-01"]),
+                "valid_to": pd.to_datetime(["2024-06-30", "2024-06-30"]),
+                "model_type": ["LR_SM", "LR_SM_DT"],
+                "q50": [65, 999],
+                "q05": [45, 900],
+                "q10": [50, 925],
+                "q25": [55, 950],
+                "q75": [75, 1050],
+                "q90": [85, 1075],
+                "q95": [95, 1100],
+            }
+        )
+
+        def mock_read_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
+            if horizon_type == "quarter":
+                return raw_quarter
+            return raw_monthly
+
+        with patch.object(data_reader, "_read_long_forecasts_api", side_effect=mock_read_api):
+            result = data_reader.read_latest_quarterly_forecasts(
+                ["S1"], forecast_date=dt.date(2024, 7, 1)
+            )
+
+        assert set(result["model_short"]) == {"LR_Base", "LR_SM"}
+        assert not {"GBT", "LR_SM_DT"} & set(result["model_short"])
+
 
 class TestReadLatestSeasonalForecasts:
     def test_returns_latest_season(self):
@@ -414,7 +523,7 @@ class TestReadLatestSeasonalForecasts:
                 "code": ["S1", "S1", "S1"],
                 "valid_from": pd.to_datetime(["2023-04-01", "2024-04-01", "2024-04-01"]),
                 "valid_to": ["2023-09-30", "2024-09-30", "2024-09-30"],
-                "model_type": ["LR", "LR", "TFT"],
+                "model_type": ["LR_Base", "LR_Base", "LR_SM"],
                 "q05": [10, 15, 12],
                 "q10": [15, 20, 17],
                 "q25": [20, 25, 22],
@@ -442,28 +551,28 @@ class TestReadLatestSeasonalForecasts:
         assert not result.empty
         # Should only have 2024 season (latest)
         assert all(result["season_year"] == 2024)
-        assert len(result) == 2  # LR and TFT for 2024
-        assert set(result["model_short"]) == {"LR", "TFT"}
+        assert len(result) == 2  # LR_Base and LR_SM for 2024
+        assert set(result["model_short"]) == {"LR_Base", "LR_SM"}
         assert "season_in_year" in result.columns
         assert "forecasted_discharge" in result.columns
 
-    def test_ensemble_models_filtered(self):
-        """Ensemble rows from API are excluded."""
+    def test_deprecated_models_filtered_and_ensemble_rows_kept(self):
+        """Deprecated raw rows are excluded; stored ensemble rows are retained."""
         import datetime as dt
 
         raw_api = pd.DataFrame(
             {
-                "code": ["S1", "S1"],
-                "valid_from": pd.to_datetime(["2024-04-01", "2024-04-01"]),
-                "valid_to": ["2024-09-30", "2024-09-30"],
-                "model_type": ["LR", "EM"],
-                "q05": [10, 20],
-                "q10": [15, 25],
-                "q25": [20, 30],
-                "q50": [30, 40],
-                "q75": [40, 50],
-                "q90": [50, 60],
-                "q95": [60, 70],
+                "code": ["S1", "S1", "S1"],
+                "valid_from": pd.to_datetime(["2024-04-01"] * 3),
+                "valid_to": ["2024-09-30"] * 3,
+                "model_type": ["LR_Base", "GBT", "EM"],
+                "q05": [10, 900, 20],
+                "q10": [15, 925, 25],
+                "q25": [20, 950, 30],
+                "q50": [30, 1000, 40],
+                "q75": [40, 1050, 50],
+                "q90": [50, 1075, 60],
+                "q95": [60, 1100, 70],
             }
         )
 
@@ -476,8 +585,8 @@ class TestReadLatestSeasonalForecasts:
             result = data_reader.read_latest_seasonal_forecasts(
                 ["S1"], forecast_date=dt.date(2024, 10, 1)
             )
-        assert len(result) == 1
-        assert result.iloc[0]["model_short"] == "LR"
+        assert set(result["model_short"]) == {"LR_Base", "EM"}
+        assert "GBT" not in set(result["model_short"])
 
     def test_empty_api_returns_empty(self):
         def mock_read_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
@@ -506,7 +615,7 @@ class TestReadLatestSeasonalForecasts:
                 "horizon_value": [3, 3, 2, 1, 0],
                 "valid_from": pd.to_datetime(["2024-04-01"] * 5),
                 "valid_to": ["2024-09-30"] * 5,
-                "model_type": ["LR"] * 5,
+                "model_type": ["LR_Base"] * 5,
                 "q50": [30, 30, 31, 32, 33],
                 "q05": [10, 10, 11, 12, 13],
                 "q10": [15, 15, 16, 17, 18],
@@ -669,7 +778,7 @@ class TestCombinedForecastNormalization:
                 "horizon_value": [1],
                 "valid_from": pd.to_datetime(["2024-01-01"]),
                 "valid_to": ["2024-03-31"],
-                "model_type": ["LR"],
+                "model_type": ["LR_Base"],
                 "q50": [30],
             }
         )
@@ -678,5 +787,5 @@ class TestCombinedForecastNormalization:
 
         assert result.iloc[0]["year"] == 2024
         assert result.iloc[0]["quarter_in_year"] == 1
-        assert result.iloc[0]["model_short"] == "LR"
+        assert result.iloc[0]["model_short"] == "LR_Base"
         assert "horizon_value" not in result.columns

--- a/apps/postprocessing_forecasts/tests/test_quarterly_data_reader.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_data_reader.py
@@ -3,6 +3,7 @@
 Phase 4b Step 2.
 """
 
+import json
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -13,6 +14,29 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from src import data_reader
+
+
+@pytest.fixture(autouse=True)
+def long_term_horizon_config(monkeypatch, tmp_path):
+    """Provide sentinel long-term resolver config for reader tests."""
+    config_dir = tmp_path / "long_term"
+    config_dir.mkdir()
+    monkeypatch.setenv("ieasyforecast_configuration_path", str(tmp_path))
+    monkeypatch.setenv("ieasyhydroforecast_ml_long_term_configuration", "long_term")
+    monkeypatch.setenv(
+        "ieasyhydroforecast_ml_long_term_supported_modes",
+        "quarter,seasonal_january,seasonal_february,seasonal_march,seasonal_april",
+    )
+    for name, lead in {
+        "quarter": 1,
+        "seasonal_january": 3,
+        "seasonal_february": 2,
+        "seasonal_march": 1,
+        "seasonal_april": 0,
+    }.items():
+        (config_dir / f"{name}.json").write_text(json.dumps({"operational_month_lead_time": lead}))
+    return config_dir
+
 
 # ===================================================================
 # read_skill_metrics() extended dispatch
@@ -116,9 +140,16 @@ class TestReadQuarterlyForecasts:
         )
         with (
             patch.object(data_reader, "read_monthly_forecasts", return_value=monthly),
-            patch.object(data_reader, "_read_long_forecasts_api", return_value=pd.DataFrame()),
+            patch.object(
+                data_reader,
+                "_read_long_forecasts_api",
+                return_value=pd.DataFrame(),
+            ) as read_api,
         ):
             result = data_reader.read_quarterly_forecasts(["S1"], 2024, 2024)
+        kwargs = read_api.call_args.kwargs
+        assert kwargs["horizon_type"] == "quarter"
+        assert kwargs["horizon_value"] == 1
         assert not result.empty
         assert "quarter_in_year" in result.columns
         assert "model_short" in result.columns
@@ -130,6 +161,26 @@ class TestReadQuarterlyForecasts:
         ):
             result = data_reader.read_quarterly_forecasts(["S1"], 2024, 2024)
         assert result.empty
+
+    def test_quarter_read_uses_resolved_lead_zero(self, long_term_horizon_config):
+        """Quarter direct API read follows a lead-0 deployment config."""
+        (long_term_horizon_config / "quarter.json").write_text(
+            json.dumps({"operational_month_lead_time": 0})
+        )
+        with (
+            patch.object(data_reader, "read_monthly_forecasts", return_value=pd.DataFrame()),
+            patch.object(
+                data_reader,
+                "_read_long_forecasts_api",
+                return_value=pd.DataFrame(),
+            ) as read_api,
+        ):
+            result = data_reader.read_quarterly_forecasts(["S1"], 2024, 2024)
+
+        assert result.empty
+        kwargs = read_api.call_args.kwargs
+        assert kwargs["horizon_type"] == "quarter"
+        assert kwargs["horizon_value"] == 0
 
     def test_direct_preferred_over_aggregated(self):
         """When same model in both sources, direct wins."""
@@ -165,7 +216,7 @@ class TestReadQuarterlyForecasts:
             }
         )
 
-        def mock_read_api(codes, start_year, end_year, horizon_type="month"):
+        def mock_read_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
             if horizon_type == "quarter":
                 return direct_api
             return pd.DataFrame()
@@ -260,10 +311,15 @@ class TestReadSeasonalForecasts:
             }
         )
 
-        with patch.object(data_reader, "_read_long_forecasts_api", return_value=raw_api):
-            result = data_reader.read_seasonal_forecasts(["19999"], 2024, 2024)
+        with patch.object(
+            data_reader,
+            "_read_long_forecasts_api",
+            return_value=raw_api,
+        ) as read_api:
+            result = data_reader.read_seasonal_forecasts(["19999"], 2024, 2024, horizon_value=3)
 
         assert len(result) == 4
+        assert read_api.call_args.kwargs["horizon_value"] == 3
         assert set(result["season_year"]) == {2024}
         assert set(result["season_in_year"]) == {0, 1, 2, 3}
         assert set(result["horizon_value"]) == {0, 1, 2, 3}
@@ -319,17 +375,25 @@ class TestReadLatestQuarterlyForecasts:
             }
         )
 
-        def mock_read_api(codes, start_year, end_year, horizon_type="month"):
+        def mock_read_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
             if horizon_type == "month":
                 return raw_monthly
             return pd.DataFrame()  # No direct quarterly data
 
-        with patch.object(data_reader, "_read_long_forecasts_api", side_effect=mock_read_api):
+        with patch.object(
+            data_reader,
+            "_read_long_forecasts_api",
+            side_effect=mock_read_api,
+        ) as read_api:
             import datetime as dt
 
             result = data_reader.read_latest_quarterly_forecasts(
                 ["S1"], forecast_date=dt.date(2024, 7, 1)
             )
+        quarter_call = [
+            call for call in read_api.call_args_list if call.kwargs.get("horizon_type") == "quarter"
+        ][0]
+        assert quarter_call.kwargs["horizon_value"] == 1
         assert not result.empty
         # Should be Q2 (latest quarter with data)
         assert all(result["quarter_in_year"] == 2)
@@ -361,15 +425,20 @@ class TestReadLatestSeasonalForecasts:
             }
         )
 
-        def mock_read_api(codes, start_year, end_year, horizon_type="month"):
+        def mock_read_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
             if horizon_type == "season":
                 return raw_api
             return pd.DataFrame()
 
-        with patch.object(data_reader, "_read_long_forecasts_api", side_effect=mock_read_api):
+        with patch.object(
+            data_reader,
+            "_read_long_forecasts_api",
+            side_effect=mock_read_api,
+        ) as read_api:
             result = data_reader.read_latest_seasonal_forecasts(
-                ["S1"], forecast_date=dt.date(2024, 10, 1)
+                ["S1"], forecast_date=dt.date(2024, 10, 1), horizon_value=3
             )
+        assert read_api.call_args.kwargs["horizon_value"] == 3
         assert not result.empty
         # Should only have 2024 season (latest)
         assert all(result["season_year"] == 2024)
@@ -398,7 +467,7 @@ class TestReadLatestSeasonalForecasts:
             }
         )
 
-        def mock_read_api(codes, start_year, end_year, horizon_type="month"):
+        def mock_read_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
             if horizon_type == "season":
                 return raw_api
             return pd.DataFrame()
@@ -411,7 +480,7 @@ class TestReadLatestSeasonalForecasts:
         assert result.iloc[0]["model_short"] == "LR"
 
     def test_empty_api_returns_empty(self):
-        def mock_read_api(codes, start_year, end_year, horizon_type="month"):
+        def mock_read_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
             return pd.DataFrame()
 
         with patch.object(data_reader, "_read_long_forecasts_api", side_effect=mock_read_api):
@@ -480,15 +549,25 @@ class TestReadQuarterlyCombinedForecasts:
                 "forecasted_discharge": [100.0],
             }
         )
-        with patch.object(data_reader, "_read_long_combined_forecasts_api", return_value=mock_df):
+        with patch.object(
+            data_reader,
+            "_read_long_combined_forecasts_api",
+            return_value=mock_df,
+        ) as read_api:
             result = data_reader.read_quarterly_combined_forecasts()
+        assert read_api.call_args.kwargs["horizon_value"] == 1
         assert len(result) == 1
 
 
 class TestReadSeasonalCombinedForecasts:
     def test_returns_empty_when_api_unavailable(self):
-        with patch.object(data_reader, "_read_long_combined_forecasts_api", return_value=None):
-            result = data_reader.read_seasonal_combined_forecasts()
+        with patch.object(
+            data_reader,
+            "_read_long_combined_forecasts_api",
+            return_value=None,
+        ) as read_api:
+            result = data_reader.read_seasonal_combined_forecasts(horizon_value=0)
+        assert read_api.call_args.kwargs["horizon_value"] == 0
         assert result.empty
 
 

--- a/apps/postprocessing_forecasts/tests/test_quarterly_ensemble_creation.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_ensemble_creation.py
@@ -348,6 +348,33 @@ class TestQuarterlyEnsembleEdgeCases:
         assert "EM" not in models
         assert "Naive Mean" not in models
 
+    def test_preexisting_baseline_replaced_not_duplicated(self):
+        """Stored ensembles in the input are dropped, not re-emitted.
+
+        Operational generation must match the maintenance recalc: a source
+        that already contains EM/Naive Mean/Skilled Mean must not yield two
+        rows for the same key (which would violate the long_forecasts unique
+        constraint on write).
+        """
+        skill = _two_model_quarterly_skill()
+        fcst = _make_quarterly_fcst(
+            [
+                ("S1", 2025, 1, "LR_Base", 100.0, 80, 85, 90, 100, 110, 115, 120),
+                ("S1", 2025, 1, "LR_SM", 120.0, 90, 95, 100, 120, 130, 135, 140),
+                # Pre-existing stored ensemble row with a stale value.
+                ("S1", 2025, 1, "Naive Mean", 999.0, 900, 905, 915, 999, 925, 935, 940),
+            ]
+        )
+
+        result = create_quarterly_ensemble_forecasts(fcst, skill)
+
+        key = ["code", "year", "quarter_in_year", "model_short"]
+        assert not result.duplicated(key).any()
+        nm = result[result["model_short"] == "Naive Mean"]
+        # One recomputed Naive Mean (mean of the two raw models), stale gone.
+        assert len(nm) == 1
+        assert np.isclose(nm.iloc[0]["forecasted_discharge"], 110.0)
+
 
 # ===================================================================
 # Seasonal ensemble creation

--- a/apps/postprocessing_forecasts/tests/test_quarterly_ensemble_creation.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_ensemble_creation.py
@@ -226,6 +226,30 @@ class TestQuarterlyEnsembleEM:
         assert np.isclose(em.iloc[0]["q95"], 130.0)
         assert str(em.iloc[0]["composition"]) == "LR_Base, LR_SM"
 
+    def test_em_accepts_db_form_lr_model_names(self):
+        skill = _make_quarterly_skill(
+            [
+                (1, "S1", "LR_BASE", 0.9, -1.0, 5.0, 0.10, 20.0, 10),
+                (1, "S1", "LR_SM", 0.8, -0.5, 5.0, 0.20, 30.0, 10),
+                (1, "S1", "GBT", 0.3, 0.95, 5.0, 0.90, 1.0, 10),
+            ]
+        )
+        fcst = _make_quarterly_fcst(
+            [
+                ("S1", 2025, 1, "LR_BASE", 100.0, 80, 85, 90, 100, 110, 115, 120),
+                ("S1", 2025, 1, "LR_SM", 120.0, 90, 95, 100, 120, 130, 135, 140),
+                ("S1", 2025, 1, "GBT", 1000.0, 900, 925, 950, 1000, 1050, 1075, 1100),
+            ]
+        )
+
+        result = create_quarterly_ensemble_forecasts(fcst, skill)
+        em = result[result["model_short"] == "EM"]
+
+        assert len(em) == 1
+        assert np.isclose(em.iloc[0]["forecasted_discharge"], 110.0)
+        assert np.isclose(em.iloc[0]["q50"], 110.0)
+        assert str(em.iloc[0]["composition"]) == "LR_BASE, LR_SM"
+
     def test_em_not_created_single_model(self):
         """Single model should not produce EM."""
         skill = _make_quarterly_skill(
@@ -429,6 +453,30 @@ class TestSeasonalEnsembleEM:
         assert np.isclose(em.iloc[0]["q50"], 110.0)
         assert np.isclose(em.iloc[0]["q95"], 130.0)
         assert str(em.iloc[0]["composition"]) == "LR_Base, LR_SM"
+
+    def test_em_accepts_db_form_lr_model_names(self):
+        skill = _make_seasonal_skill(
+            [
+                (1, "S1", "LR_BASE", 0.9, -1.0, 5.0, 0.10, 20.0, 10),
+                (1, "S1", "LR_SM", 0.8, -0.5, 5.0, 0.20, 30.0, 10),
+                (1, "S1", "GBT", 0.3, 0.95, 5.0, 0.90, 1.0, 10),
+            ]
+        )
+        fcst = _make_seasonal_fcst(
+            [
+                ("S1", 2025, 1, "LR_BASE", 100.0, 80, 85, 90, 100, 110, 115, 120),
+                ("S1", 2025, 1, "LR_SM", 120.0, 90, 95, 100, 120, 130, 135, 140),
+                ("S1", 2025, 1, "GBT", 1000.0, 900, 925, 950, 1000, 1050, 1075, 1100),
+            ]
+        )
+
+        result = create_seasonal_ensemble_forecasts(fcst, skill)
+        em = result[result["model_short"] == "EM"]
+
+        assert len(em) == 1
+        assert np.isclose(em.iloc[0]["forecasted_discharge"], 110.0)
+        assert np.isclose(em.iloc[0]["q50"], 110.0)
+        assert str(em.iloc[0]["composition"]) == "LR_BASE, LR_SM"
 
 
 class TestSeasonalEnsembleNaiveMean:

--- a/apps/postprocessing_forecasts/tests/test_quarterly_ensemble_creation.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_ensemble_creation.py
@@ -319,6 +319,64 @@ class TestSeasonalEnsembleEM:
         expected = (100.0 + 120.0) / 2
         assert np.isclose(em.iloc[0]["forecasted_discharge"], expected)
 
+    def test_four_issue_leads_produce_independent_ensembles(self):
+        leads = [3, 2, 1, 0]
+        issue_dates = {
+            3: "2025-01-01",
+            2: "2025-02-01",
+            1: "2025-03-01",
+            0: "2025-04-01",
+        }
+        forecast_rows = []
+        skill_rows = []
+        for lead in leads:
+            for model_short, offset, mae in [("LR", 0.0, 2.0), ("TFT", 20.0, 3.0)]:
+                forecast_rows.append(
+                    {
+                        "code": "PP4_S_SENTINEL",
+                        "season_year": 2025,
+                        "season_in_year": lead,
+                        "date": issue_dates[lead],
+                        "valid_from": "2025-04-01",
+                        "valid_to": "2025-09-30",
+                        "model_short": model_short,
+                        "forecasted_discharge": 100.0 + lead + offset,
+                        "q05": 80.0 + lead + offset,
+                        "q10": 85.0 + lead + offset,
+                        "q25": 90.0 + lead + offset,
+                        "q50": 100.0 + lead + offset,
+                        "q75": 110.0 + lead + offset,
+                        "q90": 115.0 + lead + offset,
+                        "q95": 120.0 + lead + offset,
+                    }
+                )
+                skill_rows.append(
+                    (
+                        lead,
+                        "PP4_S_SENTINEL",
+                        model_short,
+                        0.3,
+                        0.95,
+                        5.0,
+                        0.90,
+                        mae,
+                        10,
+                    )
+                )
+
+        result = create_seasonal_ensemble_forecasts(
+            pd.DataFrame(forecast_rows),
+            _make_seasonal_skill(skill_rows),
+        )
+
+        for model_short in {"EM", "Naive Mean", "Skilled Mean"}:
+            rows = result[result["model_short"] == model_short]
+            assert len(rows) == 4
+            assert set(rows["season_in_year"]) == {0, 1, 2, 3}
+            assert dict(zip(rows["season_in_year"], rows["date"], strict=True)) == issue_dates
+            assert set(rows["valid_from"]) == {"2025-04-01"}
+            assert set(rows["valid_to"]) == {"2025-09-30"}
+
 
 class TestSeasonalEnsembleNaiveMean:
     def test_naive_mean_created(self):

--- a/apps/postprocessing_forecasts/tests/test_quarterly_ensemble_creation.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_ensemble_creation.py
@@ -13,6 +13,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from src.ensemble_calculator import (
+    create_monthly_ensemble_forecasts,
     create_quarterly_ensemble_forecasts,
     create_seasonal_ensemble_forecasts,
 )
@@ -119,18 +120,18 @@ def _two_model_quarterly_skill():
     """Two highly skilled models for station S1, quarter 1."""
     return _make_quarterly_skill(
         [
-            (1, "S1", "LR", 0.3, 0.95, 5.0, 0.90, 2.0, 10),
-            (1, "S1", "TFT", 0.4, 0.88, 5.0, 0.85, 3.0, 10),
+            (1, "S1", "LR_Base", 0.3, 0.95, 5.0, 0.90, 2.0, 10),
+            (1, "S1", "LR_SM", 0.4, 0.88, 5.0, 0.85, 3.0, 10),
         ]
     )
 
 
 def _two_model_quarterly_fcst():
-    """Forecasts for LR and TFT, station S1, Q1 2025."""
+    """Forecasts for LR_Base and LR_SM, station S1, Q1 2025."""
     return _make_quarterly_fcst(
         [
-            ("S1", 2025, 1, "LR", 100.0, 80, 85, 90, 100, 110, 115, 120),
-            ("S1", 2025, 1, "TFT", 120.0, 90, 95, 100, 120, 130, 135, 140),
+            ("S1", 2025, 1, "LR_Base", 100.0, 80, 85, 90, 100, 110, 115, 120),
+            ("S1", 2025, 1, "LR_SM", 120.0, 90, 95, 100, 120, 130, 135, 140),
         ]
     )
 
@@ -139,18 +140,18 @@ def _two_model_seasonal_skill():
     """Two highly skilled models for station S1, season 1."""
     return _make_seasonal_skill(
         [
-            (1, "S1", "LR", 0.3, 0.95, 5.0, 0.90, 2.0, 10),
-            (1, "S1", "TFT", 0.4, 0.88, 5.0, 0.85, 3.0, 10),
+            (1, "S1", "LR_Base", 0.3, 0.95, 5.0, 0.90, 2.0, 10),
+            (1, "S1", "LR_SM", 0.4, 0.88, 5.0, 0.85, 3.0, 10),
         ]
     )
 
 
 def _two_model_seasonal_fcst():
-    """Forecasts for LR and TFT, station S1, season_year 2025."""
+    """Forecasts for LR_Base and LR_SM, station S1, season_year 2025."""
     return _make_seasonal_fcst(
         [
-            ("S1", 2025, 1, "LR", 100.0, 80, 85, 90, 100, 110, 115, 120),
-            ("S1", 2025, 1, "TFT", 120.0, 90, 95, 100, 120, 130, 135, 140),
+            ("S1", 2025, 1, "LR_Base", 100.0, 80, 85, 90, 100, 110, 115, 120),
+            ("S1", 2025, 1, "LR_SM", 120.0, 90, 95, 100, 120, 130, 135, 140),
         ]
     )
 
@@ -196,19 +197,45 @@ class TestQuarterlyEnsembleEM:
         result = create_quarterly_ensemble_forecasts(fcst, skill)
         em = result[result["model_short"] == "EM"]
         comp = str(em.iloc[0]["composition"])
-        assert "LR" in comp
-        assert "TFT" in comp
+        assert "LR_Base" in comp
+        assert "LR_SM" in comp
+
+    def test_em_uses_lr_mean_when_lr_skills_fail_thresholds(self):
+        skill = _make_quarterly_skill(
+            [
+                (1, "S1", "LR_Base", 0.9, -1.0, 5.0, 0.10, 20.0, 10),
+                (1, "S1", "LR_SM", 0.8, -0.5, 5.0, 0.20, 30.0, 10),
+                (1, "S1", "GBT", 0.3, 0.95, 5.0, 0.90, 1.0, 10),
+            ]
+        )
+        fcst = _make_quarterly_fcst(
+            [
+                ("S1", 2025, 1, "LR_Base", 100.0, 80, 85, 90, 100, 110, 115, 120),
+                ("S1", 2025, 1, "LR_SM", 120.0, 90, 95, 100, 120, 130, 135, 140),
+                ("S1", 2025, 1, "GBT", 1000.0, 900, 925, 950, 1000, 1050, 1075, 1100),
+            ]
+        )
+
+        result = create_quarterly_ensemble_forecasts(fcst, skill)
+        em = result[result["model_short"] == "EM"]
+
+        assert len(em) == 1
+        assert np.isclose(em.iloc[0]["forecasted_discharge"], 110.0)
+        assert np.isclose(em.iloc[0]["q05"], 85.0)
+        assert np.isclose(em.iloc[0]["q50"], 110.0)
+        assert np.isclose(em.iloc[0]["q95"], 130.0)
+        assert str(em.iloc[0]["composition"]) == "LR_Base, LR_SM"
 
     def test_em_not_created_single_model(self):
         """Single model should not produce EM."""
         skill = _make_quarterly_skill(
             [
-                (1, "S1", "LR", 0.3, 0.95, 5.0, 0.90, 2.0, 10),
+                (1, "S1", "LR_Base", 0.3, 0.95, 5.0, 0.90, 2.0, 10),
             ]
         )
         fcst = _make_quarterly_fcst(
             [
-                ("S1", 2025, 1, "LR", 100.0, 80, 85, 90, 100, 110, 115, 120),
+                ("S1", 2025, 1, "LR_Base", 100.0, 80, 85, 90, 100, 110, 115, 120),
             ]
         )
         result = create_quarterly_ensemble_forecasts(fcst, skill)
@@ -225,15 +252,15 @@ class TestQuarterlyEnsembleSkilledMean:
         assert not sm.empty
 
     def test_skilled_mean_weighted(self):
-        """Skilled Mean should use 1/MAE weighting (LR gets higher weight)."""
+        """Skilled Mean should use 1/MAE weighting (LR_Base gets higher weight)."""
         skill = _two_model_quarterly_skill()
         fcst = _two_model_quarterly_fcst()
         result = create_quarterly_ensemble_forecasts(fcst, skill)
         sm = result[result["model_short"] == "Skilled Mean"]
-        # LR: MAE=2.0, TFT: MAE=3.0
-        # LR has lower MAE → higher weight → result closer to LR (100)
+        # LR_Base: MAE=2.0, LR_SM: MAE=3.0
+        # LR_Base has lower MAE -> higher weight -> result closer to 100
         discharge = sm.iloc[0]["forecasted_discharge"]
-        assert discharge < 110.0  # closer to LR's 100 than simple mean 110
+        assert discharge < 110.0  # closer to 100 than simple mean 110
 
 
 class TestQuarterlyEnsembleNaiveMean:
@@ -330,7 +357,7 @@ class TestSeasonalEnsembleEM:
         forecast_rows = []
         skill_rows = []
         for lead in leads:
-            for model_short, offset, mae in [("LR", 0.0, 2.0), ("TFT", 20.0, 3.0)]:
+            for model_short, offset, mae in [("LR_Base", 0.0, 2.0), ("LR_SM", 20.0, 3.0)]:
                 forecast_rows.append(
                     {
                         "code": "PP4_S_SENTINEL",
@@ -376,6 +403,32 @@ class TestSeasonalEnsembleEM:
             assert dict(zip(rows["season_in_year"], rows["date"], strict=True)) == issue_dates
             assert set(rows["valid_from"]) == {"2025-04-01"}
             assert set(rows["valid_to"]) == {"2025-09-30"}
+
+    def test_em_uses_lr_mean_when_lr_skills_fail_thresholds(self):
+        skill = _make_seasonal_skill(
+            [
+                (1, "S1", "LR_Base", 0.9, -1.0, 5.0, 0.10, 20.0, 10),
+                (1, "S1", "LR_SM", 0.8, -0.5, 5.0, 0.20, 30.0, 10),
+                (1, "S1", "GBT", 0.3, 0.95, 5.0, 0.90, 1.0, 10),
+            ]
+        )
+        fcst = _make_seasonal_fcst(
+            [
+                ("S1", 2025, 1, "LR_Base", 100.0, 80, 85, 90, 100, 110, 115, 120),
+                ("S1", 2025, 1, "LR_SM", 120.0, 90, 95, 100, 120, 130, 135, 140),
+                ("S1", 2025, 1, "GBT", 1000.0, 900, 925, 950, 1000, 1050, 1075, 1100),
+            ]
+        )
+
+        result = create_seasonal_ensemble_forecasts(fcst, skill)
+        em = result[result["model_short"] == "EM"]
+
+        assert len(em) == 1
+        assert np.isclose(em.iloc[0]["forecasted_discharge"], 110.0)
+        assert np.isclose(em.iloc[0]["q05"], 85.0)
+        assert np.isclose(em.iloc[0]["q50"], 110.0)
+        assert np.isclose(em.iloc[0]["q95"], 130.0)
+        assert str(em.iloc[0]["composition"]) == "LR_Base, LR_SM"
 
 
 class TestSeasonalEnsembleNaiveMean:
@@ -434,3 +487,46 @@ class TestSeasonalEnsembleEdgeCases:
         )
         result = create_seasonal_ensemble_forecasts(fcst, skill)
         assert len(result) == len(fcst)
+
+
+# ===================================================================
+# Monthly regression
+# ===================================================================
+
+
+class TestMonthlyEnsembleRegression:
+    def test_monthly_em_remains_skill_gated(self):
+        forecasts = pd.DataFrame(
+            {
+                "code": ["S1", "S1"],
+                "year": [2025, 2025],
+                "month": [1, 1],
+                "month_in_year": [1, 1],
+                "model_short": ["LR_Base", "LR_SM"],
+                "forecasted_discharge": [100.0, 120.0],
+                "q05": [80.0, 90.0],
+                "q10": [85.0, 95.0],
+                "q25": [90.0, 100.0],
+                "q50": [100.0, 120.0],
+                "q75": [110.0, 130.0],
+                "q90": [115.0, 135.0],
+                "q95": [120.0, 140.0],
+            }
+        )
+        skill = pd.DataFrame(
+            {
+                "month_in_year": [1, 1],
+                "code": ["S1", "S1"],
+                "model_short": ["LR_Base", "LR_SM"],
+                "sdivsigma": [0.3, 0.9],
+                "nse": [0.95, -1.0],
+                "delta": [5.0, 5.0],
+                "accuracy": [0.90, 0.10],
+                "mae": [2.0, 30.0],
+                "n_pairs": [10, 10],
+            }
+        )
+
+        result = create_monthly_ensemble_forecasts(forecasts, skill)
+
+        assert result[result["model_short"] == "EM"].empty

--- a/apps/postprocessing_forecasts/tests/test_quarterly_gap_detector.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_gap_detector.py
@@ -82,6 +82,7 @@ class TestSeasonalGapDetection:
         combined = pd.DataFrame(
             {
                 "season_year": [2025, 2025, 2025],
+                "season_in_year": [1, 1, 1],
                 "code": ["S1", "S1", "S2"],
                 "model_short": ["LR", "EM", "LR"],
                 "forecasted_discharge": [100, 100, 80],
@@ -95,6 +96,7 @@ class TestSeasonalGapDetection:
         combined = pd.DataFrame(
             {
                 "season_year": [2025, 2025],
+                "season_in_year": [1, 1],
                 "code": ["S1", "S1"],
                 "model_short": ["LR", "EM"],
                 "forecasted_discharge": [100, 100],
@@ -108,6 +110,7 @@ class TestSeasonalGapDetection:
         combined = pd.DataFrame(
             {
                 "season_year": [2025, 2025, 2023, 2023],
+                "season_in_year": [1, 1, 1, 1],
                 "code": ["S1", "S1", "S1", "S1"],
                 "model_short": ["LR", "EM", "LR", "LR"],
                 "forecasted_discharge": [100, 100, 80, 80],
@@ -121,3 +124,24 @@ class TestSeasonalGapDetection:
         gaps = detect_missing_seasonal_ensembles(pd.DataFrame())
         assert gaps.empty
         assert "season_year" in gaps.columns
+        assert "season_in_year" in gaps.columns
+
+    def test_detects_one_missing_issue_lead_out_of_four(self):
+        combined = pd.DataFrame(
+            {
+                "season_year": [2025] * 7,
+                "season_in_year": [3, 3, 2, 2, 1, 1, 0],
+                "code": ["PP4_S_SENTINEL"] * 7,
+                "model_short": ["LR", "EM", "LR", "EM", "LR", "EM", "LR"],
+                "forecasted_discharge": [100, 100, 110, 110, 120, 120, 130],
+            }
+        )
+
+        gaps = detect_missing_seasonal_ensembles(combined)
+
+        assert len(gaps) == 1
+        gap = gaps.iloc[0]
+        assert gap["season_year"] == 2025
+        assert gap["season_in_year"] == 0
+        assert gap["code"] == "PP4_S_SENTINEL"
+        assert gap["model_short"] == "EM"

--- a/apps/postprocessing_forecasts/tests/test_quarterly_skill_metrics.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_skill_metrics.py
@@ -107,6 +107,32 @@ def _make_seasonal_fcst(rows):
     return df
 
 
+def _make_seasonal_fcst_dated(rows):
+    """(code, season_year, date, model_short, q05..q95) with season_in_year=1.
+
+    Use when several issue dates share a (season_year, lead) so the
+    per-date ensemble behaviour can be exercised.
+    """
+    df = pd.DataFrame(
+        rows,
+        columns=[
+            "code",
+            "season_year",
+            "date",
+            "model_short",
+            "q05",
+            "q10",
+            "q25",
+            "q50",
+            "q75",
+            "q90",
+            "q95",
+        ],
+    )
+    df["season_in_year"] = 1
+    return df
+
+
 # ===================================================================
 # Quarterly skill metrics
 # ===================================================================
@@ -257,6 +283,11 @@ class TestQuarterlyMetricsEnsembles:
         assert np.allclose(em_joint["q50"], [100.0, 100.0, 100.0])
         assert np.allclose(em_joint["q95"], [120.0, 120.0, 120.0])
         assert set(em_joint["composition"]) == {"LR_Base, LR_SM"}
+        # EM rows must keep their period key so the write-side NaN guard
+        # (api_writer drops rows with null year/quarter_in_year) persists them.
+        assert "quarter_in_year" in em_joint.columns
+        assert em_joint["quarter_in_year"].notna().all()
+        assert set(em_joint["quarter_in_year"].astype(int)) == {1}
         assert not em_skill.empty
         assert int(em_skill.iloc[0]["n_pairs"]) == 3
         assert pd.notna(em_skill.iloc[0]["crps"])
@@ -458,6 +489,12 @@ class TestSeasonalMetricsEnsembles:
         assert np.allclose(em_joint["q50"], [100.0, 100.0, 100.0])
         assert np.allclose(em_joint["q95"], [120.0, 120.0, 120.0])
         assert set(em_joint["composition"]) == {"LR_Base, LR_SM"}
+        # EM rows must keep their season keys so the write-side NaN guard
+        # (api_writer drops rows with null season_year/season_in_year)
+        # persists them.
+        assert {"season_year", "season_in_year"} <= set(em_joint.columns)
+        assert em_joint["season_year"].notna().all()
+        assert em_joint["season_in_year"].notna().all()
         assert not em_skill.empty
         assert int(em_skill.iloc[0]["n_pairs"]) == 3
         assert pd.notna(em_skill.iloc[0]["crps"])
@@ -497,6 +534,54 @@ class TestSeasonalMetricsEnsembles:
         assert np.allclose(em_joint["q50"], [100.0, 100.0, 100.0])
         assert set(em_joint["composition"]) == {"LR_BASE, LR_SM"}
         assert not em_skill.empty
+
+    def test_em_per_issue_date_not_collapsed(self):
+        """Each seasonal issue date yields its own clean 2-model EM.
+
+        When a (season_year, lead) is (re-)issued on several dates, the EM
+        must be computed per issue date — mean(LR_Base, LR_SM) for that
+        date — rather than averaged across dates into one blended row.
+        """
+        obs = _make_seasonal_obs(
+            [
+                ("S1", 2020, 100.0),
+                ("S1", 2021, 110.0),
+            ]
+        )
+        # Two issue dates per season_year, same lead. Per-date EM q50 is
+        # 150 (=(100+200)/2) for date d1 and 130 (=(120+140)/2) for date d2.
+        # A date-collapsing EM would instead produce a single 140 per year.
+        fcst = _make_seasonal_fcst_dated(
+            [
+                ("S1", 2020, "2020-03-25", "LR_Base", 80, 85, 95, 100, 105, 115, 120),
+                ("S1", 2020, "2020-03-25", "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+                ("S1", 2020, "2020-04-01", "LR_Base", 100, 105, 115, 120, 125, 135, 140),
+                ("S1", 2020, "2020-04-01", "LR_SM", 120, 125, 135, 140, 145, 155, 160),
+                ("S1", 2021, "2021-03-25", "LR_Base", 80, 85, 95, 100, 105, 115, 120),
+                ("S1", 2021, "2021-03-25", "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+                ("S1", 2021, "2021-04-01", "LR_Base", 100, 105, 115, 120, 125, 135, 140),
+                ("S1", 2021, "2021-04-01", "LR_SM", 120, 125, 135, 140, 145, 155, 160),
+            ]
+        )
+
+        _, joint, _ = calculate_seasonal_skill_metrics(obs, fcst)
+        em = joint[joint["model_short"] == "EM"].copy()
+
+        # One EM row per issue date (2 years x 2 dates), not one per year.
+        assert len(em) == 4
+        assert "date" in em.columns
+        assert em["date"].notna().all()
+        # Each EM is the clean 2-model mean for its own date.
+        by_date = em.groupby("date")["q50"].first().to_dict()
+        assert by_date["2020-03-25"] == pytest.approx(150.0)
+        assert by_date["2020-04-01"] == pytest.approx(130.0)
+        assert by_date["2021-03-25"] == pytest.approx(150.0)
+        assert by_date["2021-04-01"] == pytest.approx(130.0)
+        # forecasted_discharge (point) tracks the same per-date mean.
+        fd = em.groupby("date")["forecasted_discharge"].first().to_dict()
+        assert fd["2020-03-25"] == pytest.approx(150.0)
+        assert fd["2020-04-01"] == pytest.approx(130.0)
+        assert set(em["composition"]) == {"LR_Base, LR_SM"}
 
 
 class TestQFallbackQuarterly:

--- a/apps/postprocessing_forecasts/tests/test_quarterly_skill_metrics.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_skill_metrics.py
@@ -328,6 +328,40 @@ class TestQuarterlyMetricsEnsembles:
         assert set(em_joint["composition"]) == {"LR_BASE, LR_SM"}
         assert not em_skill.empty
 
+    def test_preexisting_baseline_rows_replaced_not_duplicated(self):
+        """Stored EM/Naive/Skilled rows in the input are dropped, not doubled.
+
+        The recalc regenerates the aggregated ensembles, so a source that
+        already contains them must not yield two rows for the same key
+        (which would violate the long_forecasts unique constraint on write).
+        """
+        obs = _make_quarterly_obs(
+            [
+                ("S1", 2020, 1, 100.0),
+                ("S1", 2021, 1, 110.0),
+            ]
+        )
+        fcst = _make_quarterly_fcst(
+            [
+                ("S1", 2020, 1, "LR_Base", 80, 85, 95, 100, 105, 115, 120),
+                ("S1", 2020, 1, "LR_SM", 120, 125, 135, 140, 145, 155, 160),
+                ("S1", 2021, 1, "LR_Base", 80, 85, 95, 100, 105, 115, 120),
+                ("S1", 2021, 1, "LR_SM", 120, 125, 135, 140, 145, 155, 160),
+                # Pre-existing stored ensemble row with a stale value.
+                ("S1", 2020, 1, "Naive Mean", 900, 905, 915, 999, 925, 935, 940),
+            ]
+        )
+
+        _, joint, _ = calculate_quarterly_skill_metrics(obs, fcst)
+
+        key = ["code", "year", "quarter_in_year", "model_short"]
+        assert not joint.duplicated(key).any()
+        nm = joint[joint["model_short"] == "Naive Mean"]
+        # One recomputed Naive Mean per (year, quarter), the stale one gone.
+        assert len(nm) == 2
+        assert 999.0 not in set(nm["q50"])
+        assert np.allclose(sorted(nm["q50"]), [120.0, 120.0])
+
 
 class TestQuarterlyMetricsEdgeCases:
     def test_empty_observations(self):

--- a/apps/postprocessing_forecasts/tests/test_quarterly_skill_metrics.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_skill_metrics.py
@@ -261,6 +261,42 @@ class TestQuarterlyMetricsEnsembles:
         assert int(em_skill.iloc[0]["n_pairs"]) == 3
         assert pd.notna(em_skill.iloc[0]["crps"])
 
+    def test_em_recalc_accepts_db_form_lr_model_names(self, monkeypatch):
+        for key, value in {
+            "ieasyhydroforecast_efficiency_threshold": "0.6",
+            "ieasyhydroforecast_nse_threshold": "0.8",
+            "ieasyhydroforecast_accuracy_threshold": "0.8",
+        }.items():
+            monkeypatch.setenv(key, value)
+
+        obs = _make_quarterly_obs(
+            [
+                ("S1", 2020, 1, 100.0),
+                ("S1", 2021, 1, 110.0),
+                ("S1", 2022, 1, 120.0),
+            ]
+        )
+        fcst = _make_quarterly_fcst(
+            [
+                ("S1", 2020, 1, "LR_BASE", -20, -15, -5, 0, 5, 15, 20),
+                ("S1", 2021, 1, "LR_BASE", -20, -15, -5, 0, 5, 15, 20),
+                ("S1", 2022, 1, "LR_BASE", -20, -15, -5, 0, 5, 15, 20),
+                ("S1", 2020, 1, "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+                ("S1", 2021, 1, "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+                ("S1", 2022, 1, "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+            ]
+        )
+
+        skill_stats, joint, _ = calculate_quarterly_skill_metrics(obs, fcst)
+        em_joint = joint[joint["model_short"] == "EM"].sort_values("year")
+        em_skill = skill_stats[skill_stats["model_short"] == "EM"]
+
+        assert len(em_joint) == 3
+        assert np.allclose(em_joint["forecasted_discharge"], [100.0, 100.0, 100.0])
+        assert np.allclose(em_joint["q50"], [100.0, 100.0, 100.0])
+        assert set(em_joint["composition"]) == {"LR_BASE, LR_SM"}
+        assert not em_skill.empty
+
 
 class TestQuarterlyMetricsEdgeCases:
     def test_empty_observations(self):
@@ -425,6 +461,42 @@ class TestSeasonalMetricsEnsembles:
         assert not em_skill.empty
         assert int(em_skill.iloc[0]["n_pairs"]) == 3
         assert pd.notna(em_skill.iloc[0]["crps"])
+
+    def test_em_recalc_accepts_db_form_lr_model_names(self, monkeypatch):
+        for key, value in {
+            "ieasyhydroforecast_efficiency_threshold": "0.6",
+            "ieasyhydroforecast_nse_threshold": "0.8",
+            "ieasyhydroforecast_accuracy_threshold": "0.8",
+        }.items():
+            monkeypatch.setenv(key, value)
+
+        obs = _make_seasonal_obs(
+            [
+                ("S1", 2020, 100.0),
+                ("S1", 2021, 110.0),
+                ("S1", 2022, 120.0),
+            ]
+        )
+        fcst = _make_seasonal_fcst(
+            [
+                ("S1", 2020, "LR_BASE", -20, -15, -5, 0, 5, 15, 20),
+                ("S1", 2021, "LR_BASE", -20, -15, -5, 0, 5, 15, 20),
+                ("S1", 2022, "LR_BASE", -20, -15, -5, 0, 5, 15, 20),
+                ("S1", 2020, "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+                ("S1", 2021, "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+                ("S1", 2022, "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+            ]
+        )
+
+        skill_stats, joint, _ = calculate_seasonal_skill_metrics(obs, fcst)
+        em_joint = joint[joint["model_short"] == "EM"].sort_values("season_year")
+        em_skill = skill_stats[skill_stats["model_short"] == "EM"]
+
+        assert len(em_joint) == 3
+        assert np.allclose(em_joint["forecasted_discharge"], [100.0, 100.0, 100.0])
+        assert np.allclose(em_joint["q50"], [100.0, 100.0, 100.0])
+        assert set(em_joint["composition"]) == {"LR_BASE, LR_SM"}
+        assert not em_skill.empty
 
 
 class TestQFallbackQuarterly:

--- a/apps/postprocessing_forecasts/tests/test_quarterly_skill_metrics.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_skill_metrics.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from src.skill_metrics import (
     calculate_quarterly_skill_metrics,
     calculate_seasonal_skill_metrics,
+    filter_for_highly_skilled_forecasts,
 )
 
 EXPECTED_METRIC_COLS = {
@@ -217,6 +218,49 @@ class TestQuarterlyMetricsEnsembles:
             models = joint["model_short"].unique()
             assert "Naive Mean" in models
 
+    def test_em_recalc_uses_lr_mean_when_lr_skills_fail_thresholds(self, monkeypatch):
+        for key, value in {
+            "ieasyhydroforecast_efficiency_threshold": "0.6",
+            "ieasyhydroforecast_nse_threshold": "0.8",
+            "ieasyhydroforecast_accuracy_threshold": "0.8",
+        }.items():
+            monkeypatch.setenv(key, value)
+
+        obs = _make_quarterly_obs(
+            [
+                ("S1", 2020, 1, 100.0),
+                ("S1", 2021, 1, 110.0),
+                ("S1", 2022, 1, 120.0),
+            ]
+        )
+        fcst = _make_quarterly_fcst(
+            [
+                ("S1", 2020, 1, "LR_Base", -20, -15, -5, 0, 5, 15, 20),
+                ("S1", 2021, 1, "LR_Base", -20, -15, -5, 0, 5, 15, 20),
+                ("S1", 2022, 1, "LR_Base", -20, -15, -5, 0, 5, 15, 20),
+                ("S1", 2020, 1, "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+                ("S1", 2021, 1, "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+                ("S1", 2022, 1, "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+            ]
+        )
+
+        skill_stats, joint, _ = calculate_quarterly_skill_metrics(obs, fcst)
+        raw_skill = skill_stats[skill_stats["model_short"].isin({"LR_Base", "LR_SM"})]
+        filtered_raw = filter_for_highly_skilled_forecasts(raw_skill)
+        em_joint = joint[joint["model_short"] == "EM"].sort_values("year")
+        em_skill = skill_stats[skill_stats["model_short"] == "EM"]
+
+        assert filtered_raw.empty
+        assert len(em_joint) == 3
+        assert np.allclose(em_joint["forecasted_discharge"], [100.0, 100.0, 100.0])
+        assert np.allclose(em_joint["q05"], [80.0, 80.0, 80.0])
+        assert np.allclose(em_joint["q50"], [100.0, 100.0, 100.0])
+        assert np.allclose(em_joint["q95"], [120.0, 120.0, 120.0])
+        assert set(em_joint["composition"]) == {"LR_Base, LR_SM"}
+        assert not em_skill.empty
+        assert int(em_skill.iloc[0]["n_pairs"]) == 3
+        assert pd.notna(em_skill.iloc[0]["crps"])
+
 
 class TestQuarterlyMetricsEdgeCases:
     def test_empty_observations(self):
@@ -338,6 +382,49 @@ class TestSeasonalMetricsEnsembles:
         skill_stats, _, _ = calculate_seasonal_skill_metrics(obs, fcst)
         naive_rows = skill_stats[skill_stats["model_short"] == "Naive Mean"]
         assert not naive_rows.empty
+
+    def test_em_recalc_uses_lr_mean_when_lr_skills_fail_thresholds(self, monkeypatch):
+        for key, value in {
+            "ieasyhydroforecast_efficiency_threshold": "0.6",
+            "ieasyhydroforecast_nse_threshold": "0.8",
+            "ieasyhydroforecast_accuracy_threshold": "0.8",
+        }.items():
+            monkeypatch.setenv(key, value)
+
+        obs = _make_seasonal_obs(
+            [
+                ("S1", 2020, 100.0),
+                ("S1", 2021, 110.0),
+                ("S1", 2022, 120.0),
+            ]
+        )
+        fcst = _make_seasonal_fcst(
+            [
+                ("S1", 2020, "LR_Base", -20, -15, -5, 0, 5, 15, 20),
+                ("S1", 2021, "LR_Base", -20, -15, -5, 0, 5, 15, 20),
+                ("S1", 2022, "LR_Base", -20, -15, -5, 0, 5, 15, 20),
+                ("S1", 2020, "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+                ("S1", 2021, "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+                ("S1", 2022, "LR_SM", 180, 185, 195, 200, 205, 215, 220),
+            ]
+        )
+
+        skill_stats, joint, _ = calculate_seasonal_skill_metrics(obs, fcst)
+        raw_skill = skill_stats[skill_stats["model_short"].isin({"LR_Base", "LR_SM"})]
+        filtered_raw = filter_for_highly_skilled_forecasts(raw_skill)
+        em_joint = joint[joint["model_short"] == "EM"].sort_values("season_year")
+        em_skill = skill_stats[skill_stats["model_short"] == "EM"]
+
+        assert filtered_raw.empty
+        assert len(em_joint) == 3
+        assert np.allclose(em_joint["forecasted_discharge"], [100.0, 100.0, 100.0])
+        assert np.allclose(em_joint["q05"], [80.0, 80.0, 80.0])
+        assert np.allclose(em_joint["q50"], [100.0, 100.0, 100.0])
+        assert np.allclose(em_joint["q95"], [120.0, 120.0, 120.0])
+        assert set(em_joint["composition"]) == {"LR_Base, LR_SM"}
+        assert not em_skill.empty
+        assert int(em_skill.iloc[0]["n_pairs"]) == 3
+        assert pd.notna(em_skill.iloc[0]["crps"])
 
 
 class TestQFallbackQuarterly:

--- a/apps/postprocessing_forecasts/tests/test_quarterly_workflow_integration.py
+++ b/apps/postprocessing_forecasts/tests/test_quarterly_workflow_integration.py
@@ -69,7 +69,7 @@ def _monthly_obs(n_years=3, codes=("S1",)):
     return pd.DataFrame(rows)
 
 
-def _monthly_fc(n_years=3, codes=("S1",), models=("LR", "TFT")):
+def _monthly_fc(n_years=3, codes=("S1",), models=("LR_Base", "LR_SM")):
     """Create monthly forecasts for multiple models/years."""
     rows = []
     for code in codes:
@@ -77,7 +77,7 @@ def _monthly_fc(n_years=3, codes=("S1",), models=("LR", "TFT")):
             for month in range(1, 13):
                 for model in models:
                     base = 50 + month * 5 + (year - 2020) * 2
-                    offset = 2 if model == "LR" else -1
+                    offset = 2 if model == "LR_Base" else -1
                     q50 = float(base + offset)
                     rows.append(
                         {
@@ -108,7 +108,7 @@ class TestQuarterlyRecalcWorkflow:
 
     def test_full_pipeline(self):
         monthly_obs = _monthly_obs(n_years=3)
-        monthly_fc = _monthly_fc(n_years=3, models=("LR", "TFT"))
+        monthly_fc = _monthly_fc(n_years=3, models=("LR_Base", "LR_SM"))
 
         # Aggregate
         qobs = aggregate_monthly_obs_to_quarterly(monthly_obs)
@@ -126,8 +126,8 @@ class TestQuarterlyRecalcWorkflow:
 
         # Verify models present
         models = skill_stats["model_short"].unique()
-        assert "LR" in models
-        assert "TFT" in models
+        assert "LR_Base" in models
+        assert "LR_SM" in models
 
         # Verify ensembles (multi-model → Naive Mean should exist)
         assert "Naive Mean" in models
@@ -139,7 +139,7 @@ class TestQuarterlyRecalcWorkflow:
     def test_skill_then_ensemble_creation(self):
         """Skill metrics → create ensembles from pre-calculated stats."""
         monthly_obs = _monthly_obs(n_years=3)
-        monthly_fc = _monthly_fc(n_years=3, models=("LR", "TFT"))
+        monthly_fc = _monthly_fc(n_years=3, models=("LR_Base", "LR_SM"))
 
         qobs = aggregate_monthly_obs_to_quarterly(monthly_obs)
         qfc = aggregate_monthly_fc_to_quarterly(monthly_fc)
@@ -152,8 +152,8 @@ class TestQuarterlyRecalcWorkflow:
 
         result_models = set(result["model_short"].unique())
         # Should contain original models + ensembles
-        assert "LR" in result_models
-        assert "TFT" in result_models
+        assert "LR_Base" in result_models
+        assert "LR_SM" in result_models
         assert "Naive Mean" in result_models
 
 
@@ -168,7 +168,7 @@ class TestSeasonalRecalcWorkflow:
         monkeypatch.delenv("SAPPHIRE_SEASON_END_MONTH", raising=False)
 
         monthly_obs = _monthly_obs(n_years=3)
-        monthly_fc = _monthly_fc(n_years=3, models=("LR", "TFT"))
+        monthly_fc = _monthly_fc(n_years=3, models=("LR_Base", "LR_SM"))
 
         sobs = aggregate_monthly_obs_to_seasonal(monthly_obs)
         # Build seasonal forecasts directly (replaces removed aggregation)
@@ -217,7 +217,7 @@ class TestCrossYearSeasonWorkflow:
         monkeypatch.setenv("SAPPHIRE_SEASON_END_MONTH", "3")
 
         monthly_obs = _monthly_obs(n_years=4)
-        monthly_fc = _monthly_fc(n_years=4, models=("LR", "TFT"))
+        monthly_fc = _monthly_fc(n_years=4, models=("LR_Base", "LR_SM"))
 
         sobs = aggregate_monthly_obs_to_seasonal(monthly_obs)
         # Build seasonal forecasts directly (replaces removed aggregation)
@@ -266,7 +266,7 @@ class TestQuarterlyOperationalWorkflow:
             {
                 "quarter_in_year": [1, 1],
                 "code": ["S1", "S1"],
-                "model_short": ["LR", "TFT"],
+                "model_short": ["LR_Base", "LR_SM"],
                 "sdivsigma": [0.3, 0.4],
                 "nse": [0.95, 0.88],
                 "delta": [5.0, 5.0],
@@ -282,7 +282,7 @@ class TestQuarterlyOperationalWorkflow:
                 "code": ["S1", "S1"],
                 "year": [2025, 2025],
                 "quarter_in_year": [1, 1],
-                "model_short": ["LR", "TFT"],
+                "model_short": ["LR_Base", "LR_SM"],
                 "forecasted_discharge": [100.0, 120.0],
                 "q05": [80, 90],
                 "q10": [85, 95],
@@ -311,7 +311,7 @@ class TestSeasonalOperationalWorkflow:
             {
                 "season_in_year": [1, 1],
                 "code": ["S1", "S1"],
-                "model_short": ["LR", "TFT"],
+                "model_short": ["LR_Base", "LR_SM"],
                 "sdivsigma": [0.3, 0.4],
                 "nse": [0.95, 0.88],
                 "delta": [5.0, 5.0],
@@ -326,7 +326,7 @@ class TestSeasonalOperationalWorkflow:
                 "code": ["S1", "S1"],
                 "season_year": [2025, 2025],
                 "season_in_year": [1, 1],
-                "model_short": ["LR", "TFT"],
+                "model_short": ["LR_Base", "LR_SM"],
                 "forecasted_discharge": [100.0, 120.0],
                 "q05": [80, 90],
                 "q10": [85, 95],

--- a/apps/postprocessing_forecasts/tests/test_recalc_workflow.py
+++ b/apps/postprocessing_forecasts/tests/test_recalc_workflow.py
@@ -161,6 +161,22 @@ def _setup_mocks(mock_data, mock_skill):
     }
 
 
+def _set_long_term_env(monkeypatch, tmp_path, modes):
+    config_dir = tmp_path / "long_term"
+    config_dir.mkdir()
+    monkeypatch.setenv("ieasyforecast_configuration_path", str(tmp_path))
+    monkeypatch.setenv("ieasyhydroforecast_ml_long_term_configuration", "long_term")
+    monkeypatch.setenv("ieasyhydroforecast_ml_long_term_supported_modes", ",".join(modes))
+    for name, lead in {
+        "seasonal_january": 3,
+        "seasonal_february": 2,
+        "seasonal_march": 1,
+        "seasonal_april": 0,
+    }.items():
+        if name in modes:
+            (config_dir / f"{name}.json").write_text(f'{{"operational_month_lead_time": {lead}}}')
+
+
 class TestRecalcWorkflow:
     """Tests for the yearly recalculation entry point."""
 
@@ -381,6 +397,7 @@ class TestRecalcMonthly:
                 spec.loader.exec_module(module)
 
                 module._read_station_codes = MagicMock(return_value=["10001"])
+                module._supported_seasonal_issue_leads = MagicMock(return_value=[])
 
                 with pytest.raises(SystemExit) as exc_info:
                     module.recalculate_skill_metrics()
@@ -528,3 +545,93 @@ class TestRecalcMonthly:
                 # Should still exit 0 (empty is not an error)
                 assert exc_info.value.code == 0
                 mocks["skill_metrics"].calculate_monthly_skill_metrics.assert_called_once()
+
+
+class TestRecalcSeasonalLeadSelection:
+    def test_seasonal_recalc_reads_each_supported_issue_lead(
+        self, mock_data, mock_skill, monkeypatch, tmp_path
+    ):
+        _set_long_term_env(
+            monkeypatch,
+            tmp_path,
+            [
+                "seasonal_january",
+                "seasonal_february",
+                "seasonal_march",
+                "seasonal_april",
+            ],
+        )
+        with patch.dict(
+            os.environ,
+            {
+                "SAPPHIRE_PREDICTION_MODE": "SEASONAL",
+                "SAPPHIRE_RECALC_START_YEAR": "2024",
+                "SAPPHIRE_RECALC_END_YEAR": "2024",
+            },
+        ):
+            with patch.dict(sys.modules, {}):
+                mocks = _setup_mocks(mock_data, mock_skill)
+                mocks["data_reader"].read_seasonal_observations.return_value = pd.DataFrame(
+                    {"code": ["10001"], "season_year": [2024], "discharge_avg": [10.0]}
+                )
+                mocks["data_reader"].read_seasonal_forecasts.side_effect = [
+                    pd.DataFrame(
+                        {
+                            "code": ["10001"],
+                            "season_year": [2024],
+                            "season_in_year": [lead],
+                            "model_short": ["LR"],
+                            "q50": [10.0],
+                        }
+                    )
+                    for lead in [3, 2, 1, 0]
+                ]
+
+                module, spec = import_recalc_module()
+                spec.loader.exec_module(module)
+                module._read_station_codes = MagicMock(return_value=["10001"])
+
+                with pytest.raises(SystemExit) as exc_info:
+                    module.recalculate_skill_metrics()
+
+                assert exc_info.value.code == 0
+                calls = mocks["data_reader"].read_seasonal_forecasts.call_args_list
+                assert [call.kwargs["horizon_value"] for call in calls] == [3, 2, 1, 0]
+
+    def test_seasonal_recalc_reads_only_april_issue_for_single_issue_deployment(
+        self, mock_data, mock_skill, monkeypatch, tmp_path
+    ):
+        _set_long_term_env(monkeypatch, tmp_path, ["seasonal_april"])
+        with patch.dict(
+            os.environ,
+            {
+                "SAPPHIRE_PREDICTION_MODE": "SEASONAL",
+                "SAPPHIRE_RECALC_START_YEAR": "2024",
+                "SAPPHIRE_RECALC_END_YEAR": "2024",
+            },
+        ):
+            with patch.dict(sys.modules, {}):
+                mocks = _setup_mocks(mock_data, mock_skill)
+                mocks["data_reader"].read_seasonal_observations.return_value = pd.DataFrame(
+                    {"code": ["10001"], "season_year": [2024], "discharge_avg": [10.0]}
+                )
+                mocks["data_reader"].read_seasonal_forecasts.return_value = pd.DataFrame(
+                    {
+                        "code": ["10001"],
+                        "season_year": [2024],
+                        "season_in_year": [0],
+                        "model_short": ["LR"],
+                        "q50": [10.0],
+                    }
+                )
+
+                module, spec = import_recalc_module()
+                spec.loader.exec_module(module)
+                module._read_station_codes = MagicMock(return_value=["10001"])
+
+                with pytest.raises(SystemExit) as exc_info:
+                    module.recalculate_skill_metrics()
+
+                assert exc_info.value.code == 0
+                calls = mocks["data_reader"].read_seasonal_forecasts.call_args_list
+                assert [call.kwargs["horizon_value"] for call in calls] == [0]

--- a/apps/postprocessing_forecasts/tests/test_seasonal_integration.py
+++ b/apps/postprocessing_forecasts/tests/test_seasonal_integration.py
@@ -301,6 +301,103 @@ class TestSeasonalSkillMetricsEdgeCases:
         assert model_rows.empty
 
 
+class TestSeasonalSkillMetricsPerLead:
+    """PP3: seasonal skill keeps issue lead in season_in_year."""
+
+    def test_four_issue_leads_produce_distinct_skill_rows(self):
+        code = "PP3_SENTINEL"
+        model = "LR"
+        observed_by_year = {
+            2021: 100.0,
+            2022: 120.0,
+            2023: 140.0,
+        }
+        lead_error = {
+            3: 30.0,  # January issue
+            2: 20.0,  # February issue
+            1: 10.0,  # March issue
+            0: 0.0,  # April issue
+        }
+        obs = pd.DataFrame(
+            {
+                "code": [code] * len(observed_by_year),
+                "season_year": list(observed_by_year),
+                "season_in_year": [1] * len(observed_by_year),
+                "discharge_avg": list(observed_by_year.values()),
+                "delta": [5.0] * len(observed_by_year),
+            }
+        )
+        fc_rows = []
+        for season_year, observed in observed_by_year.items():
+            for lead, error in lead_error.items():
+                q50 = observed + error
+                fc_rows.append(
+                    {
+                        "code": code,
+                        "season_year": season_year,
+                        "season_in_year": lead,
+                        "model_short": model,
+                        "q05": q50 - 20.0,
+                        "q10": q50 - 15.0,
+                        "q25": q50 - 5.0,
+                        "q50": q50,
+                        "q75": q50 + 5.0,
+                        "q90": q50 + 15.0,
+                        "q95": q50 + 20.0,
+                    }
+                )
+        fcst = pd.DataFrame(fc_rows)
+
+        skill_stats, _, _ = calculate_seasonal_skill_metrics(obs, fcst)
+        model_rows = skill_stats[
+            (skill_stats["code"] == code) & (skill_stats["model_short"] == model)
+        ]
+
+        assert set(model_rows["season_in_year"]) == {0, 1, 2, 3}
+        assert len(model_rows) == 4
+        assert set(model_rows["n_pairs"]) == {3}
+
+        mae_by_lead = dict(zip(model_rows["season_in_year"], model_rows["mae"], strict=True))
+        assert mae_by_lead == {0: 0.0, 1: 10.0, 2: 20.0, 3: 30.0}
+        assert model_rows["nse"].nunique(dropna=True) == 4
+
+    def test_single_issue_lead_zero_still_works(self):
+        code = "PP3_SINGLE_SENTINEL"
+        obs = pd.DataFrame(
+            {
+                "code": [code, code, code],
+                "season_year": [2021, 2022, 2023],
+                "season_in_year": [1, 1, 1],
+                "discharge_avg": [100.0, 120.0, 140.0],
+                "delta": [5.0, 5.0, 5.0],
+            }
+        )
+        fcst = pd.DataFrame(
+            {
+                "code": [code, code, code],
+                "season_year": [2021, 2022, 2023],
+                "season_in_year": [0, 0, 0],
+                "model_short": ["LR", "LR", "LR"],
+                "q05": [80.0, 100.0, 120.0],
+                "q10": [85.0, 105.0, 125.0],
+                "q25": [95.0, 115.0, 135.0],
+                "q50": [100.0, 120.0, 140.0],
+                "q75": [105.0, 125.0, 145.0],
+                "q90": [115.0, 135.0, 155.0],
+                "q95": [120.0, 140.0, 160.0],
+            }
+        )
+
+        skill_stats, _, _ = calculate_seasonal_skill_metrics(obs, fcst)
+        model_rows = skill_stats[
+            (skill_stats["code"] == code) & (skill_stats["model_short"] == "LR")
+        ]
+
+        assert len(model_rows) == 1
+        assert model_rows.iloc[0]["season_in_year"] == 0
+        assert model_rows.iloc[0]["mae"] == 0.0
+
+
 # ===================================================================
 # C. Data Reader Gaps
 # ===================================================================

--- a/apps/postprocessing_forecasts/tests/test_seasonal_integration.py
+++ b/apps/postprocessing_forecasts/tests/test_seasonal_integration.py
@@ -96,18 +96,18 @@ def _two_model_seasonal_skill():
     """Two highly skilled models for station S1, season 1."""
     return _make_seasonal_skill(
         [
-            (1, "S1", "LR", 0.3, 0.95, 5.0, 0.90, 2.0, 10),
-            (1, "S1", "TFT", 0.4, 0.88, 5.0, 0.85, 3.0, 10),
+            (1, "S1", "LR_Base", 0.3, 0.95, 5.0, 0.90, 2.0, 10),
+            (1, "S1", "LR_SM", 0.4, 0.88, 5.0, 0.85, 3.0, 10),
         ]
     )
 
 
 def _two_model_seasonal_fcst():
-    """Forecasts for LR and TFT, station S1, season_year 2025."""
+    """Forecasts for LR_Base and LR_SM, station S1, season_year 2025."""
     return _make_seasonal_fcst(
         [
-            ("S1", 2025, 1, "LR", 100.0, 80, 85, 90, 100, 110, 115, 120),
-            ("S1", 2025, 1, "TFT", 120.0, 90, 95, 100, 120, 130, 135, 140),
+            ("S1", 2025, 1, "LR_Base", 100.0, 80, 85, 90, 100, 110, 115, 120),
+            ("S1", 2025, 1, "LR_SM", 120.0, 90, 95, 100, 120, 130, 135, 140),
         ]
     )
 
@@ -130,7 +130,7 @@ def _monthly_obs(n_years=3, codes=("S1",), start_month=1, end_month=12):
     return pd.DataFrame(rows)
 
 
-def _monthly_fc(n_years=3, codes=("S1",), models=("LR", "TFT")):
+def _monthly_fc(n_years=3, codes=("S1",), models=("LR_Base", "LR_SM")):
     """Create monthly forecasts for multiple models/years."""
     rows = []
     for code in codes:
@@ -138,7 +138,7 @@ def _monthly_fc(n_years=3, codes=("S1",), models=("LR", "TFT")):
             for month in range(1, 13):
                 for model in models:
                     base = 50 + month * 5 + (year - 2020) * 2
-                    offset = 2 if model == "LR" else -1
+                    offset = 2 if model == "LR_Base" else -1
                     q50 = float(base + offset)
                     rows.append(
                         {
@@ -212,10 +212,10 @@ class TestSeasonalEnsembleSkilled:
         fcst = _two_model_seasonal_fcst()
         result = create_seasonal_ensemble_forecasts(fcst, skill)
         sm = result[result["model_short"] == "Skilled Mean"]
-        # LR: MAE=2.0, TFT: MAE=3.0
-        # LR has lower MAE -> higher weight -> result closer to LR (100)
+        # LR_Base: MAE=2.0, LR_SM: MAE=3.0
+        # LR_Base has lower MAE -> higher weight -> result closer to 100
         discharge = sm.iloc[0]["forecasted_discharge"]
-        assert discharge < 110.0  # closer to LR's 100 than simple mean 110
+        assert discharge < 110.0  # closer to 100 than simple mean 110
 
     def test_em_composition_string(self):
         """EM composition should contain contributing model names."""
@@ -225,19 +225,19 @@ class TestSeasonalEnsembleSkilled:
         em = result[result["model_short"] == "EM"]
         assert not em.empty
         comp = str(em.iloc[0]["composition"])
-        assert "LR" in comp
-        assert "TFT" in comp
+        assert "LR_Base" in comp
+        assert "LR_SM" in comp
 
     def test_em_not_created_single_model(self):
         """Single model should not produce EM for seasonal."""
         skill = _make_seasonal_skill(
             [
-                (1, "S1", "LR", 0.3, 0.95, 5.0, 0.90, 2.0, 10),
+                (1, "S1", "LR_Base", 0.3, 0.95, 5.0, 0.90, 2.0, 10),
             ]
         )
         fcst = _make_seasonal_fcst(
             [
-                ("S1", 2025, 1, "LR", 100.0, 80, 85, 90, 100, 110, 115, 120),
+                ("S1", 2025, 1, "LR_Base", 100.0, 80, 85, 90, 100, 110, 115, 120),
             ]
         )
         result = create_seasonal_ensemble_forecasts(fcst, skill)
@@ -437,7 +437,7 @@ class TestSeasonalDataReaderNonEmpty:
                         "2024-09-30",
                     ]
                 ),
-                "model_type": ["M1"] * 6,
+                "model_type": ["LR_Base"] * 6,
                 "q50": [100.0, 110, 120, 130, 140, 150],
                 "q05": [80, 90, 100, 110, 120, 130],
                 "q10": [85, 95, 105, 115, 125, 135],
@@ -510,7 +510,7 @@ class TestSeasonalDataReaderNonEmpty:
                         "2024-03-31",
                     ]
                 ),
-                "model_type": ["M1"] * 6,
+                "model_type": ["LR_Base"] * 6,
                 "q50": [200.0, 180, 160, 140, 150, 170],
                 "q05": [180, 160, 140, 120, 130, 150],
                 "q10": [185, 165, 145, 125, 135, 155],
@@ -610,7 +610,7 @@ class TestSeasonalCrossYearPipeline:
         monkeypatch.setenv("SAPPHIRE_SEASON_END_MONTH", "3")
 
         monthly_obs = _monthly_obs(n_years=4)
-        monthly_fc = _monthly_fc(n_years=4, models=("LR", "TFT"))
+        monthly_fc = _monthly_fc(n_years=4, models=("LR_Base", "LR_SM"))
 
         sobs = aggregate_monthly_obs_to_seasonal(monthly_obs)
         # Build seasonal forecasts directly (replaces removed aggregation)
@@ -670,8 +670,8 @@ class TestSeasonalCrossYearPipeline:
         result = create_seasonal_ensemble_forecasts(sfc, skill_stats)
         assert not result.empty
         result_models = set(result["model_short"].unique())
-        assert "LR" in result_models
-        assert "TFT" in result_models
+        assert "LR_Base" in result_models
+        assert "LR_SM" in result_models
         assert "Naive Mean" in result_models
 
     def test_custom_season_end_to_end(self, monkeypatch):
@@ -680,7 +680,7 @@ class TestSeasonalCrossYearPipeline:
         monkeypatch.setenv("SAPPHIRE_SEASON_END_MONTH", "8")
 
         monthly_obs = _monthly_obs(n_years=3)
-        monthly_fc = _monthly_fc(n_years=3, models=("LR", "TFT"))
+        monthly_fc = _monthly_fc(n_years=3, models=("LR_Base", "LR_SM"))
 
         sobs = aggregate_monthly_obs_to_seasonal(monthly_obs)
         # Build seasonal forecasts directly (replaces removed aggregation)
@@ -731,6 +731,6 @@ class TestSeasonalCrossYearPipeline:
         result = create_seasonal_ensemble_forecasts(sfc, skill_stats)
         assert not result.empty
         result_models = set(result["model_short"].unique())
-        assert "LR" in result_models
-        assert "TFT" in result_models
+        assert "LR_Base" in result_models
+        assert "LR_SM" in result_models
         assert "Naive Mean" in result_models

--- a/apps/validate_pipeline/test/test_validate_pipeline.py
+++ b/apps/validate_pipeline/test/test_validate_pipeline.py
@@ -33,6 +33,32 @@ def mock_post_client():
     return client
 
 
+@pytest.fixture(autouse=True)
+def _long_term_resolver_env(monkeypatch, tmp_path):
+    config_dir = tmp_path / "long_term_configs"
+    config_dir.mkdir()
+    leads = {
+        "quarter": 1,
+        "seasonal_january": 3,
+        "seasonal_february": 2,
+        "seasonal_march": 1,
+        "seasonal_april": 0,
+    }
+    for name, lead in leads.items():
+        (config_dir / f"{name}.json").write_text(json.dumps({"operational_month_lead_time": lead}))
+
+    monkeypatch.setenv("ieasyforecast_configuration_path", str(tmp_path))
+    monkeypatch.setenv(
+        "ieasyhydroforecast_ml_long_term_configuration",
+        "long_term_configs",
+    )
+    monkeypatch.setenv(
+        "ieasyhydroforecast_ml_long_term_supported_modes",
+        ",".join(leads),
+    )
+    return config_dir
+
+
 @pytest.fixture()
 def sample_runoff_df():
     """Sample runoff DataFrame with two stations."""
@@ -402,6 +428,53 @@ class TestModuleAttribution:
         by_name = {r.name: r.module for r in results}
         assert by_name["Long-term forecasts (month)"] == ("long_term_forecasting")
         assert by_name["Monthly skill metrics"] == "postprocessing_forecasts"
+        assert by_name["Long-term forecasts (quarter hv1)"] == "postprocessing_forecasts"
+        assert by_name["Quarterly skill metrics"] == "postprocessing_forecasts"
+        assert by_name["Long-term forecasts (season issue 2 hv2)"] == "postprocessing_forecasts"
+        assert by_name["Seasonal skill metrics"] == "postprocessing_forecasts"
+
+    def test_tier1_long_term_fails_when_quarter_bucket_empty(self, mock_post_client):
+        single_row = pd.DataFrame({"code": ["15001"], "date": ["2026-02-23"]})
+
+        def read_long_term_forecasts(**kwargs):
+            if kwargs.get("horizon_type") == "quarter":
+                return pd.DataFrame()
+            return single_row
+
+        mock_post_client.read_long_term_forecasts.side_effect = read_long_term_forecasts
+        mock_post_client.read_skill_metrics.return_value = single_row
+
+        results = vp.run_tier1_long_term(mock_post_client, date(2026, 2, 23))
+        by_name = {r.name: r for r in results}
+
+        assert by_name["Long-term forecasts (quarter hv1)"].status == "FAIL"
+        assert "no records" in by_name["Long-term forecasts (quarter hv1)"].detail
+
+    def test_tier1_long_term_fails_when_season_bucket_empty(self, mock_post_client):
+        single_row = pd.DataFrame({"code": ["15001"], "date": ["2026-02-23"]})
+
+        def read_long_term_forecasts(**kwargs):
+            if kwargs.get("horizon_type") == "season" and kwargs.get("horizon_value") == 2:
+                return pd.DataFrame()
+            return single_row
+
+        mock_post_client.read_long_term_forecasts.side_effect = read_long_term_forecasts
+        mock_post_client.read_skill_metrics.return_value = single_row
+
+        results = vp.run_tier1_long_term(mock_post_client, date(2026, 2, 23))
+        by_name = {r.name: r for r in results}
+
+        assert by_name["Long-term forecasts (season issue 2 hv2)"].status == "FAIL"
+        assert "no records" in by_name["Long-term forecasts (season issue 2 hv2)"].detail
+
+    def test_tier1_long_term_passes_when_quarter_and_season_buckets_present(self, mock_post_client):
+        single_row = pd.DataFrame({"code": ["15001"], "date": ["2026-02-23"]})
+        mock_post_client.read_long_term_forecasts.return_value = single_row
+        mock_post_client.read_skill_metrics.return_value = single_row
+
+        results = vp.run_tier1_long_term(mock_post_client, date(2026, 2, 23))
+
+        assert all(r.status == "PASS" for r in results)
 
     def test_module_shown_in_output(self, capsys):
         """Module attribution appears in printed output."""

--- a/apps/validate_pipeline/validate_pipeline.py
+++ b/apps/validate_pipeline/validate_pipeline.py
@@ -32,6 +32,22 @@ from pathlib import Path
 
 import pandas as pd
 
+try:
+    from iEasyHydroForecast.long_term_horizon_resolver import (
+        quarter_horizon_value,
+        seasonal_config_name,
+        seasonal_horizon_value,
+        supported_long_term_modes,
+    )
+except ModuleNotFoundError:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from iEasyHydroForecast.long_term_horizon_resolver import (
+        quarter_horizon_value,
+        seasonal_config_name,
+        seasonal_horizon_value,
+        supported_long_term_modes,
+    )
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -75,6 +91,8 @@ LT_QUANTILE_COLS = ["q05", "q10", "q25", "q50", "q75", "q90", "q95"]
 
 # Discharge column name in long-term forecasts.
 LT_DISCHARGE_COL = "q"
+
+SEASONAL_ISSUE_MONTHS = (1, 2, 3, 4)
 
 # Default threshold (days) for data freshness checks.
 _FRESHNESS_THRESHOLD_DEFAULT = 3
@@ -518,8 +536,69 @@ def run_tier1_long_term(
             horizon="month",
         )
     )
+    quarter_hv = quarter_horizon_value()
+    results.append(
+        check_presence(
+            post_client,
+            "read_long_term_forecasts",
+            f"Long-term forecasts (quarter hv{quarter_hv})",
+            module="postprocessing_forecasts",
+            horizon_type="quarter",
+            horizon_value=quarter_hv,
+            start_date=fd,
+            end_date=fd,
+        )
+    )
+    results.append(
+        check_presence(
+            post_client,
+            "read_skill_metrics",
+            "Quarterly skill metrics",
+            module="postprocessing_forecasts",
+            horizon="quarter",
+        )
+    )
+
+    season_issue_month, season_hv = _resolved_seasonal_presence_horizon_value(forecast_date)
+    results.append(
+        check_presence(
+            post_client,
+            "read_long_term_forecasts",
+            f"Long-term forecasts (season issue {season_issue_month} hv{season_hv})",
+            module="postprocessing_forecasts",
+            horizon_type="season",
+            horizon_value=season_hv,
+            start_date=fd,
+            end_date=fd,
+        )
+    )
+    results.append(
+        check_presence(
+            post_client,
+            "read_skill_metrics",
+            "Seasonal skill metrics",
+            module="postprocessing_forecasts",
+            horizon="season",
+        )
+    )
 
     return results
+
+
+def _resolved_seasonal_presence_horizon_value(forecast_date: date) -> tuple[int, int]:
+    """Return the configured seasonal issue month and deployment lead for a run."""
+    modes = set(supported_long_term_modes())
+    supported = [
+        issue_month
+        for issue_month in SEASONAL_ISSUE_MONTHS
+        if seasonal_config_name(issue_month) in modes
+    ]
+    if not supported:
+        raise ValueError("No seasonal long-term modes are supported by this deployment.")
+
+    eligible = [issue_month for issue_month in supported if issue_month <= forecast_date.month]
+    issue_month = max(eligible or supported)
+    return issue_month, seasonal_horizon_value(issue_month)
 
 
 # ---------------------------------------------------------------------------

--- a/bin/utils/run_skill_metrics_recalc.sh
+++ b/bin/utils/run_skill_metrics_recalc.sh
@@ -34,7 +34,7 @@ run_skill_metrics_recalc_once() {
     local timestamp="$3"
     local container_name="$4"
 
-    # Reject empty mode — the helper must not fall back to ambient env.
+    # Reject empty mode - the helper must not fall back to ambient env.
     if [ -z "$mode" ]; then
         echo "ERROR: run_skill_metrics_recalc_once requires a non-empty mode as the first argument" >&2
         return 2
@@ -43,18 +43,23 @@ run_skill_metrics_recalc_once() {
     local SERVICE_LOG="${log_dir}/${container_name}_${timestamp}.log"
 
     # macOS Docker compatibility
-    local DOCKER_HOST_OVERRIDE=""
+    local DOCKER_HOST_OVERRIDE_ARGS=()
     if [[ "$(uname)" == "Darwin" ]]; then
         if [[ "$IEASYHYDROHF_HOST" == *"localhost"* ]]; then
             local DOCKER_IEASYHYDROHF_HOST="${IEASYHYDROHF_HOST//localhost/host.docker.internal}"
             echo "macOS detected: overriding IEASYHYDROHF_HOST for Docker container"
             echo "  Original: $IEASYHYDROHF_HOST"
             echo "  Docker:   $DOCKER_IEASYHYDROHF_HOST"
-            DOCKER_HOST_OVERRIDE="-e IEASYHYDROHF_HOST=${DOCKER_IEASYHYDROHF_HOST}"
+            DOCKER_HOST_OVERRIDE_ARGS=(-e "IEASYHYDROHF_HOST=${DOCKER_IEASYHYDROHF_HOST}")
         fi
     fi
 
-    # Image resolution — mirrors the outer script's IMAGE_ID. The image-existence
+    local RECALC_START_YEAR_OVERRIDE_ARGS=()
+    if [ -n "${SAPPHIRE_RECALC_START_YEAR:-}" ]; then
+        RECALC_START_YEAR_OVERRIDE_ARGS=(-e "SAPPHIRE_RECALC_START_YEAR=${SAPPHIRE_RECALC_START_YEAR}")
+    fi
+
+    # Image resolution - mirrors the outer script's IMAGE_ID. The image-existence
     # check and `docker pull` stay in the outer script (called once per
     # invocation, not once per mode).
     local IMAGE_ID="mabesa/sapphire-postprocessing:${ieasyhydroforecast_backend_docker_image_tag:-latest}"
@@ -69,20 +74,22 @@ run_skill_metrics_recalc_once() {
     fi
 
     # Run the skill metrics recalculation container
+    # shellcheck disable=SC2154
     docker run \
         --name "$container_name" \
         --network host \
-        -e ieasyhydroforecast_data_root_dir=${ieasyhydroforecast_data_root_dir} \
-        -e ieasyhydroforecast_env_file_path=${ieasyhydroforecast_env_file_path} \
+        -e "ieasyhydroforecast_data_root_dir=${ieasyhydroforecast_data_root_dir}" \
+        -e "ieasyhydroforecast_env_file_path=${ieasyhydroforecast_env_file_path}" \
         -e SAPPHIRE_OPDEV_ENV=True \
         -e IN_DOCKER=True \
-        -e SAPPHIRE_PREDICTION_MODE=${mode} \
-        ${DOCKER_HOST_OVERRIDE} \
-        -v ${ieasyhydroforecast_data_ref_dir}/config:${ieasyhydroforecast_container_data_ref_dir}/config \
-        -v ${ieasyhydroforecast_data_ref_dir}/intermediate_data:${ieasyhydroforecast_container_data_ref_dir}/intermediate_data \
+        -e "SAPPHIRE_PREDICTION_MODE=${mode}" \
+        "${RECALC_START_YEAR_OVERRIDE_ARGS[@]}" \
+        "${DOCKER_HOST_OVERRIDE_ARGS[@]}" \
+        -v "${ieasyhydroforecast_data_ref_dir}/config:${ieasyhydroforecast_container_data_ref_dir}/config" \
+        -v "${ieasyhydroforecast_data_ref_dir}/intermediate_data:${ieasyhydroforecast_container_data_ref_dir}/intermediate_data" \
         --memory=8g \
         --memory-swap=12g \
-        ${IMAGE_ID} \
+        "${IMAGE_ID}" \
         uv run recalculate_skill_metrics.py \
         2>&1 | tee "$SERVICE_LOG"
 

--- a/doc/plans/working/ppipe_postprocessing_ensemble_hv_plan.md
+++ b/doc/plans/working/ppipe_postprocessing_ensemble_hv_plan.md
@@ -1,0 +1,684 @@
+# P-PIPE: Postprocessing Quarterly/Seasonal Ensemble `horizon_value` Plan
+
+Branch: `fix_migration_long_forecast_multihorizon`
+Scope: B branch from PP0: seasonal issue-threading, per-lead seasonal skill, quarter config-lead
+alignment, read-side lockstep, and regenerate-then-clean sequencing.
+Status: plan only; no implementation, no DB writes.
+
+`apps/` modules are in scope. Do not edit `sapphire/services/**`; service files may be read for
+contract evidence only. If an implementation phase discovers that a service schema/API contract must
+change, stop and raise a coordination blocker.
+
+P-PIPE is a hard prerequisite for the data cleanup phases in
+`doc/plans/working/longforecast_hv_convention_plan.md`. Cleanup P3/P4 must not run until P-PIPE is
+coded, reviewed, deployed, the one-time full-history quarterly/seasonal recalc has written
+new-convention rows for each deployment, aggregate verification passes, and obsolete old-hv rows are
+then cleaned.
+
+## Per-lead Skill Feasibility Verdict
+
+**Verdict: no `skill_metrics` schema change is needed for B.** Seasonal per-lead skill can be carried
+by reinterpreting `season_in_year` / API `horizon_in_year` as the seasonal lead (`3/2/1/0`) for
+`horizon_type="season"`. This stays in app-owned code and does not require `sapphire/services/**`
+edits.
+
+Evidence:
+
+- The service model already stores `horizon_in_year` on `skill_metrics` and includes it in the unique
+  key: `sapphire/services/postprocessing/app/models.py:196-235`.
+- The service create/upsert path keys on `(horizon_type, code, model_type, date, horizon_in_year)`:
+  `sapphire/services/postprocessing/app/crud.py:277-313`.
+- The service schema accepts `horizon_in_year` as an integer field without a season-specific enum:
+  `sapphire/services/postprocessing/app/schemas.py:161-188`.
+- The app writer already maps seasonal `season_in_year` to API `horizon_in_year`:
+  `apps/postprocessing_forecasts/src/api_writer.py:475-487` and writes it at `:629-636`.
+- Current seasonal skill calculation uses `period_col="season_in_year"` but hardcodes the old
+  single-season semantics via `time_group_cols=["season_year","code"]` and
+  `merge_cols=["code","season_year"]`: `apps/postprocessing_forecasts/src/skill_metrics.py:2060-2087`.
+- Skill readers already map API `horizon_in_year` back to `season_in_year`:
+  `apps/postprocessing_forecasts/src/data_reader.py:2511-2528`.
+
+Decision:
+
+- For `horizon_type="season"`, `season_in_year` becomes the lead dimension, not a literal "season
+  number". Seasonal skill rows for the same target season use the same target-season `date`, while
+  `horizon_in_year=3/2/1/0` separates Jan/Feb/Mar/Apr lead skill in the existing DB key.
+- The implementation must update seasonal skill calculation, skill writing, skill reading, and
+  skill-to-ensemble joins together so every layer keys on lead. If a reviewer rejects this semantic
+  reuse of `horizon_in_year`, that becomes a service-owner coordination blocker; the current evidence
+  does not require it.
+
+## Review Outcome (2026-06-22): GO-WITH-CHANGES -- PP0 now answered
+
+A critical review verified every file:line and surfaced must-fixes that PP0 has now resolved. The
+implementation branch is B:
+
+- **MF-1: seasonal issue identity must be threaded through every layer.** The raw seasonal rows carry
+  distinct issue dates upstream, but the postprocessing reader currently destroys that identity:
+  `_SEASONAL_FC_COLS` excludes `date` and `horizon_value`
+  (`apps/postprocessing_forecasts/src/data_reader.py:37-52`); seasonal normalization derives
+  `season_year` from `valid_from`, hardcodes `season_in_year = 1`, and drops `horizon_value`
+  (`data_reader.py:3059-3080`). The ensemble groups by `["season_year","code"]`
+  (`ensemble_calculator.py:553-558`), both operational and maintenance dedup on
+  `["season_year","code","model_short"]` (`postprocessing_operational_long_term.py:200-212`,
+  `postprocessing_maintenance_long_term.py:330-343`), and the writer overwrites the issue date with
+  target `valid_from` while hardcoding `horizon_value = 1` (`api_writer.py:1052-1079`). B requires
+  preserving an issue dimension through reader projection, ensemble grouping, dedup, writer date, and
+  per-row issue->lead resolution.
+- **MF-2: regenerate before cleanup.** PP0 chose regenerate, not re-stamp as the primary ensemble
+  correction. Sequence is P-PIPE code -> deploy -> full-history recalc with
+  `SAPPHIRE_RECALC_START_YEAR=2000` per deployment -> aggregate verify -> cleanup obsolete old-hv
+  rows. Cleanup P3/P4 in `longforecast_hv_convention_plan.md` is blocked until that gate passes.
+- **MF-3: acceptance is model-class specific.** Raw LR rows are produced by `apps/long_term_forecasting`
+  / from-file importer and already use config lead. P-PIPE changes the EM / Naive Mean / Skilled Mean
+  postprocessing ensemble rows so they land in the same buckets as the raw rows.
+- **SF-1: complete consumers and add CI guard.** Consumer changes include
+  `apps/forecast_dashboard/src/db.py:600-609`, `:806`, `:867`,
+  `apps/forecast_dashboard/dashboard/bulletin_manager.py:168`, `:186`, `:393`, `:411`, `:495`, and a
+  quarter/season presence assertion in `apps/validate_pipeline/validate_pipeline.py:493-522` so empty
+  buckets fail CI.
+- **SF-2: seasonal readers must not duplicate issues before PP-ensemble.** `read_seasonal_forecasts`
+  and `read_latest_seasonal_forecasts` (`data_reader.py:2696-2750`, `:2848-2878`) currently read
+  unfiltered seasonal rows and do not dedup per lead. The B plan puts issue/lead preservation and
+  filtering ahead of ensemble calculation.
+- **SF-3: shared resolver belongs outside dashboard internals.** The resolver should live in
+  `apps/iEasyHydroForecast` or an equivalent env-var contract read by each module, mirroring
+  `get_season_months()` / `SAPPHIRE_SEASON_*` in
+  `apps/postprocessing_forecasts/src/aggregation.py:48-66`. Do not import
+  `forecast_dashboard -> postprocessing_forecasts`.
+
+## Review 2 (2026-06-22): GO-WITH-CHANGES -- required text fixes integrated
+
+A second critical review confirmed the load-bearing claims (regen writes ensemble rows via
+`save_quarterly/seasonal_forecast_data` -> the same `api_writer` PP4 edits; the per-lead-skill schema
+reuse is sound -- `skill_metrics` key `(horizon_type, code, model_type, date, horizon_in_year)`
+`models.py:228-235`/`crud.py:281-313`, `horizon_in_year` a bare int, no service `==1` assumption). One
+Must-fix + targeted Should-fixes, folded in here:
+
+- **MF-A (cross-plan): regenerate and cleanup are not reconciled** -- see the dedicated section below.
+  This is the gate; resolve in text before any PP4/PP7 code.
+- **SF-1: per-lead seasonal skill never reaches the dashboard without two unlisted changes.**
+  `_get_data_season` (`db.py:913-927`) left-merges seasonal forecasts (pinned to `season_in_year=1` at
+  `db.py:681`) against per-lead skill (`0-3`) on `["code","season_in_year","model_short"]`, so only the
+  lead-1 (March) skill survives. **PP6 scope expands** to `db.py:681` + `db.py:913-927`, plus a test
+  asserting all four leads' skill survive the merge; also remove the forced-`1` assumption at
+  `aggregation.py:198` and the `skill_metrics.py:2068` docstring ("season_in_year is always 1").
+- **SF-2: fix the recalc helper, don't rely on operator `-e`.** `bin/utils/run_skill_metrics_recalc.sh`
+  forwards `SAPPHIRE_PREDICTION_MODE` (`:79`) but NOT `SAPPHIRE_RECALC_START_YEAR`, and uses
+  `docker run` without `--env-file`, so the one-time deep recalc silently falls to the
+  `current_year-20` (~2006) default. **PP7 scope adds** a contained `bin/`-only fix: conditionally pass
+  `-e SAPPHIRE_RECALC_START_YEAR=...` (guarded so an unset value is not passed as an empty string that
+  breaks `int()`).
+- **SF-3 (reframe):** the four seasonal issues fold today because there is **no lead/issue carrier
+  column** in the seasonal frame (`_SEASONAL_FC_COLS` lacks `date`/`horizon_value`
+  `data_reader.py:37-52`; `_normalize_combined_forecasts` hardcodes `season_in_year=1` `:3064`;
+  groupby `["season_year","code"]`), NOT because of latest-filtering (`read_latest_seasonal_forecasts`
+  `:2848-2902` does not collapse). PP2 must target the carrier column.
+- **SF-4:** "quarter is a small *writer* change" is true, but collapsing the 4 calendar quarters to a
+  single `hv1` is exactly what creates the old `hv2/3/4` orphan population that MF-A cleanup must
+  remove -- a small writer change, not a small overall change.
+- **N1:** start-year precedence is three-level: `SAPPHIRE_SKILL_METRICS_START_YEAR` ->
+  `SAPPHIRE_RECALC_START_YEAR` -> `current_year-20` (`recalculate_skill_metrics.py:287-292,334-339`).
+- **N2:** the PP4 gap-detector test must assert a per-lead gap (one missing issue among four) is
+  detected. **N4 (impl hint):** the cleanest seasonal lead source is the raw row's own
+  `horizon_value` (already `3/2/1/0` from the importer), preferred over re-deriving from issue month.
+
+## Cross-plan cleanup reconciliation (MF-A) -- supersedes longforecast P3 ensemble handling
+
+The cleanup in `doc/plans/working/longforecast_hv_convention_plan.md` P3 was designed pre-regen and now
+**conflicts** with the PP0 regenerate decision:
+
+- P3 step 2 `DELETE ... horizon_type='QUARTER' AND model_type NOT IN ('LR_BASE','LR_SM')` would delete
+  the EM/Naive/Skilled **ensembles that PP0 chose to regenerate** and PP7 writes into `QUARTER hv1`.
+- Old vs new rows mostly **coexist, not overwrite** (old: `hv1`/`date=target-start`; new: per-issue
+  `hv`/`date=issue`), so a cleanup is still required -- but on a **different row population** than P3
+  measured, and its pre-regen counts (2,890 / ~41,225 / 10,665) are now **stale**.
+- Strategy conflict: longforecast SIGNOFF set Dataset B = "delete deprecated + re-stamp LR"; PP0
+  Decision 3 = "regenerate the EM/Naive/Skilled ensembles". **PP0 regenerate wins for the ensemble
+  model class.**
+
+Resolution (authoritative; longforecast P3 ensemble handling is superseded by this):
+
+1. **Cleanup is re-derived POST-regen**, against a fresh aggregate snapshot, scoped to the
+   **old-convention signature** so predicates can never match regenerated rows:
+   - season: old ensemble rows at `hv1` with `date == valid_from` (target-season start) -- new rows
+     have `date == issue` and per-issue `hv`;
+   - quarter: old ensemble orphans at `hv2/3/4`, and old calendar-`hv1` rows whose `date == quarter
+     start` distinct from the regenerated product.
+2. **Ordering decided**: regen-first is allowed ONLY with old-signature-specific deletes (option b);
+   the current blanket `model_type NOT IN (...)` delete is NOT safe post-regen. (Alternative: delete
+   old ensembles BEFORE regen, then let recalc write only the new convention.)
+3. **Raw-LR carve-out (stated once, here):** P-PIPE never moves raw `LR_BASE`/`LR_SM` rows; the
+   re-stamp of historical raw LR `hv2/3/4 -> hv1` is a **cleanup op** (longforecast P3 step 3), not a
+   P-PIPE op -- compatible, but owned by the cleanup plan.
+4. **Counts re-measured**: the longforecast P3 collision/row counts must be re-verified against the
+   post-regen state before any delete; the pre-regen numbers are recorded as stale.
+
+PP7 cleanup gate is therefore: regen -> aggregate-verify new-convention rows exist for the full date
+range -> **re-derive + reviewer-approve old-signature-scoped delete predicates** -> execute. The
+longforecast cleanup plan now carries a banner pointing here.
+
+## Target Convention
+
+`long_forecasts.horizon_value = operational_month_lead_time` from the deployment's long-term config
+for that product.
+
+- Quarter: one product per deployment. Kyrgyz -> `hv1`; Tajik -> `hv0`.
+- Season: one product per issue month. Kyrgyz Jan/Feb/Mar/Apr -> `hv3/hv2/hv1/hv0`; Tajik April-only
+  -> `hv0`.
+- Seasonal B branch: four distinct ensemble products per target season, computed independently per
+  issue. The seasonal issue date is the `long_forecasts.date`; target season coverage remains in
+  `valid_from` / `valid_to`.
+- Seasonal skill: per-lead. `season_in_year` / `horizon_in_year` is the lead (`3/2/1/0`) for
+  `horizon_type="season"` in skill metrics and joins.
+
+Use sentinel station codes only in tests and docs. Any DB verification must be aggregate-only.
+
+## Findings
+
+### 1. Issue identity, grouping, and write semantics
+
+Evidence:
+
+- Seasonal reader projection omits issue `date` and `horizon_value`:
+  `apps/postprocessing_forecasts/src/data_reader.py:37-52`.
+- Seasonal API reads are unfiltered by lead:
+  `apps/postprocessing_forecasts/src/data_reader.py:1026-1074`, `:2726`, `:2869`, `:2988-3009`.
+- `_normalize_combined_forecasts(..., "season")` derives only the target-season year, sets
+  `season_in_year = 1`, and drops `horizon_value`: `data_reader.py:3059-3080`.
+- Seasonal ensemble grouping omits issue/lead:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:553-558`.
+- Operational and maintenance seasonal dedup omit issue/lead:
+  `apps/postprocessing_forecasts/postprocessing_operational_long_term.py:200-212`,
+  `apps/postprocessing_forecasts/postprocessing_maintenance_long_term.py:330-343`.
+- Seasonal writer computes target `valid_from` / `valid_to`, hardcodes `horizon_value = 1`, and writes
+  `date = valid_from`: `apps/postprocessing_forecasts/src/api_writer.py:1052-1079`.
+
+Decision:
+
+- Preserve `date` and `horizon_value` from raw seasonal API rows in postprocessing normalized frames.
+  Store the issue identity under a clear app-side column such as `issue_date` plus `season_lead`, or
+  preserve `date` directly until the writer builds API records.
+- For seasonal B products, ensemble time groups and dedup keys must include the lead/issue dimension:
+  at minimum `["season_year", "season_in_year", "code"]` for calculation and
+  `["season_year", "season_in_year", "code", "model_short"]` for dedup, with `date` preserved per
+  group.
+- The writer must use each row's issue date for API `date` and use the per-row resolved lead for
+  API `horizon_value`. It must not replace the issue date with target `valid_from`.
+
+### 2. Per-lead seasonal skill representation
+
+Evidence:
+
+- Skill writer selects `season_in_year` as the seasonal API `horizon_in_year` source:
+  `apps/postprocessing_forecasts/src/api_writer.py:475-487`, `:629-636`.
+- Its upsert-key comment and implementation dedup on `code`, `model_type`, `_date`, and
+  `season_in_year`: `api_writer.py:585-595`.
+- Current seasonal skill groups by `season_in_year`, `code`, `model_short` but computes only one
+  lead because readers/calculation set `season_in_year = 1`:
+  `apps/postprocessing_forecasts/src/skill_metrics.py:2060-2087`, `:2115-2163`.
+- The ensemble skill join already keys on `[period_col, "code", "model_short"]`:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:593-608`, `:687-703`.
+
+Decision:
+
+- No schema change. Update seasonal forecast frames so `season_in_year` is the resolved lead before
+  seasonal skill calculation. Then the existing skill key and ensemble join shape can separate Jan,
+  Feb, Mar, and Apr lead skill.
+- Update seasonal observations/forecast merge for skill calculation to merge target-season
+  observations to each lead-specific forecast row by `["code","season_year"]`, while metrics group by
+  `["season_in_year","code","model_short"]`. This gives per-lead skill while reusing the same target
+  observed season.
+- Writer dates for seasonal skill may remain target-season-start dates; `horizon_in_year` separates
+  the lead in the DB key. Do not introduce a service-owned `horizon_value` column for skill metrics.
+
+### 3. Lead/issue resolver home and config contract
+
+Evidence:
+
+- Long-term forecast configs load from `ieasyforecast_configuration_path` plus
+  `ieasyhydroforecast_ml_long_term_configuration`:
+  `apps/long_term_forecasting/config_forecast.py:37-65`.
+- The authoritative lead is `get_operational_month_lead_time()`:
+  `apps/long_term_forecasting/config_forecast.py:230-231`; horizon type is
+  `get_horizon_type()` at `:269-276`.
+- Operational long-term writes already use this lead:
+  `apps/long_term_forecasting/run_forecast.py:409-410`.
+- Postprocessing entry points currently call `sl.load_environment()` and load only station-selection
+  config: `apps/postprocessing_forecasts/postprocessing_operational_long_term.py:56-83`,
+  `apps/postprocessing_forecasts/recalculate_skill_metrics.py:111-119`, `:197-203`.
+- The existing season-month contract is an env-var helper in app code:
+  `apps/postprocessing_forecasts/src/aggregation.py:48-66`.
+
+Decision:
+
+- Add the resolver in `apps/iEasyHydroForecast` as shared app-owned functionality, or add a small
+  env-var/config contract there that each module reads. Do not define it in `forecast_dashboard` or
+  import dashboard code from postprocessing.
+- Contract:
+  - Config root: `ieasyforecast_configuration_path`.
+  - Long-term config directory: `ieasyhydroforecast_ml_long_term_configuration`.
+  - Quarter mode: `quarter`.
+  - Seasonal issue-month mapping: January -> `seasonal_january`, February -> `seasonal_february`,
+    March -> `seasonal_march`, April -> `seasonal_april`.
+  - Lead source: the JSON field `operational_month_lead_time`.
+  - Deployment awareness: supported modes come from
+    `ieasyhydroforecast_ml_long_term_supported_modes`; if a deployment lacks Jan/Feb/Mar seasonal
+    modes, the resolver must not synthesize them.
+- Missing/malformed config should fail loudly for writes and tests. Readers may return empty with a
+  logged warning only where existing dashboard behavior requires graceful degradation.
+
+### 4. Quarter half
+
+Evidence:
+
+- Quarterly reader/ensemble/dedup keys retain calendar quarter:
+  `data_reader.py:2675-2680`, `:2816-2819`;
+  `ensemble_calculator.py:526-531`;
+  `postprocessing_operational_long_term.py:164-179`;
+  `postprocessing_maintenance_long_term.py:276-285`.
+- Quarterly writer currently sets `horizon_value = quarter_in_year`:
+  `apps/postprocessing_forecasts/src/api_writer.py:1043-1051`.
+- The resolved convention says quarter is one config-lead product per deployment, not calendar
+  quarter encoded in `horizon_value`.
+
+Decision:
+
+- Quarter is a small writer/reader change compared with season. Set API `horizon_value` to the
+  resolved deployment quarter lead while preserving `year`, `quarter_in_year`, `valid_from`, and
+  `valid_to`.
+- Keep quarter grouping/dedup keys as `year + quarter_in_year + code (+ model_short)`; do not add
+  lead to those keys unless needed for API read filtering metadata.
+
+### 5. Read-side lockstep and consumers
+
+Evidence:
+
+- `_read_long_forecasts_api` and `_read_long_combined_forecasts_api` do not pass `horizon_value` to
+  the API: `apps/postprocessing_forecasts/src/data_reader.py:1026-1074`, `:2956-3022`.
+- Dashboard quarter getter defaults to `horizon_value=1`:
+  `apps/forecast_dashboard/src/db.py:600-609`.
+- Dashboard monthly data hardcodes quarter `hv1`: `apps/forecast_dashboard/src/db.py:806`.
+- Dashboard quarter horizon implicitly gets `hv1` through the default:
+  `apps/forecast_dashboard/src/db.py:867`.
+- Seasonal dashboard getter is unfiltered: `apps/forecast_dashboard/src/db.py:648-660`.
+- Bulletin code hardcodes quarter `hv1` and uses unfiltered season reads:
+  `apps/forecast_dashboard/dashboard/bulletin_manager.py:168`, `:186`, `:393`, `:411`, `:495`.
+- Long-term validation currently checks only monthly long forecasts and monthly skill metrics:
+  `apps/validate_pipeline/validate_pipeline.py:493-522`.
+
+Decision:
+
+- Postprocessing readers, dashboard getters, monthly dashboard enrichment, quarter dashboard horizon,
+  seasonal dashboard horizon, and bulletin paths must resolve and pass the same deployment/issue
+  lead used by writers.
+- Add a validation presence assertion for quarter and season buckets so an empty regenerated bucket
+  fails CI. The assertion must be aggregate/presence only and must not log real station codes.
+
+### 6. Two-writer alignment
+
+Evidence:
+
+- Long-term forecasting already reads/writes dependencies and forecast rows using config lead:
+  `apps/long_term_forecasting/run_forecast.py:269`, `:409-410`.
+- MIG-008 records that the from-file importer also stamps the config lead and that service code is
+  hv-agnostic:
+  `doc/plans/issues/mid_prio_gi_draft_migration_long_forecast_quarter_season_horizon_value.md`.
+- Postprocessing writer currently diverges for quarter/season:
+  `apps/postprocessing_forecasts/src/api_writer.py:1043-1067`.
+
+Decision:
+
+- Raw LR rows and EM / Naive Mean / Skilled Mean rows must land in the same natural-key bucket for
+  the same product:
+  `(horizon_type, horizon_value, code, date, model_type, valid_from, valid_to)`.
+- Seasonal B alignment means the ensemble writer must retain the raw issue `date` and use that issue
+  lead. For Kyrgyz Jan/Feb/Mar/Apr target-season products, raw LR and ensemble rows coexist at
+  `hv3/hv2/hv1/hv0` respectively.
+
+### 7. Regenerate-then-clean sequence
+
+Evidence:
+
+- `recalculate_skill_metrics.py` supports `QUARTERLY` and `SEASONAL`:
+  `apps/postprocessing_forecasts/recalculate_skill_metrics.py:91-92`, with quarter work at `:285-330`
+  and season work at `:332-371`.
+- Its default history window is `current_year - 20` unless `SAPPHIRE_RECALC_START_YEAR` is set:
+  `apps/postprocessing_forecasts/recalculate_skill_metrics.py:239-246`, `:286-293`, `:333-340`.
+- The recurring bimonthly long-term skill recalc wrapper runs `MONTHLY`, `QUARTERLY`, and `SEASONAL`:
+  `bin/bimonthly_long_term_skill_metrics_recalculation.sh:100-107`; yearly recalc delegates to the
+  same helper: `bin/yearly_skill_metrics_recalculation.sh:98-107`.
+- The shared Docker helper forwards `SAPPHIRE_PREDICTION_MODE` but not
+  `SAPPHIRE_RECALC_START_YEAR`: `bin/utils/run_skill_metrics_recalc.sh:72-87`.
+
+Decision:
+
+- No new cron. The recurring bimonthly/yearly drivers remain the forward maintenance path.
+- The one-time deep history recalc must explicitly pass `SAPPHIRE_RECALC_START_YEAR=2000` into the
+  deployed postprocessing runtime for each deployment and each mode:
+  - `SAPPHIRE_RECALC_START_YEAR=2000 SAPPHIRE_PREDICTION_MODE=QUARTERLY uv run recalculate_skill_metrics.py`
+  - `SAPPHIRE_RECALC_START_YEAR=2000 SAPPHIRE_PREDICTION_MODE=SEASONAL uv run recalculate_skill_metrics.py`
+- If operators use the existing Docker wrapper for the one-time run, they must first ensure the
+  helper forwards `SAPPHIRE_RECALC_START_YEAR`; otherwise use an explicit container command with
+  `-e SAPPHIRE_RECALC_START_YEAR=2000`. Do not treat the current wrapper invocation alone as a
+  full-history gate.
+- Cleanup P3/P4 is blocked until aggregate counts prove the new-convention EM / Naive Mean / Skilled
+  Mean rows exist for the full expected date range.
+
+### 8. Tests affected
+
+Required coverage:
+
+- Shared resolver tests with synthetic configs and supported-mode lists.
+- Writer tests: quarter config-lead; seasonal per-issue leads; seasonal writer keeps issue date.
+- Reader tests: quarter and season API calls pass hv filters; seasonal normalization preserves
+  issue date and lead.
+- Ensemble/dedup tests: four seasonal issues in the same `season_year` produce four independent
+  ensemble products; no duplicate fan-out from unfiltered seasonal readers.
+- Skill tests: seasonal skill rows and skill-to-ensemble joins key on lead.
+- Dashboard tests: Kyrgyz quarter `hv1`, Tajik quarter `hv0`, seasonal issue lead selection, monthly
+  quarter-card paths, bulletin paths.
+- Validation tests: empty quarter/season bucket fails presence check.
+
+Verification commands for implementation acceptance:
+
+- `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh postprocessing_forecasts`
+- Dashboard tests touched by PP5/PP6 in their normal app test command.
+- Validate-pipeline focused tests for the new long-term quarter/season presence guard.
+
+## Phased Plan
+
+### PP0 - Decisions Recorded and Feasibility Gate
+
+**Goal**: Freeze PP0 B-branch decisions and the no-schema-change per-lead skill verdict before any
+implementation agent starts.
+
+**Files**:
+
+- `doc/prod/ppipe_seasonal_ensemble_decisions_request.md`
+- `doc/plans/working/ppipe_postprocessing_ensemble_hv_plan.md`
+- No code files.
+- No `sapphire/services/**`.
+
+**Depends-on**: none.
+
+**Agents**: 1 planner/reviewer agent; no implementation.
+
+**Acceptance criteria**:
+
+- PP0 answers are recorded as B: four distinct seasonal ensemble products per target season, computed
+  independently per issue.
+- Per-lead skill feasibility is recorded as no service schema change, using seasonal
+  `horizon_in_year` / `season_in_year` as lead.
+- Any reviewer objection to reusing `horizon_in_year` is captured as a service-owner coordination
+  blocker before PP1 starts.
+
+### PP1 - Shared Lead and Issue Resolver
+
+**Goal**: Add shared app-owned resolution of quarter/season lead and seasonal issue mode, using the
+long-term config JSONs and supported-mode list.
+
+**Files**:
+
+- `apps/iEasyHydroForecast/` shared helper module or `setup_library.py`-adjacent helper.
+- Tests under `apps/iEasyHydroForecast/tests/`.
+- Import call sites only as needed in later phases.
+- No `sapphire/services/**`.
+
+**Depends-on**: PP0.
+
+**Agents**: 1 implementation agent.
+
+**Acceptance criteria**:
+
+- Resolver reads `ieasyforecast_configuration_path` and
+  `ieasyhydroforecast_ml_long_term_configuration`.
+- Resolver maps quarter -> `quarter` and issue months Jan/Feb/Mar/Apr ->
+  `seasonal_january/february/march/april`.
+- Resolver reads `operational_month_lead_time` from the selected JSON.
+- Resolver respects `ieasyhydroforecast_ml_long_term_supported_modes`; unsupported seasonal issues
+  are reported and not synthesized.
+- Missing or malformed config fails loudly for write/recalc paths.
+- Unit tests use temporary synthetic config files and sentinel values only.
+
+### PP2 - Seasonal Identity Preservation in Postprocessing Readers
+
+**Goal**: Preserve raw seasonal issue identity and lead before any ensemble or skill work consumes
+seasonal frames.
+
+**Files**:
+
+- `apps/postprocessing_forecasts/src/data_reader.py`
+- Tests under `apps/postprocessing_forecasts/tests/` for seasonal data reader and integration paths.
+- Shared resolver from PP1.
+- No `sapphire/services/**`.
+
+**Depends-on**: PP1.
+
+**Agents**: 1 implementation agent.
+
+**Acceptance criteria**:
+
+- `_SEASONAL_FC_COLS` or equivalent normalized output includes issue `date` and a lead field
+  (`season_in_year` as lead and/or explicit `season_lead`) through the ensemble boundary.
+- `_read_long_forecasts_api` and `_read_long_combined_forecasts_api` can pass `horizon_value` for
+  quarter/season reads.
+- Seasonal normalization no longer hardcodes all rows to `season_in_year = 1`; it maps raw
+  `horizon_value` / issue date to the lead.
+- Seasonal readers dedup by lead/issue where needed and do not feed duplicate issue rows into
+  ensemble creation.
+- Tests prove Jan/Feb/Mar/Apr issue rows for one `season_year` survive as four products.
+
+### PP3 - Per-lead Seasonal Skill Calculation and Persistence
+
+**Goal**: Recalculate and persist seasonal skill per lead, with skill-to-ensemble joins keying on
+that lead.
+
+**Files**:
+
+- `apps/postprocessing_forecasts/src/skill_metrics.py`
+- `apps/postprocessing_forecasts/src/api_writer.py` for skill writer behavior if needed.
+- `apps/postprocessing_forecasts/src/data_reader.py` for skill reader normalization if needed.
+- `apps/postprocessing_forecasts/recalculate_skill_metrics.py` only if recalc orchestration needs
+  explicit lead context.
+- Tests under `apps/postprocessing_forecasts/tests/`.
+- No `sapphire/services/**`.
+
+**Depends-on**: PP2.
+
+**Agents**: 1 implementation agent.
+
+**Acceptance criteria**:
+
+- Seasonal skill stats include separate rows for lead `3/2/1/0` when those issue products exist.
+- Skill metric API records use `horizon_in_year=lead` for season; no service schema change.
+- Seasonal skill dedup keeps separate leads for the same code/model/date.
+- Seasonal ensemble skill joins include lead via `season_in_year`.
+- Tests cover different MAE/skill values by lead and prove the Jan lead does not use April lead
+  weights.
+
+### PP4 - Ensemble, Gap, Dedup, and Writers
+
+**Goal**: Produce and write independent quarter/season ensemble products under the config-lead
+convention.
+
+**Files**:
+
+- `apps/postprocessing_forecasts/src/ensemble_calculator.py`
+- `apps/postprocessing_forecasts/src/gap_detector.py`
+- `apps/postprocessing_forecasts/src/api_writer.py`
+- `apps/postprocessing_forecasts/src/file_writer.py` if sorting/diagnostics require lead columns.
+- `apps/postprocessing_forecasts/postprocessing_operational_long_term.py`
+- `apps/postprocessing_forecasts/postprocessing_maintenance_long_term.py`
+- Tests under `apps/postprocessing_forecasts/tests/`.
+- No `sapphire/services/**`.
+
+**Depends-on**: PP2, PP3.
+
+**Agents**: 1 implementation agent.
+
+**Acceptance criteria**:
+
+- Quarter writer uses resolved config lead, not `quarter_in_year`.
+- Seasonal writer uses per-row issue lead, not hardcoded `1`.
+- Seasonal writer preserves issue `date` as API `date`; `valid_from` / `valid_to` continue to describe
+  the target season.
+- Seasonal ensemble groupby and dedup include lead/issue, producing four independent Kyrgyz products
+  for Jan/Feb/Mar/Apr when all exist.
+- Gap detection checks missing seasonal ensembles per lead, not only per target season.
+- Raw LR and EM / Naive Mean / Skilled Mean rows land in the same hv/date/valid range buckets for
+  each product.
+- Monthly PP-032 behavior remains unchanged.
+
+### PP5 - Postprocessing Read Lockstep
+
+**Goal**: Make postprocessing read paths deployment/lead-aware so maintenance, operational, and recalc
+jobs read the same buckets written by PP4.
+
+**Files**:
+
+- `apps/postprocessing_forecasts/src/data_reader.py`
+- `apps/postprocessing_forecasts/postprocessing_operational_long_term.py` if explicit issue selection
+  is needed.
+- `apps/postprocessing_forecasts/postprocessing_maintenance_long_term.py` if explicit issue selection
+  is needed.
+- `apps/postprocessing_forecasts/recalculate_skill_metrics.py` if full-history recalc needs explicit
+  quarter/season mode loops.
+- Tests under `apps/postprocessing_forecasts/tests/`.
+- No `sapphire/services/**`.
+
+**Depends-on**: PP4.
+
+**Agents**: 1 implementation agent.
+
+**Acceptance criteria**:
+
+- Quarter direct/latest/combined reads filter to deployment lead (`hv1` Kyrgyz, `hv0` Tajik) without
+  losing `quarter_in_year`.
+- Seasonal direct/latest/combined reads filter by the selected supported issue lead or deliberately
+  iterate supported issue leads for recalc/full-history work.
+- Seasonal maintenance gap-fill cannot collapse Jan/Feb/Mar/Apr products into one row.
+- Tests assert API client calls include expected `horizon_value` filters and expected issue selection.
+
+### PP6 - Dashboard and Validation Consumers
+
+**Goal**: Update read-side app consumers so dashboards, bulletins, and CI presence checks use the new
+quarter/season buckets immediately after regeneration.
+
+**Files**:
+
+- `apps/forecast_dashboard/src/db.py`
+- `apps/forecast_dashboard/dashboard/bulletin_manager.py`
+- `apps/forecast_dashboard/tests/test_db.py`
+- Bulletin/dashboard focused tests as needed.
+- `apps/validate_pipeline/validate_pipeline.py`
+- `apps/validate_pipeline/tests/` if present, or the existing validate-pipeline test location.
+- Shared resolver from PP1.
+- No `sapphire/services/**`.
+
+**Depends-on**: PP1, PP5.
+
+**Agents**: 1 implementation agent.
+
+**Acceptance criteria**:
+
+- `get_long_forecasts_quarter` no longer globally defaults every deployment to `hv1`; callers either
+  pass the resolved lead or the function resolves it.
+- Monthly dashboard enrichment, quarter dashboard data, and bulletin quarter paths stop hardcoding
+  `hv1`.
+- Seasonal dashboard and bulletin paths pass the selected issue lead instead of unfiltered
+  `horizon_type="season"`.
+- Tests cover Tajik quarter `hv0`, Kyrgyz quarter `hv1`, and Kyrgyz seasonal issue leads.
+- `validate_pipeline` Tier 1 long-term presence checks fail when expected quarter or season buckets
+  are empty after deployment/recalc.
+
+### PP7 - Verification, Deploy, Full-history Recalc, Then Cleanup Gate
+
+**Goal**: Verify implementation, deploy it, regenerate full-history quarter/season ensembles under
+the new convention, and only then unblock cleanup P3/P4.
+
+**Files**:
+
+- Code files changed in PP1-PP6.
+- Deployment/run notes if reviewer requests them.
+- `doc/plans/working/longforecast_hv_convention_plan.md` may be updated only to record the P-PIPE
+  completion gate; no DB SQL changes in this implementation phase.
+- No `sapphire/services/**`.
+
+**Depends-on**: PP4, PP5, PP6.
+
+**Agents**: 1 verification/release agent.
+
+**Acceptance criteria**:
+
+- `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh postprocessing_forecasts` is green.
+- Dashboard tests touched by PP6 are green.
+- Validate-pipeline focused tests for quarter/season presence are green.
+- Reviewer confirms no `sapphire/services/**` files changed.
+- Deployment sequence is explicit per deployment:
+  1. Deploy P-PIPE code.
+  2. Run one-time deep recalc for quarter and season with `SAPPHIRE_RECALC_START_YEAR=2000` passed
+     into the runtime.
+  3. Run aggregate-only verification.
+  4. Only then allow cleanup P3/P4 from `longforecast_hv_convention_plan.md`.
+- Aggregate verification distinguishes model classes:
+  - Raw LR rows: already in config-lead buckets from long-term forecasting/from-file importer; P-PIPE
+    must not move or rewrite them.
+  - EM / Naive Mean / Skilled Mean rows: regenerated by postprocessing recalc into Kyrgyz quarter
+    `hv1`, Tajik quarter `hv0`, Kyrgyz season `hv3/hv2/hv1/hv0` by issue, and Tajik season `hv0`.
+- Cleanup P3/P4 is not authorized until regenerated-row counts cover the expected full-history date
+  range and obsolete old-hv rows are identified by reviewed aggregate/dry-run counts.
+
+## Regeneration and Cleanup Ordering
+
+1. Implement and test PP1-PP6 in `apps/`.
+2. Reviewer pass with special attention to seasonal issue identity, per-lead skill, and read/write
+   lockstep.
+3. Deploy P-PIPE per deployment.
+4. Run one-time full-history recalc per deployment:
+   - `SAPPHIRE_RECALC_START_YEAR=2000 SAPPHIRE_PREDICTION_MODE=QUARTERLY uv run recalculate_skill_metrics.py`
+   - `SAPPHIRE_RECALC_START_YEAR=2000 SAPPHIRE_PREDICTION_MODE=SEASONAL uv run recalculate_skill_metrics.py`
+5. If using Docker, verify `SAPPHIRE_RECALC_START_YEAR=2000` is actually passed into the container.
+   The current `bin/utils/run_skill_metrics_recalc.sh:72-87` helper does not pass it.
+6. Run aggregate-only acceptance queries for raw LR versus EM / Naive Mean / Skilled Mean buckets; do
+   not expose real station codes or discharge values in plan artifacts.
+7. Proceed to cleanup P3/P4 from `doc/plans/working/longforecast_hv_convention_plan.md` only after
+   owner sign-off and reviewed dry-run counts.
+
+## Dependency Graph
+
+```json
+{
+  "phases": {
+    "PP0": { "depends_on": [], "parallel_agents": 1, "type": "planner_gate" },
+    "PP1": { "depends_on": ["PP0"], "parallel_agents": 1 },
+    "PP2": { "depends_on": ["PP1"], "parallel_agents": 1 },
+    "PP3": { "depends_on": ["PP2"], "parallel_agents": 1 },
+    "PP4": { "depends_on": ["PP2", "PP3"], "parallel_agents": 1 },
+    "PP5": { "depends_on": ["PP4"], "parallel_agents": 1 },
+    "PP6": { "depends_on": ["PP1", "PP5"], "parallel_agents": 1 },
+    "PP7": { "depends_on": ["PP4", "PP5", "PP6"], "parallel_agents": 1 },
+    "longforecast_cleanup_P3": {
+      "depends_on": [
+        "PP7",
+        "deploy",
+        "quarterly_seasonal_recalc_start_year_2000",
+        "aggregate_verify_new_convention_rows",
+        "owner_signoff_reviewed_dry_run_counts"
+      ],
+      "parallel_agents": 1,
+      "external_plan": "doc/plans/working/longforecast_hv_convention_plan.md#P3"
+    },
+    "longforecast_cleanup_P4": {
+      "depends_on": [
+        "longforecast_cleanup_P3",
+        "PP7",
+        "aggregate_verify_new_convention_rows",
+        "owner_signoff_reviewed_dry_run_counts"
+      ],
+      "parallel_agents": 1,
+      "external_plan": "doc/plans/working/longforecast_hv_convention_plan.md#P4"
+    }
+  }
+}
+```

--- a/doc/plans/working/two_model_ensemble_plan.md
+++ b/doc/plans/working/two_model_ensemble_plan.md
@@ -1,0 +1,423 @@
+# P-PIPE Follow-on: Two-model Quarterly/Seasonal Ensemble Plan
+
+Branch: `develop_ppipe_ensemble_hv` (P-PIPE / PR #382 follow-on)
+Status: plan only; no implementation, no DB writes.
+
+Scope: `apps/` and documentation. Do not edit `sapphire/services/**`. This
+follow-on is a behavior change, not just the P-PIPE horizon-value convention, so
+it should be considered as a separate PR from PR #382 unless the reviewer asks
+to fold it in.
+
+Use sentinel station codes only in operational evidence. DB work is
+aggregate-only until an approved cleanup execution step.
+
+## Review outcome (2026-06-23): GO-WITH-CHANGES -- integrated
+
+A critical review verified the core (both EM paths, durability mechanism,
+quarter/season-only scoping). Decisions + fixes folded in:
+
+- **M1 (decided, owner): leave Naive Mean / Skilled Mean as-is; de-skill-gate
+  ONLY EM.** EM must reliably = `mean(LR_Base, LR_SM)`. Do NOT stop writing Naive
+  Mean / Skilled Mean in this PR (additive, no dashboard-visible product removal;
+  EM and Naive Mean will be numerically identical for quarter/season -- accepted).
+  This is now a hard prerequisite of P3 (resolved).
+- **M2 (Must): change only EM's FORMATION gate, never its downstream skill
+  computation.** The recalc EM path computes EM-row skill (CRPS/PIT/sharpness,
+  `skill_metrics.py:2238-2291`) and concats into skill_stats -- keep that intact,
+  or we re-starve the very skill displays this work populates. The P3 agent prompt
+  must state this explicitly.
+- **S1: the P2 reader filter is THE durable fix.** Quarter raw is synthesized at
+  read time from MONTH rows (`source=aggregated_from_monthly`), so the
+  `long_forecasts` QUARTER-raw deprecated DELETE is likely a **0-row no-op = success,
+  not failure**. Real physical cleanup targets: (a) `skill_metrics` QUARTER
+  deprecated rows (stored), (b) stale ensemble rows in both tables.
+- **S2: filter ALL FOUR aggregated readers** -- add `read_seasonal_forecasts`
+  (`data_reader.py:2711`) + `read_latest_seasonal_forecasts` (`:2878`) to P2, not
+  just the two quarter readers.
+- **S3: put the filter in the READER, not `aggregation.py`** (the reader combines
+  monthly-aggregated + direct-quarter sources; `aggregate_monthly_fc_to_quarterly`
+  misses the direct-quarter source). Drop the `aggregation.py` option from P2.
+- **S4: P4 runbook must reference + supersede by name** the P-PIPE plan's MF-A
+  `DELETE ... horizon_type='QUARTER' AND model_type NOT IN ('LR_BASE','LR_SM')`
+  statement, so an operator doesn't nuke the regenerated EM.
+- **N1:** "both LR present or no EM" matches current behavior (`is_multi_model_composition`
+  drops single-model groups today); keep it as the conservative default, but note
+  the continuity gap (a station with only one LR gets no quarter/season ensemble).
+  **N3:** P1 must test the **recalc** EM path (not just operational), since it must
+  match operational for full-history regen.
+
+## Findings
+
+### 1. Current quarter/season ensemble formation
+
+Quarterly and seasonal ensemble forecasts use the shared
+`_create_aggregated_ensemble_forecasts()` path:
+
+- Quarter calls it with `period_col="quarter_in_year"` and
+  `time_group_cols=["year", "quarter_in_year", "code"]`:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:506-531`.
+- Season calls it with `period_col="season_in_year"` and
+  `time_group_cols=["season_year", "season_in_year", "code"]`:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:534-558`.
+- The function first normalizes `forecasted_discharge`, copies the input to
+  `joint`, and excludes baseline rows `{"EM", "Naive Mean", "Skilled Mean"}`:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:577-590`.
+
+Current EM is not a simple LR mean. It is a threshold-filtered mean:
+
+- EM calls `filter_for_highly_skilled_forecasts(skill_stats)`:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:592-594`.
+- It inner-joins forecasts to the filtered skill keys
+  `[period_col, "code", "model_short"]`, drops baseline rows, and drops NaN
+  forecasts: `apps/postprocessing_forecasts/src/ensemble_calculator.py:603-610`.
+- It averages `forecasted_discharge` and every available quantile column:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:613-630`.
+- It writes `composition`, sets `model_short="EM"`, then discards any group
+  whose composition is not multi-model:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:631-638`.
+
+The skill gate is strict:
+
+- Threshold defaults are `sdivsigma < 0.6`, `nse > 0.8`, and
+  `accuracy > 0.8`: `apps/postprocessing_forecasts/src/skill_metrics.py:23-59`.
+- Threshold filtering reads env overrides, allows `"False"` to disable a metric,
+  and applies `>` for higher-is-better metrics and `<` otherwise:
+  `apps/postprocessing_forecasts/src/skill_metrics.py:1673-1699`.
+
+This explains why a two-model LR ensemble does not reliably form: both
+`LR_Base` and `LR_SM` must pass every skill threshold for the same
+period/code/lead. If either fails, the inner join leaves one or zero qualifying
+models, and the multi-model composition filter discards the EM row.
+
+Minimal behavior change for operational EM:
+
+- For quarter/season only, define the candidate pool as available non-null
+  `LR_Base` + `LR_SM` rows and compute EM as the equal-weight mean of those two
+  rows, independent of the high-skill threshold gate.
+- Keep the existing two-model requirement: if either LR row is missing or NaN
+  for a target group, do not fabricate EM.
+- Apply the same rule in both operational ensemble creation and
+  full-history recalculation. Recalculation has its own aggregated EM path that
+  also filters skill and discards single-model groups:
+  `apps/postprocessing_forecasts/src/skill_metrics.py:2199-2236`.
+
+### 2. EM, Naive Mean, and Skilled Mean semantics with two models
+
+Current semantics:
+
+- EM: threshold-filtered unweighted mean of qualifying models:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:592-638`.
+- Naive Mean: unweighted average of all non-baseline models, no skill filter:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:738-777`.
+- Skilled Mean: inverse-MAE weighted mean of threshold-filtered models:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:662-735`.
+
+With the owner-confirmed quarter/season input set reduced to `LR_Base` and
+`LR_SM`:
+
+- Recommended EM: equal-weight mean of `LR_Base` and `LR_SM`.
+- Naive Mean becomes identical to EM if its input pool is also only
+  `LR_Base` and `LR_SM`.
+- Skilled Mean remains distinct only when both LR models pass the skill gate
+  and have usable MAE; otherwise it will still disappear under current logic.
+
+Owner/modeller decision point:
+
+- Keep all three rows for continuity, accepting that EM and Naive Mean are
+  redundant for quarter/season under a two-model-only pool.
+- Or keep EM as the official simple LR mean and drop/stop writing Naive Mean and
+  Skilled Mean for quarter/season to avoid duplicate or inconsistently missing
+  products.
+
+Planner recommendation: make EM the required acceptance target and treat Naive
+Mean / Skilled Mean as an explicit modeller decision before implementation. Do
+not silently change their public meaning.
+
+### 3. Horizon scope
+
+This change must be scoped to quarter/season only.
+
+Monthly ensembles use a separate implementation:
+
+- `create_monthly_ensemble_forecasts()` builds monthly groups and includes
+  `horizon_value` when present for PP-032:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:222-281`.
+- Monthly EM still uses the threshold-filtered skill pool:
+  `apps/postprocessing_forecasts/src/ensemble_calculator.py:283-333`.
+- Monthly Skilled Mean and Naive Mean remain the existing 1/MAE and all-model
+  implementations: `apps/postprocessing_forecasts/src/ensemble_calculator.py:334-349`.
+
+Do not change monthly behavior or its full model set. The aggregate evaluation
+confirms monthly currently includes the full long-term model population:
+`doc/plans/working/forecast_skill_eval_results.md:25-32`.
+
+### 4. Deprecated-model cleanup scope
+
+Quarterly forecasts are built from monthly forecasts:
+
+- `read_quarterly_forecasts()` aggregates monthly forecasts with
+  `aggregate_monthly_fc_to_quarterly()` and also reads direct quarterly API
+  forecasts: `apps/postprocessing_forecasts/src/data_reader.py:2621-2672`.
+- `aggregate_monthly_fc_to_quarterly()` groups by
+  `["code", "year", "quarter_in_year", "model_short"]`, so all monthly model
+  types become quarterly model rows unless filtered:
+  `apps/postprocessing_forecasts/src/aggregation.py:217-257`.
+
+Therefore the code change must prevent re-creation of deprecated raw quarter
+rows during recalc. A DB delete alone is not durable.
+
+Deprecated quarter model inputs:
+
+- Drop for `horizon_type=QUARTER`: `GBT`, `LR_SM_DT`, `LR_SM_ROF`, `MC_ALD`,
+  `SM_GBT`, `SM_GBT_LR`, `SM_GBT_NORM` / app spelling `SM_GBT_Norm`.
+- Keep: `LR_Base`, `LR_SM`.
+
+Season check:
+
+- Current aggregate evaluation shows season already has only `LR_Base` and
+  `LR_SM`: `doc/plans/working/forecast_skill_eval_results.md:25-32` and
+  `doc/plans/working/forecast_skill_eval_results.md:143-148`.
+- Still include a dry-run count for the seven deprecated models under
+  `horizon_type=SEASON`; if nonzero, delete them under the same policy after
+  reviewer approval.
+
+Cleanup tables and predicates:
+
+- `long_forecasts`: delete deprecated raw model rows for
+  `horizon_type IN ('QUARTER', 'SEASON')`, scoped to the seven deprecated model
+  labels after confirming exact DB enum/storage labels.
+- `skill_metrics`: delete matching skill rows for the same horizon/model set so
+  stale skill cannot feed downstream displays or future calculations.
+- Old ensemble rows (`EM` / `ENSEMBLE_MEAN`, `Naive Mean` / `NAIVE_MEAN`,
+  `Skilled Mean` / `SKILLED_MEAN`) should be regenerated under the new
+  semantics. Do not preserve old 9-model or skill-gated quarter/season ensemble
+  rows as authoritative.
+
+Model label caution:
+
+- App write mapping sends long-term app labels such as `LR_Base`, `LR_SM`, and
+  `SM_GBT_Norm`: `apps/postprocessing_forecasts/src/api_writer.py:20-44`.
+- Existing P-PIPE runbook examples refer to DB enum names such as
+  `ENSEMBLE_MEAN`, `NAIVE_MEAN`, and `SKILLED_MEAN`:
+  `doc/prod/ppipe_ensemble_hv_deploy_runbook.md:82-98`.
+- Dry-run counts must report the actual labels present before any cleanup
+  statement is approved.
+
+Checked-in aggregate evidence:
+
+- Quarter p8 pairs include all seven deprecated inputs plus LR models and
+  ensembles: `doc/plans/working/forecast_skill_eval_results.md:117-142`.
+- Season p8 pairs include only `LR_Base` and `LR_SM`:
+  `doc/plans/working/forecast_skill_eval_results.md:143-148`.
+- Aggregate pair totals by horizon are quarter `40305` and season `10880`:
+  `doc/plans/working/forecast_skill_eval_results.md:206-224`.
+
+### 5. MIG-008 / P-PIPE reconciliation
+
+This follow-on supersedes and clarifies the older Dataset B understanding:
+
+- P-PIPE PR #382 fixes quarter/season ensemble `horizon_value` placement,
+  seasonal issue threading, and per-lead skill.
+- This follow-on changes the quarter/season ensemble model policy: the seven
+  non-LR models are genuinely deprecated for quarter/season, EM is the simple
+  `LR_Base` + `LR_SM` mean, and old quarter/season ensemble rows must be
+  regenerated under that policy.
+- The P-PIPE plan already blocks old-hv cleanup until code is deployed,
+  full-history recalc runs, and aggregate verification passes:
+  `doc/plans/working/ppipe_postprocessing_ensemble_hv_plan.md:126-159`.
+- The P-PIPE runbook currently says not to move raw `LR_BASE` / `LR_SM` rows as
+  part of P-PIPE: `doc/prod/ppipe_ensemble_hv_deploy_runbook.md:9-19`. This
+  follow-on is a separate cleanup policy: delete deprecated non-LR
+  quarter/season raw rows and regenerate LR-only ensembles.
+
+Cross-plan impact: any cleanup plan that deletes all non-LR quarter rows must
+not delete regenerated EM rows. The raw deprecated-model cleanup and stale
+ensemble cleanup need separate predicates.
+
+### 6. Sequence and re-validation
+
+Required order per deployment:
+
+1. Implement and deploy code that scopes quarter/season raw inputs and EM
+   calculation to `LR_Base` + `LR_SM`.
+2. Run local/sentinel validation that EM forms when both LR rows are present,
+   even when one or both LR skill rows fail current high-skill thresholds.
+3. Dry-run aggregate DB counts for deprecated raw rows and old ensemble rows in
+   `long_forecasts` and `skill_metrics`.
+4. Delete approved deprecated quarter/season raw rows and stale quarter/season
+   ensemble rows.
+5. Recalculate quarter and season full history per deployment.
+6. Verify EM equals the arithmetic mean of `LR_Base` and `LR_SM` at the
+   deployment's config-lead `horizon_value` per issue/quarter.
+7. Verify deprecated models are gone for quarter/season, monthly rows are
+   unchanged, and test suites are green.
+
+## Recommended Semantics
+
+Required:
+
+- Quarter/season EM = equal-weight mean of the two available non-null raw
+  inputs: `LR_Base` and `LR_SM`.
+- EM is not skill-gated for quarter/season.
+- EM forms only when both LR inputs exist in the same target group and both have
+  non-null forecast values.
+- Quantiles are averaged column-wise and monotonicity enforcement remains in
+  place.
+
+Decision needed:
+
+- Naive Mean: keep as the all-input mean, knowing it equals EM with only two LR
+  inputs, or stop writing it for quarter/season.
+- Skilled Mean: keep as inverse-MAE weighted LR mean, knowing it remains
+  skill-gated and may be absent, or stop writing it for quarter/season.
+
+## Phased Plan
+
+### P1 -- Pin the two-model policy in tests
+
+**Goal**: Add focused failing tests that describe the desired quarter/season
+behavior before implementation.
+
+**Files**:
+
+- `apps/postprocessing_forecasts/tests/test_quarterly_ensemble_creation.py`
+- `apps/postprocessing_forecasts/tests/test_quarterly_skill_metrics.py`
+- `apps/postprocessing_forecasts/tests/test_quarterly_data_reader.py`
+- Optional: `apps/postprocessing_forecasts/tests/test_quarterly_workflow_integration.py`
+
+**Depends on**: none.
+
+**Agents**: 1 agent.
+
+**Acceptance criteria**:
+
+- Tests assert quarter/season EM is `mean(LR_Base, LR_SM)` when LR skill does
+  not pass current high-skill thresholds.
+- Tests assert deprecated model inputs are ignored for quarter/season
+  aggregation/recalc and do not enter EM composition.
+- Tests assert monthly ensemble tests remain unchanged.
+
+### P2 -- Scope quarter/season raw forecast inputs
+
+**Goal**: Prevent quarter/season recalc and operational paths from recreating or
+using deprecated raw model rows.
+
+**Files**:
+
+- `apps/postprocessing_forecasts/src/data_reader.py`
+- `apps/postprocessing_forecasts/src/aggregation.py` only if the filter belongs
+  at aggregation boundary
+- Relevant tests from P1
+
+**Depends on**: P1.
+
+**Agents**: 1 agent.
+
+**Acceptance criteria**:
+
+- `read_quarterly_forecasts()` and `read_latest_quarterly_forecasts()` return
+  only `LR_Base` and `LR_SM` raw model rows for quarter, whether the source is
+  aggregated monthly or direct quarter API rows.
+- Seasonal reads continue to return only supported LR rows; any deprecated
+  season rows are ignored if present.
+- Monthly reads still expose the full model set.
+
+### P3 -- Change aggregated EM behavior
+
+**Goal**: Make quarter/season EM a deterministic two-LR arithmetic mean in both
+operational ensemble creation and full-history recalculation.
+
+**Files**:
+
+- `apps/postprocessing_forecasts/src/ensemble_calculator.py`
+- `apps/postprocessing_forecasts/src/skill_metrics.py`
+- Relevant tests from P1
+
+**Depends on**: P2.
+
+**Agents**: 1 agent.
+
+**Acceptance criteria**:
+
+- Quarter/season EM uses exactly `LR_Base` and `LR_SM` when both are present.
+- EM no longer depends on `filter_for_highly_skilled_forecasts()` for
+  quarter/season.
+- Single-LR or missing-value groups do not create EM.
+- Monthly EM remains skill-gated and full-model.
+- Naive Mean and Skilled Mean behavior follows the modeller decision recorded
+  before implementation.
+
+### P4 -- Cleanup runbook and aggregate dry-runs
+
+**Goal**: Prepare per-deployment cleanup instructions without executing DB
+writes.
+
+**Files**:
+
+- `doc/prod/ppipe_ensemble_hv_deploy_runbook.md`
+- Optional follow-on cleanup note under `doc/plans/working/`
+
+**Depends on**: P3.
+
+**Agents**: 1 agent.
+
+**Acceptance criteria**:
+
+- Runbook separates raw deprecated-model cleanup from stale ensemble cleanup.
+- Dry-run queries report aggregate counts by `horizon_type`, `horizon_value`,
+  `model_type`, and date range for `long_forecasts` and `skill_metrics`.
+- Predicates are explicitly scoped to quarter/season and reviewed before any
+  delete.
+
+### P5 -- Deploy, delete, recalc, verify
+
+**Goal**: Execute the operational data transition per deployment after reviewed
+code is deployed.
+
+**Files**: no repository files unless private deployment notes are maintained
+outside git.
+
+**Depends on**: P4.
+
+**Agents**: 0 code agents; operator/reviewer execution.
+
+**Acceptance criteria**:
+
+- Deprecated raw quarter models are absent from `long_forecasts` and
+  `skill_metrics`; deprecated season models are absent if any existed.
+- Stale old-semantics quarter/season ensemble rows are removed or superseded by
+  reviewed predicates.
+- Full-history quarter and season recalc completes per deployment.
+- Aggregate verification shows EM rows at the correct config-lead
+  `horizon_value`.
+- Sentinel spot checks confirm `EM == (LR_Base + LR_SM) / 2` for q and each
+  quantile, within rounding tolerance.
+- Monthly aggregate counts and model population are unchanged.
+
+## Dependency Graph
+
+```json
+{
+  "phases": {
+    "P1": { "depends_on": [], "parallel_agents": 1 },
+    "P2": { "depends_on": ["P1"], "parallel_agents": 1 },
+    "P3": { "depends_on": ["P2"], "parallel_agents": 1 },
+    "P4": { "depends_on": ["P3"], "parallel_agents": 1 },
+    "P5": { "depends_on": ["P4"], "parallel_agents": 0 }
+  }
+}
+```
+
+## Final Acceptance
+
+- Quarter and season EM reliably form from `LR_Base` + `LR_SM` at the correct
+  config-lead `horizon_value` per issue/quarter.
+- EM equals the arithmetic mean of `LR_Base` and `LR_SM` for q and quantiles,
+  after normal rounding/monotonicity handling.
+- Deprecated quarter models are gone from `long_forecasts` and `skill_metrics`;
+  season is confirmed clean or cleaned if needed.
+- Old 9-model/skill-gated quarter/season ensemble rows no longer appear as the
+  active product.
+- Monthly ensemble behavior and monthly full model population are unchanged.
+- `SAPPHIRE_TEST_ENV=True bash run_tests.sh` is green, plus targeted
+  postprocessing tests for quarter/season.

--- a/doc/prod/ppipe_ensemble_hv_deploy_runbook.md
+++ b/doc/prod/ppipe_ensemble_hv_deploy_runbook.md
@@ -6,6 +6,37 @@ per-deployment, aggregate-only, and uses sentinel station codes only. Do not put
 real station codes, discharge values, row payloads, or delete statements in this
 document.
 
+## Update 2026-06-23 — Two-Model EM Correctness Fixes (PR #383)
+
+PR #383 (`develop_two_model_ensemble`) fixes three defects in the quarter/season
+two-model ensemble. **Every deployment must redeploy the postprocessing image
+and re-run the one-time recalculation** below — including deployments that
+already ran the original P-PIPE recalc, because their stored EM/Naive Mean/
+Skilled Mean rows were produced by the buggy code.
+
+What changed and why a re-run is required:
+
+1. **EM forecasts were never persisted.** The aggregated EM/Naive/Skilled rows
+   lost their period key on append and were dropped by the write-side NaN guard,
+   so `long_forecasts` had EM *skill* but no EM *forecast*. Fixed.
+2. **Seasonal EM collapsed multiple issue dates.** A lead re-issued on several
+   dates was blended into one row. EM is now computed per issue `date` as a clean
+   `mean(LR_Base, LR_SM)`.
+3. **Bulk write 500 on deployments with stored baselines.** The recalc re-read
+   stored EM/Naive/Skilled rows and re-appended freshly computed ones; a shared
+   unique key (`horizon_type, horizon_value, code, date, model_type, valid_from,
+   valid_to`) raised a `UniqueViolation` and the whole forecast batch failed.
+   This also affected the scheduled **bimonthly** long-term skill recalc on any
+   deployment that already held those rows (e.g. Tajik): it wrote skill but
+   silently failed to write the ensemble forecasts. The recalc now drops the
+   three regenerated baselines from its input before recomputing.
+
+**Self-heal note:** once the fixed image is deployed, the scheduled bimonthly
+recalc (`bin/bimonthly_long_term_skill_metrics_recalculation.sh`, modes MONTHLY/
+QUARTERLY/SEASONAL) regenerates correct EM on its next run with the default
+history window. Run the one-time recalc below to land the fix immediately and
+over full history (`SAPPHIRE_RECALC_START_YEAR=2000`).
+
 ## Scope and Hard Stops
 
 - Deploy only after the P-PIPE code is merged through the normal deployment
@@ -31,10 +62,34 @@ not in committed documentation.
 
 ### 1. Merge and Deploy P-PIPE
 
-1. Merge the P-PIPE branch through the normal review path.
-2. Deploy the merged code to each target deployment independently.
-3. Confirm the deployed image or checkout contains the P-PIPE code before
-   starting the recalculation.
+1. Merge the branch (PR #383) into `maxat_sapphire_2` through the normal review
+   path. The push to `maxat_sapphire_2` triggers `deploy_production.yml`, which
+   builds and pushes `mabesa/sapphire-postprocessing`. Wait for that workflow to
+   finish before deploying to servers.
+2. Deploy the merged code to each target deployment independently. On each
+   server, refresh the postprocessing image and restart the stack. The generic
+   image-pull / migration / restart procedure is in
+   `doc/prod/update_deployment_checklist.md`; for this change the
+   postprocessing image is the only one that must be refreshed:
+
+   ```bash
+   # Operator vars (see update_deployment_checklist.md):
+   #   ORG_SLUG (kghm|tjhm|uzhm), DATA_DIR, ENV_FILE_PATH, LOG_DIR
+   cd /data/SAPPHIRE_Forecast_Tools
+   git fetch && git checkout maxat_sapphire_2 && git pull
+   docker pull mabesa/sapphire-postprocessing:latest
+   ```
+
+   No schema migration is required for PR #383 (no new columns).
+3. Confirm the deployed image contains the fix before starting the
+   recalculation. The image must include the stored-baseline de-duplication;
+   without it the bulk write 500s on deployments that already hold ensemble
+   rows. Quick check:
+
+   ```bash
+   docker run --rm mabesa/sapphire-postprocessing:latest \
+     grep -c "_AGGREGATED_BASELINES" src/skill_metrics.py   # expect >= 2
+   ```
 
 ### 2. One-Time Full-History Recalculation
 
@@ -99,6 +154,39 @@ ORDER BY horizon_type, horizon_value, model_type;
 
 Compare the aggregate result against the deployment's expected full-history date
 range. Do not publish row-level data or discharge values.
+
+Also confirm that EM forecasts were persisted (not just EM skill) and that each
+EM equals the clean two-model mean at its exact key. With the PR #383 fix, every
+recalc-written EM (composition populated) must satisfy
+`q = mean(LR_BASE.q, LR_SM.q)` joined on
+`(horizon_type, horizon_value, code, date, valid_from, valid_to)`. Expect
+`mismatch = 0`; for season this holds **per issue date** (one EM row per date,
+not one blended row per lead).
+
+```sql
+WITH j AS (
+  SELECT em.q AS em_q, (lb.q + ls.q) / 2.0 AS lr_mean
+  FROM long_forecasts em
+  JOIN long_forecasts lb USING (horizon_type, horizon_value, code, date, valid_from, valid_to)
+  JOIN long_forecasts ls USING (horizon_type, horizon_value, code, date, valid_from, valid_to)
+  WHERE em.horizon_type IN ('QUARTER', 'SEASON')
+    AND em.model_type = 'ENSEMBLE_MEAN'
+    AND lb.model_type = 'LR_BASE'
+    AND ls.model_type = 'LR_SM'
+    AND em.q IS NOT NULL
+    AND COALESCE(em.composition, '') <> ''
+    AND em.code IN ('KG_SENTINEL_CODE', 'TJ_SENTINEL_CODE')
+)
+SELECT
+  COUNT(*) AS em_pairs,
+  COUNT(*) FILTER (WHERE abs(em_q - lr_mean) < 0.001) AS match,
+  COUNT(*) FILTER (WHERE abs(em_q - lr_mean) >= 0.001) AS mismatch
+FROM j;
+```
+
+A non-zero `mismatch` on composition-populated rows means the deployed image is
+stale (pre-fix). Pre-existing rows with empty `composition` are old-convention
+artifacts and are excluded here; they are handled by the cleanup gate below.
 
 ### 4. Cleanup Gate
 

--- a/doc/prod/ppipe_ensemble_hv_deploy_runbook.md
+++ b/doc/prod/ppipe_ensemble_hv_deploy_runbook.md
@@ -1,0 +1,138 @@
+# P-PIPE Ensemble Horizon-Value Deploy Runbook
+
+This runbook covers the operational sequence for deploying P-PIPE ensemble
+horizon-value handling and safely unblocking the later cleanup. It is
+per-deployment, aggregate-only, and uses sentinel station codes only. Do not put
+real station codes, discharge values, row payloads, or delete statements in this
+document.
+
+## Scope and Hard Stops
+
+- Deploy only after the P-PIPE code is merged through the normal deployment
+  process.
+- Run the one-time full-history recalculation once per deployment and prediction
+  mode.
+- Verify only aggregate counts and date ranges for sentinel station codes.
+- Do not run cleanup until regenerated new-convention rows cover the full
+  expected date range.
+- Do not move or rewrite raw `LR_BASE` / `LR_SM` rows as part of P-PIPE.
+
+## Sentinel Codes
+
+Use deployment-local sentinel codes selected by the operator:
+
+- Kyrgyz sentinel: `KG_SENTINEL_CODE`
+- Tajik sentinel: `TJ_SENTINEL_CODE`
+
+Replace these placeholders only in private operational notes or command history,
+not in committed documentation.
+
+## Ordered Sequence
+
+### 1. Merge and Deploy P-PIPE
+
+1. Merge the P-PIPE branch through the normal review path.
+2. Deploy the merged code to each target deployment independently.
+3. Confirm the deployed image or checkout contains the P-PIPE code before
+   starting the recalculation.
+
+### 2. One-Time Full-History Recalculation
+
+Run both modes per deployment with `SAPPHIRE_RECALC_START_YEAR=2000`.
+
+Direct runtime form:
+
+```bash
+SAPPHIRE_RECALC_START_YEAR=2000 SAPPHIRE_PREDICTION_MODE=QUARTERLY uv run recalculate_skill_metrics.py
+SAPPHIRE_RECALC_START_YEAR=2000 SAPPHIRE_PREDICTION_MODE=SEASONAL uv run recalculate_skill_metrics.py
+```
+
+Docker helper form:
+
+```bash
+SAPPHIRE_RECALC_START_YEAR=2000 SAPPHIRE_PREDICTION_MODE=QUARTERLY bin/utils/run_skill_metrics_recalc.sh
+SAPPHIRE_RECALC_START_YEAR=2000 SAPPHIRE_PREDICTION_MODE=SEASONAL bin/utils/run_skill_metrics_recalc.sh
+```
+
+The helper now forwards non-empty `SAPPHIRE_RECALC_START_YEAR` into `docker run`.
+If bypassing the helper, pass the equivalent explicit container environment:
+
+```bash
+-e SAPPHIRE_RECALC_START_YEAR=2000
+```
+
+Do not pass an empty `SAPPHIRE_RECALC_START_YEAR`; the recalculation code parses
+the value as an integer.
+
+### 3. Aggregate-Only Verification
+
+Verify that regenerated EM / Naive Mean / Skilled Mean rows exist under the new
+convention for the full expected date range. Keep checks aggregate-only.
+
+Kyrgyz expectations:
+
+- Quarter rows exist at `horizon_type='QUARTER'` and `horizon_value=1`.
+- Seasonal rows exist at `horizon_type='SEASON'` and `horizon_value in (3,2,1,0)`.
+
+Tajik expectations:
+
+- Quarter rows exist at `horizon_type='QUARTER'` and `horizon_value=0`.
+- Seasonal rows exist at `horizon_type='SEASON'` and `horizon_value=0`.
+
+Aggregate query template:
+
+```sql
+SELECT
+  horizon_type,
+  horizon_value,
+  model_type,
+  MIN(date) AS first_issue_date,
+  MAX(date) AS last_issue_date,
+  COUNT(*) AS row_count
+FROM long_forecasts
+WHERE code IN ('KG_SENTINEL_CODE', 'TJ_SENTINEL_CODE')
+  AND model_type IN ('ENSEMBLE_MEAN', 'NAIVE_MEAN', 'SKILLED_MEAN')
+  AND horizon_type IN ('QUARTER', 'SEASON')
+GROUP BY horizon_type, horizon_value, model_type
+ORDER BY horizon_type, horizon_value, model_type;
+```
+
+Compare the aggregate result against the deployment's expected full-history date
+range. Do not publish row-level data or discharge values.
+
+### 4. Cleanup Gate
+
+Only after the aggregate verification passes may the cleanup owner re-derive
+obsolete old-convention cleanup predicates.
+
+The authoritative cleanup ordering is the cross-plan reconciliation section in
+`doc/plans/working/ppipe_postprocessing_ensemble_hv_plan.md`. That section
+supersedes the old ensemble handling in
+`doc/plans/working/longforecast_hv_convention_plan.md` P3.
+
+Cleanup requirements:
+
+- Re-derive predicates after the regeneration, not from pre-regeneration counts.
+- Scope predicates to old-convention signatures only.
+- Season old signature: ensemble rows at `horizon_value=1` where `date` is the
+  target-season start, not the issue date.
+- Quarter old signature: obsolete ensemble rows at `horizon_value in (2,3,4)`,
+  plus old calendar `horizon_value=1` rows distinguishable from the regenerated
+  product by reviewed aggregate predicates.
+- Obtain reviewer approval on aggregate dry-run counts before any delete.
+
+The superseded longforecast P3 banner points back to the P-PIPE reconciliation:
+predicates must be re-derived post-regen, old-signature-scoped, and the old
+pre-regen counts are stale.
+
+## Completion Evidence
+
+For each deployment, retain private operational evidence with:
+
+- deployed version identifier;
+- quarter and seasonal recalculation timestamps;
+- aggregate verification counts and full date ranges for sentinel codes;
+- cleanup dry-run counts and reviewer approval, if cleanup proceeds.
+
+Do not commit private evidence containing real station codes, discharge values,
+connection details, or write output.

--- a/doc/prod/ppipe_seasonal_ensemble_decisions_request.md
+++ b/doc/prod/ppipe_seasonal_ensemble_decisions_request.md
@@ -1,0 +1,97 @@
+# Decision request (PP0): seasonal ensemble semantics, per-lead skill, historical regeneration
+
+**For**: long-term modeller + postprocessing-service owner
+**From**: forecast-tools side (MIG-008 / P-PIPE -- extending the config-lead `horizon_value` convention
+to the `apps/postprocessing_forecasts` quarterly/seasonal ensemble pipeline)
+**Blocks**: all P-PIPE implementation and the downstream data cleanup (P3/P4). Nothing is coded yet.
+**Why**: a plan + review found that the answers below **change the size and shape** of the work
+(especially the seasonal half). We need your decisions before writing any code.
+
+## Background (settled)
+
+`horizon_value = operational_month_lead_time` (config lead). Quarter: kyg `hv1`, taj `hv0`. Season per
+issue: kyg Jan/Feb/Mar/Apr = `hv3/2/1/0`, taj Apr = `hv0`. The raw forecast writers already follow
+this. The **ensemble** pipeline (`api_writer._write_quarterly/seasonal_ensemble_to_api`) does not -- it
+writes quarter `hv = calendar quarter (1-4)` and season `hv = 1` (hardcoded). We will fix it; the
+questions are about *what the correct product is*.
+
+## Decision 1 -- Seasonal ensemble: one product per run, or four issue products? (the big one)
+
+Today the ensemble pipeline **collapses** all seasonal issues for a target year into a single row:
+the reader drops the issue date, and the ensemble/dedup key is `(season_year, code, model_short)`. So
+a Kyrgyz target season currently yields **one** ensemble row regardless of the Jan/Feb/Mar/Apr issue.
+
+Which is correct?
+
+- **(A) One ensemble product per target season** (e.g. the latest/current issue only). Then the
+  ensemble pipeline writes a single seasonal `hv` (the current issue's lead), the collapse is fine, and
+  only the **raw** forecast rows populate all four `hv3/2/1/0` buckets. **Small change.**
+- **(B) Four distinct seasonal ensemble products**, one per issue (Jan/Feb/Mar/Apr), each at its own
+  lead `hv3/2/1/0`. Then we must carry the **issue date** through the reader, ensemble grouping, dedup,
+  and writer (a per-issue ensemble). **Materially larger change.**
+
+Please choose A or B. If B, confirm the ensemble should be computed **independently per issue**.
+
+## Decision 2 -- Per-lead seasonal skill (only if Decision 1 = B)
+
+Seasonal skill is currently a single value per target season (no lead dimension). If the four issues
+become distinct products at different leads, should each lead get its **own skill** (a January
+3-month-ahead forecast is normally less skilful than an April 0-month-ahead one), or is the **same
+season skill applied to all leads**? This affects the ensemble weighting (EM / Skilled Mean).
+
+## Decision 3 -- Historical quarter/season ensemble: regenerate, re-stamp, or drop?
+
+The DB holds ~41k historical QUARTER **ensemble** rows (EM / Naive Mean / Skilled Mean, 2000-2026) plus
+the seasonal `hv1` ensembles. Under the new convention these need to move to the correct hv. The only
+full-history rebuild path is `recalculate_skill_metrics.py` with `SAPPHIRE_RECALC_START_YEAR=2000`
+(a **manual** run; the cron never does it). Options:
+
+- **(i) Re-stamp** the historical ensemble rows' `horizon_value` in place (cheap, preserves history,
+  same approach we used for the raw LR rows). No recalc needed.
+- **(ii) Delete + full-history regenerate** via the manual recalc (expensive, and a delete that depends
+  on a non-cron manual step is risky).
+- **(iii) Drop** the historical ensembles entirely (only keep forward-generated ones).
+
+Which do you want, and should the EM / Naive Mean / Skilled Mean historical ensembles be preserved at
+all?
+
+## Decision 4 (technical confirmation) -- config source for postprocessing
+
+Confirm postprocessing may read the same long-term config JSONs as `apps/long_term_forecasting` to
+resolve the lead (env/path contract), and the issue-month -> `seasonal_january/february/march/april`
+mapping. We can propose a concrete contract if you prefer; just confirm the config root is shared.
+
+## What is on hold until you answer
+
+- All P-PIPE code (writer/reader/ensemble/dashboard changes).
+- The data cleanup (P3/P4) -- gated behind P-PIPE + your Decision 3.
+
+Once you answer Decision 1 (and 2 if B) and Decision 3, we will rewrite the P-PIPE phase scope +
+acceptance and proceed via the usual plan -> review -> implement loop. Aggregate-only DB verification;
+sentinel station codes in all artifacts.
+
+---
+
+## ANSWERS (2026-06-22, modeller / owner)
+
+- **Decision 1 = B**: **four distinct seasonal ensemble products**, one per issue (Jan/Feb/Mar/Apr ->
+  `hv3/2/1/0`), computed independently per issue. This is the larger change: issue identity must be
+  threaded through the reader projection (`_SEASONAL_FC_COLS`), the ensemble groupby, the dedup keys,
+  and a per-row issue->lead mapping in the writer.
+- **Decision 2 = yes**: **each lead gets its own skill** -- seasonal skill gains an issue/lead
+  dimension; the skill->ensemble join must key on lead (a 3-month-ahead January ensemble is weighted
+  with January-lead skill, not the April-lead skill).
+- **Decision 3 = regenerate** ("re-run them with the proper settings"): rebuild the historical
+  ensembles via `recalculate_skill_metrics.py`, then clean up the obsolete old-convention rows.
+  **No new cron job needed** -- the recurring recalc is already scheduled
+  (`bin/bimonthly_long_term_skill_metrics_recalculation.sh` covers QUARTERLY/SEASONAL via
+  `run_skill_metrics_recalc.sh`; plus `bin/yearly_skill_metrics_recalculation.sh`). The one-time deep
+  history (back to 2000, since the cron default window is ~`current_year-20` = 2006) is a **single
+  manual recalc run** with `SAPPHIRE_RECALC_START_YEAR=2000` per deployment. Sequence: P-PIPE code ->
+  deploy -> recalc (start 2000) writes new-convention rows -> aggregate verify -> then clean up the
+  obsolete old-hv rows.
+- **Decision 4 = confirmed**: postprocessing may read the long-term config JSONs to resolve the lead +
+  issue-month -> seasonal-config mapping.
+
+Scope is therefore the **B branch** (the larger one). P-PIPE will be re-planned in detail (expanded
+seasonal issue-threading + per-lead skill + the regenerate-then-clean sequence) before implementation.


### PR DESCRIPTION
## Summary

Fixes to the two-model (LR_Base + LR_SM) aggregated ensemble for quarter and
season forecasts, found while validating that recalculated EM forecasts land in
`long_forecasts` on the dev DB for both Kyrgyz and Tajik.

1. **EM persistence** — `_ENSEMBLE_JOINT_COLS` lacked the quarter/season period
   keys, so `_append_to_joint` stripped `quarter_in_year` / `season_in_year` /
   `season_year` from EM/Naive/Skilled rows. They went NaN on concat and the
   write-side NaN guard dropped every ensemble row — EM forecasts never reached
   `long_forecasts` even though EM *skill* was computed. Added the period keys.

2. **Per-issue-date seasonal EM** — seasonal forecasts at a given lead can be
   re-issued on several dates, but the ensemble grouped only on
   `(season_year, season_in_year, code)`, blending distinct issue dates into one
   row. Now grouped by `date` too, so each issue yields its own clean
   `mean(LR_Base, LR_SM)`. A defensive present-columns filter keeps quarter and
   date-less frames on the existing period-level grouping unchanged.

3. **Drop stored baselines before regeneration** — the recalc reads raw
   forecasts that may already contain stored EM/Naive/Skilled rows, then
   recomputes and appends them. A stored row sharing a freshly-computed key
   caused a `UniqueViolation` and the bulk `long_forecasts` write 500'd (no
   ensembles landed). Surfaced on Tajik, whose DB already held Naive Mean rows.
   The recalc now drops the three regenerated baselines from its input (other
   ensembles like NE untouched).

## Tests

`SAPPHIRE_TEST_ENV=True bash run_tests.sh postprocessing_forecasts` →
**1368 passed, 0 skipped**. New tests cover EM period-key retention, per-issue
-date seasonal EM, and stored-baseline de-duplication.

## Dev-DB validation (aggregate only)

Every recalc-written EM equals `mean(LR_Base, LR_SM)` at its exact key,
**0 mismatch**, for all four combinations:

| Org | QUARTER | SEASON |
|-----|---------|--------|
| Kyrgyz | 467/467 | 938/938 |
| Tajik  | 129/129 | 38/38  |

## Deployment

Per-deployment steps (image pull/restart + one-time quarter/season recalc per
org + verification) are documented in
`doc/prod/ppipe_ensemble_hv_deploy_runbook.md` (updated in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)