### PR TITLE
PREPG-007: Self-healing snow population (365-day maintenance window + Jan-1 norms)

### DIFF
--- a/apps/preprocessing_gateway/dg_utils.py
+++ b/apps/preprocessing_gateway/dg_utils.py
@@ -706,7 +706,12 @@ def _read_existing_snow_fields(
             for _, row in api_df.iterrows():
                 d = pd.to_datetime(row["date"]).strftime("%Y-%m-%d")
                 values = {}
-                for field in ("norm", *SNOW_PRESERVED_STAT_FIELDS):
+                for field in (
+                    "value",
+                    "norm",
+                    *SNOW_PRESERVED_STAT_FIELDS,
+                    *(f"value{i}" for i in range(1, 15)),
+                ):
                     field_val = row.get(field)
                     if pd.notna(field_val):
                         values[field] = float(field_val)
@@ -744,7 +749,7 @@ def write_snow_to_api(
 
     Supports different sync modes:
     - operational (default): write yesterday+today (2-day window)
-    - maintenance: write the last 30 days
+    - maintenance: write the last 365 days
     - initial: write all data
 
     Args:
@@ -818,7 +823,7 @@ def write_snow_to_api(
         # Include yesterday, today, and any forecast dates beyond today
         data_to_write = data[data["date"] >= yesterday]
     elif sync_mode == "maintenance":
-        cutoff = ref - pd.Timedelta(days=30)
+        cutoff = ref - pd.Timedelta(days=365)
         data_to_write = data[data["date"] >= cutoff]
     elif sync_mode == "initial":
         data_to_write = data
@@ -903,10 +908,31 @@ def write_snow_to_api(
         elif "norm" in existing_fields:
             local_norm = round(existing_fields["norm"], 3)
 
-        local_value = (
+        incoming_value = (
             round(float(row[main_value_col]), 3)
             if main_value_col and pd.notna(row.get(main_value_col))
             else None
+        )
+        incoming_band_values = {}
+        for band_num, col_name in value_columns.items():
+            if band_num <= 14:
+                incoming_band_values[band_num] = (
+                    round(float(row[col_name]), 3) if pd.notna(row.get(col_name)) else None
+                )
+
+        if incoming_value is None and all(
+            band_value is None for band_value in incoming_band_values.values()
+        ):
+            continue
+
+        local_value = (
+            incoming_value
+            if incoming_value is not None
+            else (
+                _format_existing_snow_field("value", existing_fields["value"])
+                if "value" in existing_fields
+                else None
+            )
         )
 
         record = {
@@ -939,11 +965,16 @@ def write_snow_to_api(
             else None
         )
 
-        # Add elevation band values (value1-value14)
-        for band_num, col_name in value_columns.items():
-            if band_num <= 14:
-                record[f"value{band_num}"] = (
-                    round(float(row[col_name]), 3) if pd.notna(row.get(col_name)) else None
+        # Add or preserve elevation band values (value1-value14).
+        for band_num in range(1, 15):
+            field_name = f"value{band_num}"
+            incoming_band_value = incoming_band_values.get(band_num)
+            if incoming_band_value is not None:
+                record[field_name] = incoming_band_value
+            elif field_name in existing_fields:
+                record[field_name] = _format_existing_snow_field(
+                    field_name,
+                    existing_fields[field_name],
                 )
 
         records.append(record)

--- a/apps/preprocessing_gateway/test/test_api_integration.py
+++ b/apps/preprocessing_gateway/test/test_api_integration.py
@@ -163,8 +163,8 @@ class TestWriteSnowToApi:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)
 
     @patch("dg_utils.SapphirePreprocessingClient")
-    def test_nan_values_are_none(self, mock_client_class):
-        """Test that NaN values are converted to None."""
+    def test_nan_values_skip_empty_rows(self, mock_client_class):
+        """NaN-only snow rows are skipped instead of writing empty records."""
         if not dg_utils.SAPPHIRE_API_AVAILABLE:
             pytest.skip("sapphire-api-client not installed")
 
@@ -180,16 +180,14 @@ class TestWriteSnowToApi:
             data = pd.DataFrame(
                 {
                     "date": [today],
-                    "code": [12345],
+                    "code": ["19999"],
                     "SWE": [np.nan],
                 }
             )
 
             result = dg_utils.write_snow_to_api(data, "SWE", "test_hru")
-            assert result is True
-
-            call_args = mock_client.write_snow.call_args[0][0]
-            assert call_args[0]["value"] is None
+            assert result is False
+            mock_client.write_snow.assert_not_called()
         finally:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)
 
@@ -236,14 +234,14 @@ class TestWriteSnowToApi:
 
 
 # =============================================================================
-# Tests for _write_snow_to_api (maintenance mode - writes last 30 days)
+# Tests for _write_snow_to_api (maintenance mode - writes last 365 days)
 # =============================================================================
 
 
 class TestWriteSnowToApiMaintenance:
     """Tests for dg_utils.write_snow_to_api in maintenance mode.
 
-    Maintenance mode writes the last 30 days of data relative to
+    Maintenance mode writes the last 365 days of data relative to
     reference_date (used by snow_data_renalysis).
     """
 
@@ -301,8 +299,8 @@ class TestWriteSnowToApiMaintenance:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)
 
     @patch("dg_utils.SapphirePreprocessingClient")
-    def test_writes_last_30_days_only(self, mock_client_class):
-        """Only the last 30 days of data should be written (maintenance behavior)."""
+    def test_writes_last_365_days_only(self, mock_client_class):
+        """Only the last 365 days of data should be written (maintenance behavior)."""
         if not dg_utils.SAPPHIRE_API_AVAILABLE:
             pytest.skip("sapphire-api-client not installed")
 
@@ -310,17 +308,17 @@ class TestWriteSnowToApiMaintenance:
         try:
             mock_client = Mock()
             mock_client.readiness_check.return_value = True
-            mock_client.write_snow.return_value = 30
+            mock_client.write_snow.return_value = 366
             mock_client.read_snow.return_value = pd.DataFrame()
             mock_client_class.return_value = mock_client
 
-            # Data spanning 60 days ending 2024-03-01
-            dates = pd.date_range(end="2024-03-01", periods=60, freq="D")
+            # Data spanning 500 days ending 2024-03-01
+            dates = pd.date_range(end="2024-03-01", periods=500, freq="D")
             data = pd.DataFrame(
                 {
                     "date": dates,
-                    "code": [12345] * 60,
-                    "SWE": np.random.uniform(50, 200, 60),
+                    "code": ["19999"] * 500,
+                    "SWE": np.arange(500, dtype=float),
                 }
             )
 
@@ -335,7 +333,9 @@ class TestWriteSnowToApiMaintenance:
 
             mock_client.write_snow.assert_called_once()
             call_args = mock_client.write_snow.call_args[0][0]
-            assert len(call_args) == 31  # 30 days + cutoff day
+            assert len(call_args) == 366  # 365 days + cutoff day
+            assert min(r["date"] for r in call_args) == "2023-03-02"
+            assert max(r["date"] for r in call_args) == "2024-03-01"
         finally:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)
 
@@ -1802,8 +1802,8 @@ class TestSnowSyncMode:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)
 
     @patch("dg_utils.SapphirePreprocessingClient")
-    def test_maintenance_mode_writes_last_30_days(self, mock_client_class):
-        """Maintenance mode should write the last 30 days."""
+    def test_maintenance_mode_writes_last_365_days(self, mock_client_class):
+        """Maintenance mode should write the last 365 days."""
         if not dg_utils.SAPPHIRE_API_AVAILABLE:
             pytest.skip("sapphire-api-client not installed")
 
@@ -1811,17 +1811,17 @@ class TestSnowSyncMode:
         try:
             mock_client = Mock()
             mock_client.readiness_check.return_value = True
-            mock_client.write_snow.return_value = 31
+            mock_client.write_snow.return_value = 366
             mock_client.read_snow.return_value = pd.DataFrame()
             mock_client_class.return_value = mock_client
 
             today = pd.Timestamp.today().normalize()
-            dates = pd.date_range(end=today, periods=60, freq="D")
+            dates = pd.date_range(end=today, periods=500, freq="D")
             data = pd.DataFrame(
                 {
                     "date": dates,
-                    "code": [12345] * 60,
-                    "SWE": range(60),
+                    "code": ["19999"] * 500,
+                    "SWE": range(500),
                 }
             )
 
@@ -1829,7 +1829,7 @@ class TestSnowSyncMode:
             assert result is True
 
             records = mock_client.write_snow.call_args[0][0]
-            assert len(records) == 31  # last 30 days + cutoff day
+            assert len(records) == 366  # last 365 days + cutoff day
         finally:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)
 
@@ -2082,6 +2082,133 @@ class TestSnowNormPreservation:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)
 
     @patch("dg_utils.SapphirePreprocessingClient")
+    def test_maintenance_old_row_preserves_stat_bands(self, mock_client_class):
+        """Maintenance writes old rows without clobbering existing stat bands."""
+        if not dg_utils.SAPPHIRE_API_AVAILABLE:
+            pytest.skip("sapphire-api-client not installed")
+
+        os.environ["SAPPHIRE_API_ENABLED"] = "true"
+        try:
+            reference_date = pd.Timestamp("2024-05-10")
+            old_date = reference_date - pd.Timedelta(days=100)
+            mock_client = Mock()
+            mock_client.readiness_check.return_value = True
+            mock_client.write_snow.return_value = 1
+            mock_client.read_snow.return_value = pd.DataFrame(
+                {
+                    "date": pd.to_datetime([old_date]),
+                    "code": ["19999"],
+                    "snow_type": ["SWE"],
+                    "value": [10.0],
+                    "norm": [20.0],
+                    "count": [11],
+                    "mean": [21.0],
+                    "std": [2.0],
+                    "min": [5.0],
+                    "max": [35.0],
+                    "q05": [6.0],
+                    "q25": [15.0],
+                    "q50": [22.0],
+                    "q75": [28.0],
+                    "q95": [34.0],
+                    "previous": [18.0],
+                    "current": [10.0],
+                }
+            )
+            mock_client_class.return_value = mock_client
+
+            data = pd.DataFrame(
+                {
+                    "date": pd.to_datetime([old_date]),
+                    "code": ["19999"],
+                    "SWE": [12.3456],
+                }
+            )
+
+            result = dg_utils.write_snow_to_api(
+                data,
+                "SWE",
+                "test_hru",
+                mode="maintenance",
+                reference_date=reference_date,
+            )
+            assert result is True
+
+            records = mock_client.write_snow.call_args[0][0]
+            assert len(records) == 1
+            record = records[0]
+            assert record["date"] == old_date.strftime("%Y-%m-%d")
+            assert record["code"] == "19999"
+            assert record["value"] == 12.346
+            assert record["current"] == 12.346
+            assert record["norm"] == 20.0
+            assert record["count"] == 11
+            assert record["mean"] == 21.0
+            assert record["std"] == 2.0
+            assert record["min"] == 5.0
+            assert record["max"] == 35.0
+            assert record["q05"] == 6.0
+            assert record["q25"] == 15.0
+            assert record["q50"] == 22.0
+            assert record["q75"] == 28.0
+            assert record["q95"] == 34.0
+            assert record["previous"] == 18.0
+        finally:
+            os.environ.pop("SAPPHIRE_API_ENABLED", None)
+
+    @patch("dg_utils.SapphirePreprocessingClient")
+    def test_maintenance_value_only_row_preserves_elevation_bands(self, mock_client_class):
+        """Value-only maintenance updates do not null existing elevation bands."""
+        if not dg_utils.SAPPHIRE_API_AVAILABLE:
+            pytest.skip("sapphire-api-client not installed")
+
+        os.environ["SAPPHIRE_API_ENABLED"] = "true"
+        try:
+            reference_date = pd.Timestamp("2024-05-10")
+            old_date = reference_date - pd.Timedelta(days=100)
+            existing_bands = {f"value{i}": float(i) for i in range(1, 15)}
+            mock_client = Mock()
+            mock_client.readiness_check.return_value = True
+            mock_client.write_snow.return_value = 1
+            mock_client.read_snow.return_value = pd.DataFrame(
+                {
+                    "date": pd.to_datetime([old_date]),
+                    "code": ["19999"],
+                    "snow_type": ["SWE"],
+                    "value": [10.0],
+                    **{field: [value] for field, value in existing_bands.items()},
+                }
+            )
+            mock_client_class.return_value = mock_client
+
+            data = pd.DataFrame(
+                {
+                    "date": pd.to_datetime([old_date]),
+                    "code": ["19999"],
+                    "SWE": [22.0],
+                }
+            )
+
+            result = dg_utils.write_snow_to_api(
+                data,
+                "SWE",
+                "test_hru",
+                mode="maintenance",
+                reference_date=reference_date,
+            )
+            assert result is True
+
+            records = mock_client.write_snow.call_args[0][0]
+            assert len(records) == 1
+            record = records[0]
+            assert record["value"] == 22.0
+            assert record["current"] == 22.0
+            for field, value in existing_bands.items():
+                assert record[field] == value
+        finally:
+            os.environ.pop("SAPPHIRE_API_ENABLED", None)
+
+    @patch("dg_utils.SapphirePreprocessingClient")
     def test_local_norm_takes_precedence(self, mock_client_class):
         """Incoming data has norm → overrides existing API norm."""
         if not dg_utils.SAPPHIRE_API_AVAILABLE:
@@ -2195,18 +2322,18 @@ class TestSnowNormPreservation:
         try:
             mock_client = Mock()
             mock_client.readiness_check.return_value = True
-            mock_client.write_snow.return_value = 31
+            mock_client.write_snow.return_value = 366
             mock_client.read_snow.return_value = pd.DataFrame()
             mock_client_class.return_value = mock_client
 
             # Data ends at 2024-02-15, well in the past
             ref_date = pd.Timestamp("2024-02-15")
-            dates = pd.date_range(end="2024-02-15", periods=60, freq="D")
+            dates = pd.date_range(end="2024-02-15", periods=500, freq="D")
             data = pd.DataFrame(
                 {
                     "date": dates,
-                    "code": [12345] * 60,
-                    "SWE": range(60),
+                    "code": ["19999"] * 500,
+                    "SWE": range(500),
                 }
             )
 
@@ -2220,10 +2347,10 @@ class TestSnowNormPreservation:
             assert result is True
 
             records = mock_client.write_snow.call_args[0][0]
-            # 30-day window from Feb 15 → Jan 16 to Feb 15 = 31 days
-            assert len(records) == 31
+            # 365-day window from Feb 15 -> Feb 15 to Feb 15 = 366 days
+            assert len(records) == 366
             record_dates = sorted(r["date"] for r in records)
-            assert record_dates[0] == "2024-01-16"
+            assert record_dates[0] == "2023-02-15"
             assert record_dates[-1] == "2024-02-15"
         finally:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)

--- a/apps/preprocessing_gateway/test/test_edge_cases.py
+++ b/apps/preprocessing_gateway/test/test_edge_cases.py
@@ -74,8 +74,8 @@ class TestSnowWriteEdgeCases:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)
 
     @patch("dg_utils.SapphirePreprocessingClient")
-    def test_all_nan_value_column(self, mock_client_class):
-        """All-NaN value column produces records with value=None."""
+    def test_all_nan_value_column_skips_empty_rows(self, mock_client_class):
+        """All-NaN value column skips rows with no incoming snow values."""
         if not dg_utils.SAPPHIRE_API_AVAILABLE:
             pytest.skip("sapphire-api-client not installed")
 
@@ -83,7 +83,7 @@ class TestSnowWriteEdgeCases:
         try:
             mock_client = Mock()
             mock_client.readiness_check.return_value = True
-            mock_client.write_snow.return_value = 2
+            mock_client.write_snow.return_value = 0
             mock_client.read_snow.return_value = pd.DataFrame()
             mock_client_class.return_value = mock_client
 
@@ -91,24 +91,20 @@ class TestSnowWriteEdgeCases:
             data = pd.DataFrame(
                 {
                     "date": [today, today],
-                    "code": [12345, 67890],
+                    "code": ["19999", "19999"],
                     "SWE": [np.nan, np.nan],
                 }
             )
 
             result = dg_utils.write_snow_to_api(data, "SWE", "test_hru")
-            assert result is True
-
-            records = mock_client.write_snow.call_args[0][0]
-            assert len(records) == 2
-            assert records[0]["value"] is None
-            assert records[1]["value"] is None
+            assert result is False
+            mock_client.write_snow.assert_not_called()
         finally:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)
 
     @patch("dg_utils.SapphirePreprocessingClient")
     def test_mixed_nan_valid_values(self, mock_client_class):
-        """Mixed NaN/valid values produce correct None/float split."""
+        """Mixed NaN/valid values write valid rows and skip empty rows."""
         if not dg_utils.SAPPHIRE_API_AVAILABLE:
             pytest.skip("sapphire-api-client not installed")
 
@@ -124,7 +120,7 @@ class TestSnowWriteEdgeCases:
             data = pd.DataFrame(
                 {
                     "date": [today, today, today],
-                    "code": [11111, 22222, 33333],
+                    "code": ["19999", "19999", "19999"],
                     "SWE": [100.0, np.nan, 200.0],
                 }
             )
@@ -133,9 +129,9 @@ class TestSnowWriteEdgeCases:
             assert result is True
 
             records = mock_client.write_snow.call_args[0][0]
+            assert len(records) == 2
             assert records[0]["value"] == 100.0
-            assert records[1]["value"] is None
-            assert records[2]["value"] == 200.0
+            assert records[1]["value"] == 200.0
         finally:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)
 
@@ -563,8 +559,8 @@ class TestDateBoundaryEdgeCases:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)
 
     @patch("dg_utils.SapphirePreprocessingClient")
-    def test_maintenance_30_day_window_spanning_year_boundary(self, mock_client_class):
-        """Maintenance mode: 30-day window from Jan 15 goes back to Dec 16."""
+    def test_maintenance_365_day_window_spanning_year_boundary(self, mock_client_class):
+        """Maintenance mode includes ref-365d and excludes ref-366d."""
         if not dg_utils.SAPPHIRE_API_AVAILABLE:
             pytest.skip("sapphire-api-client not installed")
 
@@ -572,16 +568,16 @@ class TestDateBoundaryEdgeCases:
         try:
             mock_client = Mock()
             mock_client.readiness_check.return_value = True
-            mock_client.write_snow.return_value = 31
+            mock_client.write_snow.return_value = 366
             mock_client.read_snow.return_value = pd.DataFrame()
             mock_client_class.return_value = mock_client
 
-            # Data spans Nov 1 to Jan 15
-            dates = pd.date_range("2023-11-01", "2024-01-15", freq="D")
+            # Data spans Jan 14, 2023 to Jan 15, 2024.
+            dates = pd.date_range("2023-01-14", "2024-01-15", freq="D")
             data = pd.DataFrame(
                 {
                     "date": dates,
-                    "code": [12345] * len(dates),
+                    "code": ["19999"] * len(dates),
                     "SWE": [100.0] * len(dates),
                 }
             )
@@ -595,9 +591,10 @@ class TestDateBoundaryEdgeCases:
             )
 
             records = mock_client.write_snow.call_args[0][0]
-            # Cutoff: Jan 15 - 30 days = Dec 16
+            # Cutoff: Jan 15, 2024 - 365 days = Jan 15, 2023.
             record_dates = [r["date"] for r in records]
-            assert min(record_dates) == "2023-12-16"
+            assert "2023-01-14" not in record_dates
+            assert min(record_dates) == "2023-01-15"
             assert max(record_dates) == "2024-01-15"
         finally:
             os.environ.pop("SAPPHIRE_API_ENABLED", None)

--- a/apps/preprocessing_gateway/test/test_integration_preprocessing_gateway.py
+++ b/apps/preprocessing_gateway/test/test_integration_preprocessing_gateway.py
@@ -45,7 +45,7 @@ TestCrossScriptDataFlow (5 tests)
     (QM → extend_era5 → snow) end-to-end.
 
 TestSyncModes (5 tests)
-    Operational writes yesterday+today, maintenance writes ~30 days,
+    Operational writes yesterday+today, maintenance writes ~365 days,
     initial writes all data, reanalysis write skipped in
     operational mode, reanalysis write active in maintenance mode.
 
@@ -1210,7 +1210,7 @@ class TestSnowPipelineIntegration:
 
     def test_snow_operational_vs_maintenance_filtering(self, gateway_env, mock_api_client):
         """Operational writes yesterday onward (including forecast);
-        maintenance writes 30 days."""
+        maintenance writes 365 days."""
         env = gateway_env
         today = datetime.today()
         dates = [(today - timedelta(days=d)).strftime("%d.%m.%Y") for d in range(60, -1, -1)]

--- a/bin/README.md
+++ b/bin/README.md
@@ -120,7 +120,7 @@ docker compose -f bin/docker-compose-luigi.yml run --rm pentadal
 # Run daily maintenance
 docker compose -f bin/docker-compose-luigi.yml run --rm daily-maintenance
 
-# Run periodic maintenance (long_term, skill_recalc, snow_norms, or monthly_norms)
+# Run periodic maintenance (long_term, skill_recalc, or snow_norms)
 MAINTENANCE_TASK_TYPE=skill_recalc \
   docker compose -f bin/docker-compose-luigi.yml run --rm periodic-maintenance
 ```
@@ -227,8 +227,8 @@ See `doc/deployment.md` for the full recommended crontab. Summary:
 | 19:00 | `run_daily_maintenance.sh` | Daily maintenance (all steps) |
 | 22:00 1st odd months | `run_periodic_maintenance.sh long_term` | Long-term postprocessing |
 | 01:00 Dec 31 | `run_periodic_maintenance.sh skill_recalc` | Yearly skill recalculation |
-| 02:00 Aug 31 | `run_periodic_maintenance.sh snow_norms` | Yearly snow norm recalculation |
-| 03:00 Jan 1  | `run_periodic_maintenance.sh monthly_norms` | Yearly monthly discharge norm recalculation from iEH HF SDK |
+| 02:00 Jan 1 | `run_periodic_maintenance.sh snow_norms` | Yearly snow norm recalculation |
+| 03:00 Jan 1 | `yearly_runoff_hydrograph_aggregation.sh` | Yearly runoff hydrograph aggregation for monthly and seasonal dashboard views |
 
 Log files use timestamped names (`sapphire_*_YYYYMMDD.log`) with automatic
 cleanup of logs older than 7 days.

--- a/bin/daily_gateway_maintenance.sh
+++ b/bin/daily_gateway_maintenance.sh
@@ -9,7 +9,7 @@
 # API instead of just yesterday+today:
 #   - Quantile_Mapping_OP.py:    last 30 days of meteo (P, T)
 #   - extend_era5_reanalysis.py: last 365 days of reanalysis + dashboard norms
-#   - snow_data_operational.py:  last 30 days of snow (SWE, HS, RoF)
+#   - snow_data_operational.py:  last 365 days of snow (SWE, HS, RoF)
 #
 # CSVs are always written in full regardless of sync mode.
 #
@@ -98,7 +98,7 @@ fi
 # SAPPHIRE_SYNC_MODE=maintenance triggers:
 #   - Meteo (QM):        write last 30 days to API
 #   - Reanalysis (ERA5): write last 365 days to API (skipped in operational)
-#   - Snow:              write last 30 days to API
+#   - Snow:              write last 365 days to API
 # The container CMD chains all three scripts:
 #   Quantile_Mapping_OP.py && extend_era5_reanalysis.py && snow_data_operational.py
 docker run \

--- a/bin/run_periodic_maintenance.sh
+++ b/bin/run_periodic_maintenance.sh
@@ -7,8 +7,7 @@
 # Task types:
 #   long_term      - Bimonthly long-term postprocessing (1st of odd months)
 #   skill_recalc   - Yearly full skill metrics recalculation (December 31)
-#   snow_norms     - Yearly snow norm recalculation (August 31)
-#   monthly_norms  - Yearly monthly norm recalculation from iEH HF SDK (January 1)
+#   snow_norms     - Yearly snow norm recalculation (January 1)
 #
 # Example:
 #   bash bin/run_periodic_maintenance.sh long_term /path/to/config/.env
@@ -24,7 +23,7 @@ TASK_TYPE="${1}"
 if [ -z "$TASK_TYPE" ]; then
     echo "| Error: task_type argument required."
     echo "| Usage: bash bin/run_periodic_maintenance.sh <task_type> <env_file_path>"
-    echo "| Valid task_types: long_term, skill_recalc, snow_norms, monthly_norms"
+    echo "| Valid task_types: long_term, skill_recalc, snow_norms"
     exit 1
 fi
 echo "| Running Periodic Maintenance: ${TASK_TYPE}"

--- a/bin/yearly_snow_norm_recalculation.sh
+++ b/bin/yearly_snow_norm_recalculation.sh
@@ -5,8 +5,8 @@
 # and dashboard-facing statistics (SWE, HS, RoF) from historical reanalysis
 # CSVs, then writes them to the SAPPHIRE preprocessing API.
 #
-# Designed to run once a year (e.g., end of August) after the snow
-# reanalysis files have been updated for the previous season.
+# Designed to run once a year on January 1 to populate current-calendar-year
+# snow norms and statistics from completed historical snow reanalysis files.
 #
 # Usage:
 #   bash bin/yearly_snow_norm_recalculation.sh <env_file_path>
@@ -20,8 +20,8 @@
 # 3. Write full-year norm and statistic records to the preprocessing API
 # 4. Log all output to a timestamped log file
 #
-# Crontab example (run snow norm/stat recalculation Aug 25 at 02:00):
-#   0 2 25 8 * /path/to/bin/yearly_snow_norm_recalculation.sh /path/to/config/.env
+# Crontab example (run snow norm/stat recalculation Jan 1 at 02:00):
+#   0 2 1 1 * /path/to/bin/yearly_snow_norm_recalculation.sh /path/to/config/.env
 #
 # Author: Beatrice Marti
 

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -904,8 +904,8 @@ Add the following to the crontab file:
 0 22 1 1,3,5,7,9,11 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh long_term /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_longterm_$(date +\%Y\%m\%d).log 2>&1
 # Yearly skill recalculation at 01:00 UTC on December 31
 0 1 31 12 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_skillrecalc_$(date +\%Y\%m\%d).log 2>&1
-# Yearly snow norm/stat recalculation at 02:00 UTC on August 31
-0 2 31 8 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_snownorms_$(date +\%Y\%m\%d).log 2>&1
+# Yearly snow norm/stat recalculation at 02:00 UTC on January 1
+0 2 1 1 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_snownorms_$(date +\%Y\%m\%d).log 2>&1
 # Yearly monthly discharge norm recalculation from iEH HF SDK at 03:00 UTC on January 1
 0 3 1 1 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh monthly_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_monthlynorms_$(date +\%Y\%m\%d).log 2>&1
 ```

--- a/doc/plans/deployment_new_hydromet_aws.md
+++ b/doc/plans/deployment_new_hydromet_aws.md
@@ -646,8 +646,8 @@ Skip this section if the deployment is LAN-only — users can reach the dashboar
   0 17 1 1,3,5,7,9,11 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh long_term /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_longterm_$(date +\%Y\%m\%d).log 2>&1
   # Yearly skill recalculation (December 31)
   0 1 31 12 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_skillrecalc_$(date +\%Y\%m\%d).log 2>&1
-  # Yearly snow norm recalculation (August 31)
-  0 2 31 8 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_snownorms_$(date +\%Y\%m\%d).log 2>&1
+  # Yearly snow norm recalculation (January 1)
+  0 2 1 1 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_snownorms_$(date +\%Y\%m\%d).log 2>&1
   # Yearly monthly discharge norm recalculation from iEH HF SDK (January 1)
   0 3 1 1 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh monthly_norms /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_periodic_monthlynorms_$(date +\%Y\%m\%d).log 2>&1
   ```

--- a/doc/plans/issues/high_prio_gi_draft_prepg_snow_population_self_heal.md
+++ b/doc/plans/issues/high_prio_gi_draft_prepg_snow_population_self_heal.md
@@ -1,0 +1,419 @@
+# PREPG-007: Snow visualization population gaps - self-healing curve and Jan 1 snow norms
+
+**Status**: Draft (2026-06-25)
+**Module**: `apps/preprocessing_gateway` + deployment cron/docs
+**Priority**: **High** (user-facing defect on a deployed forecast dashboard)
+**Labels**: `preprocessing_gateway`, `snow-data`, `operational`, `dashboard`, `maintenance`
+**Source of truth**: `doc/plans/snow_visualization_population_design.md`
+**Related**: PREPG-001, PREPG-006, PREPG-008, FD-014
+
+> Sanitized: use placeholder station code `19999` in tests and examples. Do not commit real
+> station codes, real discharge values, real SWE values, or deployment secrets.
+
+---
+
+## Summary
+
+Fix two operational snow-population gaps that make the dashboard snow plot incomplete:
+
+1. Current-season `value`/`current` can develop a historical gap because operational snow writes only
+   `date >= yesterday`, and maintenance snow writes only `today - 30 days` even though the gateway
+   already fetches `today - 365 days`.
+2. Snow norm/previous/percentile bands are missing for the current calendar-year part of the
+   hydrological display window because `snow_norms` runs on Aug 31 and writes the current calendar
+   year only then.
+
+This issue implements the validated design with reviewer corrections:
+
+- **Change B**: widen only the maintenance-mode snow write filter in `dg_utils.write_snow_to_api()`
+  from 30 days to 365 days. Operational mode remains `date >= yesterday`. Add the defensive
+  anti-clobber guard needed for the wider write window.
+- **Change A**: retarget the existing annual `snow_norms` periodic-maintenance schedule from Aug 31
+  (`0 2 31 8 *`) to Jan 1. Give `snow_norms` its own Jan-1 cron line, for example `0 2 1 1 *`,
+  at least 30 minutes away from the real Jan-1 runoff hydrograph aggregation job at 03:00.
+- **Rollout**: after deploy, take a pre-remediation backup and SQL count snapshot, run one widened
+  maintenance sync, then run one current-year snow norm recalc for 2026.
+
+No service changes, no new scripts, and no second annual snow-norm pass are in scope.
+
+---
+
+## Problem
+
+The forecast dashboard snow plot uses a hydrological display window, for example
+`2025-09-01 ... 2026-08-31`. On a deployed dashboard:
+
+- The current-season curve is present through early 2026, has a gap, then resumes around mid-May.
+- From mid-May onward the current-season curve and forecast render, but `norm`, `previous`, and
+  percentile/min-max bands are absent for the 2026 portion.
+
+The service schema and `/snow/` endpoint already expose the needed fields. This is an operational
+population problem, not a dashboard rendering problem.
+
+## Root Cause
+
+### Bands
+
+`recalculate_snow_norms.py` writes records per calendar year and already defaults to the current
+calendar year. The current cron runs `run_periodic_maintenance.sh snow_norms` on Aug 31
+(`0 2 31 8 *`), so the Jan-Aug part of the hydrological display window has no current-year bands
+until late August.
+
+The script itself does not need a code change for this issue. Climatology inputs are identical on
+Jan 1 and Aug 31 because they come from completed prior years. The leap-year day-of-year climatology
+bug is tracked separately as PREPG-008 because fixing it requires editing `recalculate_snow_norms.py`,
+which is out of scope here.
+
+### Current curve
+
+`snow_data_operational.py` already fetches the last 365 days, but `dg_utils.write_snow_to_api()` drops
+all but the last 30 days in maintenance mode. There is no path that heals a hole older than 30 days.
+
+Existing cooperation must remain unchanged:
+
+- Maintenance writes preserve recalc bands in `dg_utils.py` (`norm`, stats, `previous` fields).
+- Recalc preserves existing `value`/`current` in `recalculate_snow_norms.py`.
+
+The wider maintenance window also increases the blast radius of incomplete incoming CSV rows. In
+`dg_utils.py:943-947`, elevation-band columns `value1` ... `value14` are taken only from the incoming
+CSV row. They are not in `SNOW_PRESERVED_STAT_FIELDS`, and the service upsert overwrites columns with
+`None` because `crud.py:238` uses `model_dump()` without `exclude_none`, then `crud.py:256-257`
+blindly assigns every field. The P1 implementation must therefore include a narrow anti-clobber guard.
+
+---
+
+## Executor Constraints
+
+- Agents may modify only the files listed in each phase's allow-list.
+- Changes must be additive/minimal. Do **NOT** change existing function signatures, data flow, or
+  control flow beyond the specific filter widening and defensive row/field guard described here.
+- Test behavior, not implementation details. New or changed logic gets tests; follow
+  `doc/dev/testing_workflow.md`.
+- Use placeholder station code `19999` in new or changed tests/fixtures. Do not use real station
+  codes or real discharge/SWE values.
+- Do not edit `sapphire/services/**`; the snow fields already exist.
+- Do not add scripts or a second annual snow-norm pass. Retarget the existing `snow_norms` annual
+  cadence.
+- Do not change `apps/preprocessing_gateway/snow_data_operational.py`; it already fetches 365 days.
+- Do not change `apps/preprocessing_gateway/recalculate_snow_norms.py` in PREPG-007. Leap-year
+  climatology alignment is PREPG-008.
+- Change A and Change B must ship as one deployable unit. Do not deploy the Jan-1 cron retarget to a
+  server without the widened maintenance sync: the removed Aug-31 recalc previously backfilled
+  `current` for Jan-Aug, and that responsibility transfers to maintenance after this change.
+
+---
+
+## Phases
+
+### P1 - Change B: self-healing maintenance snow writes
+
+**Goal**
+
+Widen maintenance-mode snow writes so `daily_gateway_maintenance.sh` rewrites the full 365-day snow
+window and can heal historical `value`/`current` holes. Keep operational mode unchanged.
+
+**Files**
+
+Allowed to modify:
+
+- `apps/preprocessing_gateway/dg_utils.py`
+- `apps/preprocessing_gateway/test/test_api_integration.py`
+- `apps/preprocessing_gateway/test/test_edge_cases.py`
+- `apps/preprocessing_gateway/test/test_integration_preprocessing_gateway.py`
+- `apps/preprocessing_gateway/test/test_api_coverage_gaps.py`
+
+No other files.
+
+**Depends on**
+
+None.
+
+**Agents**
+
+1 Sonnet 4.6 general-purpose agent, `isolation: "worktree"`.
+
+Scope:
+
+- In `write_snow_to_api()`, change only the maintenance-mode cutoff from `ref - 30 days` to
+  `ref - 365 days`.
+- Update the maintenance docstring in `dg_utils.py:739-748` and any stale "30 day" wording in the
+  snow write path to 365.
+- Rewrite and rename these existing tests that will fail after the 365-day change. Do not delete
+  them:
+  - `test_api_integration.py:304` `test_writes_last_30_days_only`
+  - `test_api_integration.py:1805` `test_maintenance_mode_writes_last_30_days`
+  - `test_api_integration.py:2189` `test_reference_date_used_for_maintenance` (update expected
+    count and start date)
+  - `test_edge_cases.py:566` `test_maintenance_30_day_window_spanning_year_boundary`
+- Correct stale snow-maintenance docstrings/comments at:
+  - `test_api_integration.py:239`, `:246`, `:305`, `:1806`, `:2223`, and class doc `:244-248`
+  - `test_edge_cases.py:566-567`, `:598`
+  - `test_integration_preprocessing_gateway.py:1212-1213` (`test_snow_operational_vs_maintenance_filtering`)
+    from "maintenance writes 30 days" to 365 days; its body only asserts
+    `len(maintenance_snow) >= len(operational_snow)` at `:1300-1304`, which holds for both window
+    sizes, so exact-window coverage comes from the new boundary test rather than strengthening this
+    integration assertion.
+- Use `test_api_integration.py:2362`
+  `test_maintenance_mode_writes_last_365_days` as the reanalysis precedent/template.
+- Add a maintenance-mode band-preservation test for an old row: seed `read_snow` with a non-empty
+  record about 100 days before `reference_date` carrying `norm`, `mean`, `min`, `max`, `q05`, `q25`,
+  `q50`, `q75`, `q95`, and `previous`; run `mode="maintenance"` with incoming data lacking those
+  columns; assert the written old-date record retains every stat-band field and updates only
+  `value`/`current`.
+- Add a 365/366 boundary test: a row at `reference_date - 366 days` is not written, and a row at
+  `reference_date - 365 days` is written.
+- Add a defensive anti-clobber guard in `write_snow_to_api()` for wider-window incomplete rows:
+  - Skip appending a record when its incoming main value and all incoming elevation-band values are
+    `None`.
+  - For value-only incoming rows, do not send `value1` ... `value14` as `None` over existing
+    DB-populated bands. Either preserve existing band values or omit absent band keys so the upsert
+    does not null them.
+  - If the incoming main value is missing, fall `value` back to the existing API value the same way
+    `current` already does at `dg_utils.py:918-926`.
+  - Do not change function signatures or unrelated control flow.
+- Add a test proving an old date with DB-populated `value1` ... `value14` bands and value-only
+  incoming data is not nulled by the write.
+- Do not alter unrelated write/read behavior.
+
+Explicitly out of scope / do not touch (legitimately 30-day or unrelated):
+
+- `test_consistency_failures.py:189-207` (`reanalysis _check_snow_consistency`)
+- `test_integration_preprocessing_gateway.py:946-963` (meteo QM)
+- `test_api_integration.py:2280-2306` (meteo QM)
+
+**Acceptance criteria**
+
+- [ ] Maintenance mode writes snow rows across the full 365-day window using a deterministic
+      reference date; the assertion is behavioral (records written by date), not implementation
+      inspection.
+- [ ] The `reference_date - 365 days` boundary is inclusive and `reference_date - 366 days` is
+      excluded.
+- [ ] Operational mode remains unchanged: it writes only records with `date >= yesterday`.
+- [ ] Maintenance write preservation still holds after widening: existing `norm`, `mean`, `min`,
+      `max`, `q05`, `q25`, `q50`, `q75`, `q95`, `previous`, and `current` cooperation is not
+      clobbered by the wider write.
+- [ ] Existing DB-populated elevation bands (`value1` ... `value14`) are not nulled when an old
+      maintenance-row update has only the main snow value and no incoming band columns/values.
+- [ ] Fully empty incoming rows (no main value and no elevation-band values) are not written.
+- [ ] Recalc cooperation remains intact by test or existing-test coverage: `recalculate_snow_norms.py`
+      preserves existing `value`/`current` values when writing bands.
+- [ ] No real station codes or real data values appear in new/changed tests; use `19999` and dummy
+      numeric values only.
+- [ ] From `apps/`, `SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_gateway` passes with zero
+      unexpected skips. The only acceptable skip is the explicit `sapphire-api-client` dependency gate.
+
+### P2 - Change A: retarget annual snow_norms to Jan 1
+
+**Goal**
+
+Retarget the annual `snow_norms` periodic-maintenance schedule from Aug 31 to Jan 1, replacing the
+Aug-31 run. Keep one annual snow-norm pass only.
+
+**Files**
+
+Allowed to modify:
+
+- `doc/deployment.md`
+- `doc/prod/update_deployment_checklist.md`
+- `doc/prod/first_deploy_checklist.md`
+- `doc/plans/deployment_new_hydromet_aws.md`
+- `bin/README.md`
+- `bin/run_periodic_maintenance.sh`
+- `bin/yearly_snow_norm_recalculation.sh`
+- `bin/daily_gateway_maintenance.sh`
+
+No other files.
+
+**Depends on**
+
+None. P2 can run in parallel with P1.
+
+**Agents**
+
+1 Sonnet 4.6 general-purpose agent, `isolation: "worktree"`.
+
+Scope:
+
+- Update deployment cron snippets and schedule tables so `snow_norms` runs on Jan 1 and targets the
+  current calendar year.
+- Do not describe `snow_norms` as co-scheduled with `monthly_norms`. `monthly_norms` is not a
+  supported `RunPeriodicMaintenanceWorkflow` task type in `apps/pipeline/pipeline_docker.py:2049-2053`;
+  running `bin/run_periodic_maintenance.sh monthly_norms` would raise `ValueError`.
+- Give `snow_norms` its own Jan-1 cron line, for example `0 2 1 1 *`, kept at least 30 minutes away
+  from the real Jan-1 runoff hydrograph aggregation job (`bin/yearly_runoff_hydrograph_aggregation.sh`,
+  cron `0 3 1 1 *`) to avoid SSH-tunnel/cleanup-trap contention.
+- In `doc/deployment.md:909-910` and `doc/plans/deployment_new_hydromet_aws.md:651-652`, the
+  documented `run_periodic_maintenance.sh monthly_norms` cron lines are a known adjacent defect and
+  out of scope for PREPG-007; do not modify them here, but place the new `snow_norms` Jan-1 line at
+  least 30 minutes away from the documented `0 3 1 1 *` job in each file.
+- Correct the stale `monthly_norms` claim in the `bin/README.md` periodic-maintenance schedule/table.
+- Remove stale references that instruct operators to run annual snow norms on Aug 31.
+- In `bin/run_periodic_maintenance.sh`, update task descriptions so they only list supported task
+  types (`long_term`, `skill_recalc`, `snow_norms`) unless the code is changed in a separate issue.
+- In `bin/yearly_snow_norm_recalculation.sh`, update only the docstring wording so it no longer
+  implies an August cadence and aligns with the Jan-1 schedule. That file's example cron is
+  `0 2 25 8 *`, not a day-31 cron, so there is no `0 2 31 8 *` line there to change.
+- In `bin/daily_gateway_maintenance.sh`, update operator-facing comments at `:12` and the
+  `SAPPHIRE_SYNC_MODE` block around `:98-102` so snow says 365 days. This file has no cron line, so
+  it is exempt from the `0 2 31 8` grep check.
+- Update only schedule/docs/docstrings. Do not change `recalculate_snow_norms.py`.
+- Do not create a second annual snow-norm task; replace the old annual cadence.
+
+**Acceptance criteria**
+
+- [ ] All listed docs/docstrings show the Jan-1 snow-norm schedule and state that it targets the
+      current calendar year.
+- [ ] `snow_norms` has its own Jan-1 cron line and is at least 30 minutes away from the 03:00 Jan-1
+      runoff hydrograph aggregation cron line.
+- [ ] Except for the explicitly out-of-scope existing cron lines in `doc/deployment.md` and
+      `doc/plans/deployment_new_hydromet_aws.md`, no docs claim `monthly_norms` is a valid
+      `run_periodic_maintenance.sh` task unless a separate implementation adds it to
+      `RunPeriodicMaintenanceWorkflow`.
+- [ ] No stale Aug-31 snow-norm schedule remains in the P2 deployment-cron/schedule allow-list. Run
+      and record:
+      `rg -n "0 2 31 8 \\*|August 31|Aug 31|8/31" doc/deployment.md doc/prod/update_deployment_checklist.md doc/prod/first_deploy_checklist.md doc/plans/deployment_new_hydromet_aws.md bin/README.md bin/run_periodic_maintenance.sh bin/yearly_snow_norm_recalculation.sh`.
+      Intentional old-state references in the design doc, this issue file, other/archived issues,
+      `bin/daily_gateway_maintenance.sh`, and dated review checklists are expected and out of scope.
+- [ ] No second annual snow-norm pass is documented or added.
+- [ ] No implementation files outside the allow-list are changed.
+
+### P3 - Rollout and one-time remediation runbook
+
+**Goal**
+
+Execute the post-deploy operational remediation that the steady-state fix does not backfill by itself:
+fill the current 2026 `value`/`current` window and then write the current-year bands.
+
+**Files**
+
+No implementation files. The runbook is this phase in this issue; deployment docs touched in P2 may
+refer to the steady-state Jan-1 schedule but must not add new code or scripts for this one-time action.
+
+**Depends on**
+
+P1 and P2.
+
+**Agents**
+
+No implementation agent required. Operator/orchestrator action after deploy.
+
+Scope:
+
+- Before remediation, take a database backup: snow-table `pg_dump` or a volume snapshot.
+- Before remediation, capture a SQL count snapshot for each `snow_type` over
+  `2025-09-01 ... 2026-08-31`, counting non-null `value`, `current`, `norm`, `previous`, `q50`, and
+  `mean`. Use placeholder station code `19999` in example SQL; never paste real station codes or
+  values into this issue.
+- Before and after crontab edits, verify `crontab -l | grep -c snow_norms` equals `1`. This catches
+  both duplicate annual passes and a missed `snow_norms` entry.
+- Retarget the live crontab on each already-deployed environment, including Tajik and Kyrgyz where
+  applicable: use `crontab -e` to replace the `snow_norms` Aug-31 entry (`0 2 31 8 *`) with the
+  Jan-1 schedule. Keep it at least 30 minutes away from the 03:00 Jan-1 runoff hydrograph aggregation
+  cron line.
+- Run exactly these commands once after the P1/P2 changes are deployed to the target environment:
+
+  ```bash
+  bash bin/daily_gateway_maintenance.sh <env>
+  ieasyhydroforecast_SNOW_RECALC_YEAR=2026 bash bin/run_periodic_maintenance.sh snow_norms <env>
+  ```
+
+- Order rationale: maintenance-first fills `value`/`current`; recalc-second
+  (`SNOW_RECALC_YEAR=2026`) is calendar-year scoped, so it wraps bands around the 2026 records and
+  cannot touch the 2025 portion of the hydrological window. If step 1 logs per-station write errors,
+  re-run step 1 successfully before step 2.
+- Verify the snow table and dashboard for the hydrological window `2025-09-01 ... 2026-08-31`.
+- Do not add code for this one-time remediation.
+
+Example sanitized SQL shape:
+
+```sql
+SELECT
+  snow_type,
+  count(*) FILTER (WHERE value IS NOT NULL) AS n_value,
+  count(*) FILTER (WHERE current IS NOT NULL) AS n_current,
+  count(*) FILTER (WHERE norm IS NOT NULL) AS n_norm,
+  count(*) FILTER (WHERE previous IS NOT NULL) AS n_previous,
+  count(*) FILTER (WHERE q50 IS NOT NULL) AS n_q50,
+  count(*) FILTER (WHERE mean IS NOT NULL) AS n_mean
+FROM snow
+WHERE code = '19999'
+  AND date BETWEEN DATE '2025-09-01' AND DATE '2026-08-31'
+GROUP BY snow_type
+ORDER BY snow_type;
+```
+
+**Acceptance criteria**
+
+- [ ] PRE backup exists before remediation: snow-table `pg_dump` or volume snapshot.
+- [ ] PRE SQL count snapshot exists for `2025-09-01 ... 2026-08-31`, grouped by `snow_type`, with
+      non-null counts for `value`, `current`, `norm`, `previous`, `q50`, and `mean`.
+- [ ] On each already-deployed environment, `crontab -l | grep -c snow_norms` equals `1` before and
+      after the cron edit.
+- [ ] On each already-deployed environment, the active crontab is retargeted: `crontab -l` shows the
+      Jan-1 `snow_norms` schedule, with no Aug-31 `snow_norms` entry remaining.
+- [ ] The widened maintenance sync completes successfully for `<env>` and writes `value`/`current`
+      rows over the 365-day maintenance window. If per-station write errors appear, step 1 is re-run
+      before step 2.
+- [ ] The one-time 2026 snow norm recalc completes successfully and writes `norm`, `previous`,
+      percentile fields, `mean`, `min`, and `max` for current-year snow rows.
+- [ ] POST SQL count verification is mandatory. For each expected snow type:
+      - POST `n_value` and `n_current` are greater than or equal to PRE and cover the known gap dates.
+      - POST 2026-portion band counts (`norm`, `previous`, `q50`, `mean`, plus percentile/min/max
+        spot checks) are greater than or equal to PRE.
+      - POST Sep-Dec 2025 band counts are greater than or equal to PRE; existing 2025 bands must not
+        decrease.
+- [ ] Verification confirms that the live dashboard snow plot shows a continuous current-season curve
+      plus norm/previous/percentile bands across the hydrological display window.
+- [ ] If verification fails, capture only sanitized counts/dates and re-run the appropriate deployed
+      task; do not expand scope into dashboard or service changes without a new issue.
+
+---
+
+## Overall Acceptance Criteria
+
+- [ ] P1 and P2 are implemented as one deployable unit.
+- [ ] Change A is not deployed anywhere without Change B.
+- [ ] Maintenance snow writes now self-heal the last 365 days; operational writes still use
+      `date >= yesterday`.
+- [ ] Band-preservation, elevation-band anti-clobber, and value-preservation cooperation all hold:
+      maintenance does not clobber recalc/stat/elevation bands, and recalc does not clobber existing
+      `value`/`current`.
+- [ ] From `apps/`, `SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_gateway` passes with zero
+      unexpected skips. The only acceptable skip is the explicit `sapphire-api-client` dependency gate.
+- [ ] All updated docs/docstrings show Jan 1 for `snow_norms`, and the grep check
+      `rg -n "0 2 31 8 \\*|August 31|Aug 31|8/31" doc/deployment.md doc/prod/update_deployment_checklist.md doc/prod/first_deploy_checklist.md doc/plans/deployment_new_hydromet_aws.md bin/README.md bin/run_periodic_maintenance.sh bin/yearly_snow_norm_recalculation.sh`
+      finds no stale snow-norm schedule references in the P2 deployment-cron/schedule allow-list.
+      Intentional old-state references in the design doc, this issue file, other/archived issues,
+      `bin/daily_gateway_maintenance.sh`, and dated review checklists are expected and out of scope.
+- [ ] On each already-deployed environment, `crontab -l | grep -c snow_norms` equals `1` before and
+      after the edit, and `crontab -l` shows the Jan-1 `snow_norms` schedule with no Aug-31
+      `snow_norms` entry remaining.
+- [ ] The one-time remediation commands are run after deploy for the current 2026 window, in the
+      documented order.
+- [ ] Mandatory PRE/POST SQL count verification shows no count regressions and confirms gap coverage.
+- [ ] Live verification shows the dashboard snow plot has a continuous current-season curve and
+      norm/previous/percentile bands across the hydrological window.
+
+## Out of Scope
+
+- `sapphire/services/**` changes.
+- New scripts.
+- A second annual `snow_norms` cron entry/pass.
+- Dashboard rendering changes.
+- `recalculate_snow_norms.py` changes in PREPG-007. Leap-year climatology alignment is PREPG-008.
+- Investigation of why the historical Jan-to-mid-May 2026 operational write gap happened on the
+  server. This fix makes that class of gap self-healing regardless of cause.
+
+---
+
+## Dependency Graph
+
+```json
+{
+  "phases": {
+    "P1": { "depends_on": [], "parallel_agents": 1 },
+    "P2": { "depends_on": [], "parallel_agents": 1 },
+    "P3": { "depends_on": ["P1", "P2"], "parallel_agents": 0 }
+  }
+}
+```

--- a/doc/plans/issues/mid_prio_gi_draft_prepg_snow_climatology_leapyear_dayofyear.md
+++ b/doc/plans/issues/mid_prio_gi_draft_prepg_snow_climatology_leapyear_dayofyear.md
@@ -1,0 +1,97 @@
+# PREPG-008: Snow climatology leap-year day-of-year alignment bug
+
+**Status**: Draft (2026-06-25)
+**Module**: `apps/preprocessing_gateway`
+**Priority**: **Medium** (real snow data-quality bug; next leap year is 2028)
+**Labels**: `preprocessing_gateway`, `snow-data`, `climatology`, `leap-year`, `dashboard`
+**Related**: PREPG-001, PREPG-006, PREPG-007, FD-014
+
+> Sanitized: use placeholder station code `19999` in tests and examples. Do not commit real
+> station codes, real SWE values, or deployment secrets.
+
+---
+
+## Summary
+
+Snow climatology is keyed by `dayofyear`. In leap years, dates after February shift by one day
+relative to non-leap years. This conflates neighboring calendar dates and assigns the wrong norm and
+percentile band to much of a leap year.
+
+The bug is pre-existing, but PREPG-007's Jan-1 full-year band write makes it visible earlier and for a
+whole leap year. It is split out because the fix must edit `recalculate_snow_norms.py`, which is
+explicitly out of PREPG-007 scope.
+
+---
+
+## Problem
+
+The snow norm/stat computation groups historical records by `df["date"].dt.dayofyear`. That makes
+Feb 29 share the ordinal calendar with Mar 1 in non-leap years, and every date after February is
+shifted by one in leap years relative to non-leap years.
+
+Result: for roughly 300 days in and after leap years, the `norm`, `mean`, `min`, `max`, and
+percentile bands assigned to a date can be a neighboring day's climatology rather than that calendar
+date's climatology.
+
+## Evidence
+
+- `apps/preprocessing_gateway/dg_utils.py:453` sets `df["dayofyear"] = df["date"].dt.dayofyear` in
+  `calculate_snow_norms_from_api()`.
+- `apps/preprocessing_gateway/dg_utils.py:467` groups norms by `dayofyear`.
+- `apps/preprocessing_gateway/dg_utils.py:593` sets `df["dayofyear"] = df["date"].dt.dayofyear` in
+  `calculate_snow_stats_from_api()`.
+- `apps/preprocessing_gateway/dg_utils.py:596` groups stats by `["snow_type", "code", "dayofyear"]`.
+- `apps/preprocessing_gateway/recalculate_snow_norms.py:142` builds a fresh target-year
+  `date_range`.
+- `apps/preprocessing_gateway/recalculate_snow_norms.py:232`, `:234`, and `:272` remap each target
+  date through `dt.dayofyear` lookups.
+
+## Why Now
+
+This bug already exists in the climatology implementation. PREPG-007 retargets `snow_norms` from
+Aug 31 to Jan 1 and writes the full current calendar year immediately. In the next leap year, that
+means the shifted climatology can be written early and persist across the whole dashboard season
+instead of surfacing only late in August.
+
+## Fix Direction
+
+Choose one calendar-normalization strategy and apply it consistently to norms and stats:
+
+- Key climatology by `(month, day)` and handle Feb 29 explicitly, for example by omitting it,
+  interpolating it, or using a documented neighboring-day policy.
+- Or normalize all years to a common 365-day climatology calendar before grouping, with an explicit
+  Feb-29 policy.
+
+Add leap/non-leap alignment tests that prove:
+
+- Mar 1 climatology does not mix with Feb 29.
+- Dates after February map to the same calendar day across leap and non-leap years.
+- The target-year recalc writes the expected norm/stat values for a leap year and a non-leap year.
+
+This requires editing `apps/preprocessing_gateway/recalculate_snow_norms.py` and the snow
+climatology helpers/tests. Do not fold it into PREPG-007.
+
+## Candidate Files
+
+- `apps/preprocessing_gateway/dg_utils.py`
+- `apps/preprocessing_gateway/recalculate_snow_norms.py`
+- `apps/preprocessing_gateway/test/test_recalculate_snow_norms.py`
+- `apps/preprocessing_gateway/test/test_api_integration.py` or a focused climatology test module
+
+## Acceptance Criteria
+
+- [ ] Snow norms and stats no longer group leap-year and non-leap-year calendar dates by raw
+      `dayofyear` in a way that shifts dates after February.
+- [ ] Feb 29 behavior is explicit, documented in code comments/docstrings, and covered by tests.
+- [ ] Leap/non-leap tests prove Mar 1 and later dates receive the intended same-calendar-day
+      climatology.
+- [ ] Existing preservation behavior remains intact: recalc still preserves existing `value`,
+      `current`, and elevation-band values.
+- [ ] From `apps/`, `SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_gateway` passes with zero
+      unexpected skips. The only acceptable skip is the explicit `sapphire-api-client` dependency gate.
+
+## Out of Scope
+
+- PREPG-007 maintenance-window widening and cron retargeting.
+- Dashboard rendering changes.
+- `sapphire/services/**` changes.

--- a/doc/plans/issues/review_gi_draft_prepg_snow_population_self_heal.md
+++ b/doc/plans/issues/review_gi_draft_prepg_snow_population_self_heal.md
@@ -1,6 +1,6 @@
 # PREPG-007: Snow visualization population gaps - self-healing curve and Jan 1 snow norms
 
-**Status**: Draft (2026-06-25)
+**Status**: Review (2026-06-25) — P1+P2 implemented, awaiting review
 **Module**: `apps/preprocessing_gateway` + deployment cron/docs
 **Priority**: **High** (user-facing defect on a deployed forecast dashboard)
 **Labels**: `preprocessing_gateway`, `snow-data`, `operational`, `dashboard`, `maintenance`

--- a/doc/plans/module_issues.md
+++ b/doc/plans/module_issues.md
@@ -124,7 +124,7 @@ These are blocking decisions — work downstream cannot advance until they are r
 | ~~**PREPG-003**~~ | ~~Snow operational API write discards all data — wall-clock-anchored window vs DG lag~~ | | Closed (Not a Bug) | [`archive/high_prio_gi_draft_prepg_snow_api_operational_window.md`](issues/archive/high_prio_gi_draft_prepg_snow_api_operational_window.md) | — |
 | ~~**PREPG-005**~~ | ~~Meteo API write discards all forecast rows — `date <= today` upper bound~~ | **High** | Complete | [`archive/high_prio_gi_draft_prepg_meteo_forecast_not_in_api.md`](issues/archive/high_prio_gi_draft_prepg_meteo_forecast_not_in_api.md) | — |
 | **PREPG-006** | Migrate snow norm computation from CSV to API | **Medium** | Draft | [`mid_prio_gi_draft_prepg_snow_norms_csv_to_api.md`](issues/mid_prio_gi_draft_prepg_snow_norms_csv_to_api.md) | PREPG-001, API must have historical snow data |
-| **PREPG-007** | Snow visualization population gaps: self-healing curve and Jan-1 snow norms | **High** | Draft | [`high_prio_gi_draft_prepg_snow_population_self_heal.md`](issues/high_prio_gi_draft_prepg_snow_population_self_heal.md) | — |
+| **PREPG-007** | Snow visualization population gaps: self-healing curve and Jan-1 snow norms | **High** | Review | [`review_gi_draft_prepg_snow_population_self_heal.md`](issues/review_gi_draft_prepg_snow_population_self_heal.md) | — |
 | **PREPG-008** | Snow climatology leap-year day-of-year alignment bug | **Medium** | Draft | [`mid_prio_gi_draft_prepg_snow_climatology_leapyear_dayofyear.md`](issues/mid_prio_gi_draft_prepg_snow_climatology_leapyear_dayofyear.md) | — |
 
 ### Preprocessing Runoff (`prepq`)

--- a/doc/plans/module_issues.md
+++ b/doc/plans/module_issues.md
@@ -124,6 +124,8 @@ These are blocking decisions — work downstream cannot advance until they are r
 | ~~**PREPG-003**~~ | ~~Snow operational API write discards all data — wall-clock-anchored window vs DG lag~~ | | Closed (Not a Bug) | [`archive/high_prio_gi_draft_prepg_snow_api_operational_window.md`](issues/archive/high_prio_gi_draft_prepg_snow_api_operational_window.md) | — |
 | ~~**PREPG-005**~~ | ~~Meteo API write discards all forecast rows — `date <= today` upper bound~~ | **High** | Complete | [`archive/high_prio_gi_draft_prepg_meteo_forecast_not_in_api.md`](issues/archive/high_prio_gi_draft_prepg_meteo_forecast_not_in_api.md) | — |
 | **PREPG-006** | Migrate snow norm computation from CSV to API | **Medium** | Draft | [`mid_prio_gi_draft_prepg_snow_norms_csv_to_api.md`](issues/mid_prio_gi_draft_prepg_snow_norms_csv_to_api.md) | PREPG-001, API must have historical snow data |
+| **PREPG-007** | Snow visualization population gaps: self-healing curve and Jan-1 snow norms | **High** | Draft | [`high_prio_gi_draft_prepg_snow_population_self_heal.md`](issues/high_prio_gi_draft_prepg_snow_population_self_heal.md) | — |
+| **PREPG-008** | Snow climatology leap-year day-of-year alignment bug | **Medium** | Draft | [`mid_prio_gi_draft_prepg_snow_climatology_leapyear_dayofyear.md`](issues/mid_prio_gi_draft_prepg_snow_climatology_leapyear_dayofyear.md) | — |
 
 ### Preprocessing Runoff (`prepq`)
 

--- a/doc/plans/snow_visualization_population_design.md
+++ b/doc/plans/snow_visualization_population_design.md
@@ -1,0 +1,105 @@
+# Snow Visualization Population — Durable Self-Healing Design
+
+**Status:** Validated design (brainstorming complete) — ready for issue planning.
+**Date:** 2026-06-25
+
+## Problem
+
+On the forecast dashboard snow plot (display window is *hydrological*, e.g.
+KGHM `SNOW_DISPLAY_START=09-01` → window `2025-09-01 … 2026-08-31`):
+
+1. **Curve gap** — `value`/`current` displays correctly through ~Jan 2026, then a
+   gap until ~mid-May 2026, after which the current-season curve resumes.
+2. **Missing bands** — from mid-May onward the current-season curve and the
+   forecast render, but `norm`, `previous`, and the percentile/min–max bands
+   (`mean/min/max/q05..q95`) are absent for the whole 2026 portion.
+
+Both are **operational population gaps, not dashboard bugs**. The service schema
+and `/snow/` endpoint expose all fields correctly.
+
+## Root cause
+
+Two independent population paths, each structurally fragile:
+
+- **Bands** are written only by `recalculate_snow_norms.py`, scheduled **once a
+  year on Aug 31** (`run_periodic_maintenance.sh snow_norms`, cron `0 2 31 8 *`).
+  The recalc writes records **per calendar year** (`{year}-01-01 … {year}-12-31`,
+  `recalculate_snow_norms.py:142`) and defaults to the current year
+  (`recalculate_snow_norms.py:381`). Because the display window is *hydrological*,
+  it straddles two calendar years: the Aug-31 run writes year-N bands at the end
+  of year N, so on Jan 1 of year N the bands for that year do not yet exist and
+  will not until the following Aug 31. → symptom 2, recurring every January.
+
+- **`value`/`current`** is written by the gateway snow sync. Operational mode
+  writes only `date >= yesterday` (`dg_utils.py:819`); maintenance mode widens to
+  `today-30` (`dg_utils.py:821`). The gateway *fetches* `today-365`
+  (`snow_data_operational.py`), but the write filter discards all but the last 30
+  days. There is **no path that heals a historical hole** — a stretch of missed
+  daily writes (Jan→mid-May on this server) stays empty permanently. → symptom 1.
+
+The two jobs already cooperate without clobbering: maintenance writes preserve
+recalc's bands (`dg_utils.py:864`), and recalc preserves the existing `value`
+(`recalculate_snow_norms.py:245`).
+
+## Design (reuse existing machinery — no new programs)
+
+### Change A — bands present year-round (cron cadence)
+
+Retarget the existing `snow_norms` periodic-maintenance task from **Aug 31** to
+**Jan 1**, targeting the current calendar year (co-schedule with the existing
+`monthly_norms` Jan-1 task). The recalc is already current-year-aware and
+idempotent; climatology is computed from completed prior years, so it is fully
+available on Jan 1. One run per year at the start of the year covers the whole
+Sep→Aug window (year N-1 bands cover Sep–Dec, year N bands cover Jan–Aug).
+
+No `recalculate_snow_norms.py` change. Cron/doc change only.
+
+### Change B — self-healing curve (widen the maintenance write window)
+
+Widen the snow branch of the maintenance write filter in `dg_utils.py:821` from
+`today-30` to **`today-365`**, matching the data the gateway already fetches and
+the reanalysis-maintenance precedent (also 365 d). The existing
+`daily_gateway_maintenance.sh` then rewrites the full window every run, so any
+`value`/`current` gap self-heals at the maintenance cadence. No new script, no new
+cron entry. (365 d covers the hydrological window in practice; data written in
+earlier runs persists via upsert, so the window-start month remains populated even
+when it ages past the 365-day lookback late in the year.)
+
+## Rollout (steady-state fix + one-time remediation)
+
+The cadence change is steady-state and does **not** retroactively populate the
+current (2026) window. After deploying A + B, run once to heal this season:
+
+1. Widened maintenance sync (fills `value`/`current` for the full window):
+   `bash bin/daily_gateway_maintenance.sh <env>`
+2. Current-year band recalc:
+   `ieasyhydroforecast_SNOW_RECALC_YEAR=2026 bash bin/run_periodic_maintenance.sh snow_norms <env>`
+
+Verify with the dashboard and/or the snow-table SQL counts (value/current/norm/
+percentile/previous row counts over `2025-09-01 … 2026-08-31`).
+
+## Files affected
+
+- `apps/preprocessing_gateway/dg_utils.py` — maintenance snow filter `30 → 365` (Change B).
+- Cron schedule + docs for `snow_norms` (Change A):
+  `doc/deployment.md`, `doc/prod/update_deployment_checklist.md`,
+  `doc/prod/first_deploy_checklist.md`, `doc/plans/deployment_new_hydromet_aws.md`,
+  `bin/README.md`, and the docstrings in `bin/run_periodic_maintenance.sh` /
+  `bin/yearly_snow_norm_recalculation.sh`.
+- Tests: `apps/preprocessing_gateway/test/` (maintenance window width).
+
+## Out of scope / non-goals
+
+- No service (`sapphire/services/`) changes — fields already exist.
+- No new scripts or cron entries — reuse `daily_gateway_maintenance.sh` and the
+  `snow_norms` periodic task.
+- The "why did operational snow writes stop Jan→mid-May on this server" history is
+  a separate ops question; Change B makes it self-healing regardless of cause.
+
+## Testing
+
+- Unit: maintenance-mode snow filter returns the full 365-day window (not 30 d);
+  operational mode still narrow (`date >= yesterday`); band-preservation and
+  value-preservation cooperation unchanged.
+- Recalc current-year default + `SNOW_RECALC_YEAR` override behavior (existing).
+- `SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_gateway` — zero skips.

--- a/doc/prod/first_deploy_checklist.md
+++ b/doc/prod/first_deploy_checklist.md
@@ -793,11 +793,11 @@ The block below is the post-S1-2026 consolidated Luigi-wrapper pattern. The auth
   # (consolidated Luigi wrapper). Full-history safety net.
   0 1 31 12 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_yearly_skill_recalc_$(date +\%Y\%m\%d).log 2>&1
 
-  # (8) Yearly snow norm/stat recalculation at 02:00 UTC on August 31
+  # (8) Yearly snow norm/stat recalculation at 02:00 UTC on January 1
   # (consolidated Luigi wrapper). Supersedes legacy
   # bin/yearly_snow_norm_recalculation.sh (kept for manual / debugging
   # use only).
-  0 2 31 8 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_yearly_snow_norm_$(date +\%Y\%m\%d).log 2>&1
+  0 2 1 1 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_yearly_snow_norm_$(date +\%Y\%m\%d).log 2>&1
 
   # (9) Yearly runoff hydrograph aggregation at 03:00 UTC on January 1.
   # Replaces the retired YearlyMonthlyNormsRecalculation Luigi task. Builds

--- a/doc/prod/update_deployment_checklist.md
+++ b/doc/prod/update_deployment_checklist.md
@@ -722,10 +722,10 @@ The canonical schedule below follows the post-S1-2026 consolidated Luigi-wrapper
   # dashboard tiles fresh; this is the annual deep recalc).
   0 1 31 12 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_yearly_skill_recalc_$(date +\%Y\%m\%d).log 2>&1
 
-  # (8) Yearly snow norm/stat recalculation at 02:00 UTC on August 31.
+  # (8) Yearly snow norm/stat recalculation at 02:00 UTC on January 1.
   # Consolidated Luigi wrapper. Supersedes legacy bin/yearly_snow_norm_recalculation.sh
   # (kept on origin for manual / debugging use only).
-  0 2 31 8 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_yearly_snow_norm_$(date +\%Y\%m\%d).log 2>&1
+  0 2 1 1 * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_yearly_snow_norm_$(date +\%Y\%m\%d).log 2>&1
 
   # (9) Yearly runoff hydrograph aggregation at 03:00 UTC on January 1.
   # Replaces the retired YearlyMonthlyNormsRecalculation Luigi task. Builds


### PR DESCRIPTION
## Summary

Fixes two operational gaps that left the dashboard snow plot incomplete (curve gap Jan→mid-May, and missing norm/previous/percentile bands for the current year). Both were population-cadence problems, not rendering bugs. Implements the validated design in `doc/plans/snow_visualization_population_design.md`.

Two root causes, two fixes (reuse-only — no new scripts, no service changes):

- **Bands missing for the current year (P2):** the `snow_norms` recalc ran once a year on **Aug 31**, but the display window is hydrological (straddles two calendar years), so the current calendar year had no bands until late August. → Retarget the cron to **Jan 1** (current year), across all deployment docs/crontab snippets.
- **Curve gaps never self-heal (P1):** gateway maintenance-mode snow writes covered only the last **30 days**, so any missed-write stretch stayed empty permanently. → Widen the maintenance write window to **365 days** (data is already fetched), with an **anti-clobber guard** that preserves existing `value`/elevation bands and skips fully-empty incoming rows so the wider write can't null populated data.

## Changes

- **P1** — `apps/preprocessing_gateway/dg_utils.py`: maintenance snow window 30→365 + anti-clobber guard; tests rewritten to 365-day behaviour plus new old-row stat-band preservation, elevation-band preservation, and 365/366 boundary coverage.
- **P2** — cron retarget Aug 31→Jan 1 in `doc/deployment.md`, both prod checklists, `deployment_new_hydromet_aws.md`, `bin/README.md`, and `bin/run_periodic_maintenance.sh`/`bin/yearly_snow_norm_recalculation.sh` docstrings; removed `monthly_norms` from the periodic-maintenance task list (not a valid Luigi task) and documented Jan-1 monthly work runs via `yearly_runoff_hydrograph_aggregation.sh`; gateway maintenance comments updated to 365-day snow.
- **Planning** — design doc, PREPG-007 (this, now in Review) and PREPG-008 (leap-year day-of-year climatology follow-up) issue drafts + index rows.

## Testing

`SAPPHIRE_TEST_ENV=True bash run_tests.sh preprocessing_gateway` → **326 passed, 0 skips** on the consolidated branch.

## Post-merge operator action (P3 — not automated)

The cadence fix is steady-state; it does not retroactively populate the current (2026) window. After deploy, per the runbook in the issue: snapshot/backup → widened maintenance sync → `SNOW_RECALC_YEAR=2026` recalc → PRE/POST SQL count check (anti-clobber: Sep–Dec 2025 band counts must not decrease) → confirm `crontab -l | grep -c snow_norms == 1`. **Deploy P1 and P2 together** — the Jan-1 cron must not ship without the widened maintenance sync.

## Follow-up

- **PREPG-008** (filed): pre-existing leap-year `dayofyear` climatology phase error, exposed earlier by the Jan-1 full-year write; out of scope here because it requires editing `recalculate_snow_norms.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)