### PR TITLE
Docs: capture kyg long-term deploy learnings

### DIFF
--- a/doc/prod/backfill_ml_fromfile.md
+++ b/doc/prod/backfill_ml_fromfile.md
@@ -560,6 +560,19 @@ sentinel code `19999`; never paste real station codes into committed files.
   **`GBT_Base`** (long-term, tracked as **LTF-006**). Run the §4 model-name pre-flight before
   long-term writes; exclude/skip unmappable names.
 
+### 13.8 Long-forecast importer pre-cutoff trap on per-station canary writes
+- The importer's MODE detection is **per `(horizon_type, horizon_value, code)`**: if a target key
+  already has rows it switches from `full-import` to `pre-cutoff` (imports only *older-than-existing*).
+  So a **per-station canary write first** (`--mode <m> --model LR_Base --station-filter <code>`)
+  creates a cutoff for that station, and the subsequent **full mode-write then skips that whole
+  station — including the model you did *not* canary** (the cutoff is keyed by station, not model).
+  On kyg this left one station with `LR_Base` but no `LR_SM` at `SEASON hv0`, so no EM was computed
+  for it.
+  - **Avoid:** for a single configured mode, skip the per-station canary — run **dry-run → full
+    mode-write** directly (the full write itself surfaces a 422 via `failed>0`, so it is its own gate).
+  - **If already canaried:** `DELETE` that station's rows for the bucket, re-run the full mode-write
+    (now `full-import`s the station), then re-run the skill recalc.
+
 ### Open hardening items (deployment-agnostic, not Tajik-blocking)
 - API bulk forecast write should be dedup-safe (INFRA-013 class).
 - `ml_raw_to_export.py` should skip unknown/deprecated models, not raise.

--- a/doc/prod/long_term_deploy_runbook.md
+++ b/doc/prod/long_term_deploy_runbook.md
@@ -27,6 +27,14 @@ two deployments differ — see the parameter table below.
 > update" failure was a **deployment `.env` misconfiguration** (the var was unset
 > / pointed at a missing template), surfacing as `os.path.join(None, …)`. It is
 > therefore an **env-preflight item (Phase 2)**, not a code change to ship.
+>
+> **Concrete form (kyg, 2026-06-24):** the `.env` defined the var under the
+> *old* name `ieasyforecast_template_seasonal_bulletin_file` (`seasonal`), while
+> `bulletins.py` reads `...season...` (renamed in `e82c951e`). `os.getenv`
+> returned `None` → the join failed. The fix is a one-line `.env` **rename**
+> (value unchanged; the template file itself was present). **Check this on every
+> deployment** — taj and uzb `.env`s likely carry the same stale `seasonal` key:
+> `grep -E 'template_(season|seasonal)_bulletin_file' <env>`.
 
 ---
 
@@ -255,10 +263,22 @@ Confirm:
    pre-fix one — revisit Phase 1. `mismatch = 0` alone is not sufficient; it can
    also mean the join found no EM/LR pairs.
    *(Model labels in the DB are uppercase: `LR_BASE`, `LR_SM`, `ENSEMBLE_MEAN`.)*
-3. **Seasonal bulletin renders** (change d): in the dashboard, generate a seasonal
-   bulletin and confirm the Excel file is written (this exercises
-   `ieasyforecast_template_season_bulletin_file` end-to-end). Also smoke-check the
-   monthly/decad/pentad bulletins haven't regressed.
+3. **Seasonal bulletin renders** (change d): first **recreate the dashboard** so it
+   reloads the corrected `.env` — do this **through the deployment's env path**, not
+   a bare `docker restart`. A plain restart reuses the container's baked env and
+   leaves `ieasyhydroforecast_url_pentad` empty (it is *derived* in
+   `bin/utils/common_functions.sh` from the env-file suffix, then exported before
+   `up`), so the dashboard crash-loops with `ERROR: Empty host value`. Recreate via:
+   ```bash
+   set +u +o pipefail          # read_configuration trips set -u on $-in-secret .env values
+   source bin/utils/common_functions.sh
+   export ieasyhydroforecast_env_file_path="<env>"
+   read_configuration "<env>"
+   docker compose --env-file "<env>" -f sapphire/docker-compose.yml up -d --force-recreate --no-deps dashboard
+   ```
+   Then in the dashboard, generate a seasonal bulletin and confirm the Excel file is
+   written (this exercises `ieasyforecast_template_season_bulletin_file` end-to-end).
+   Also smoke-check the monthly/decad/pentad bulletins haven't regressed.
 
 Do not start Phase 5 until 1–3 pass.
 


### PR DESCRIPTION
## Summary

Three deployment-agnostic learnings from the kyg long-term forecast server deploy (2026-06-24), captured so taj/uzb don't rediscover them.

- **`doc/prod/long_term_deploy_runbook.md`**
  - change-(d) note: the "bulletin won't update" failure is concretely a **stale `.env` key name** — `ieasyforecast_template_seasonal_bulletin_file` (`seasonal`) vs the code's `...season...` (renamed in `e82c951e`). One-line `.env` rename; check on every deployment.
  - Phase 4 bulletin-render step: **recreate the dashboard via `read_configuration`**, not a bare `docker restart` (a plain restart bakes an empty `ieasyhydroforecast_url_pentad` → `ERROR: Empty host value` crash loop).
- **`doc/prod/backfill_ml_fromfile.md`** §13.8: the long-forecast importer's **per-station pre-cutoff trap** — a per-station canary write makes the subsequent full mode-write skip that station; prefer dry-run → full mode-write for a single mode.

## Testing
Docs only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)