### PR TITLE
PREPG-009 P1: stable ORDER BY for get_snow pagination (⚠ service — needs owner review)

### DIFF
--- a/sapphire/services/preprocessing/app/crud.py
+++ b/sapphire/services/preprocessing/app/crud.py
@@ -297,6 +297,7 @@ def get_snow(db: Session, snow_type: Optional[str] = None, code: Optional[str] =
             query = query.filter(Snow.date >= start_date)
         if end_date:
             query = query.filter(Snow.date <= end_date)
+        query = query.order_by(Snow.snow_type, Snow.code, Snow.date, Snow.id)
         results = query.offset(skip).limit(limit).all()
         logger.info(f"Fetched {len(results)} snow records (code={code}, skip={skip}, limit={limit})")
         return results

--- a/sapphire/services/preprocessing/tests/test_crud.py
+++ b/sapphire/services/preprocessing/tests/test_crud.py
@@ -5,6 +5,7 @@ Tests the SQLAlchemy CRUD functions directly (no HTTP layer) using
 SQLite in-memory databases.
 """
 
+import random
 from datetime import date
 
 import pytest
@@ -339,6 +340,107 @@ class TestSnowCRUD:
     def test_empty_results(self, db_session):
         results = crud.get_snow(db_session, code="NONEXISTENT")
         assert results == []
+
+
+# -------------------------------------------------------------------
+# Snow pagination stable ordering (PREPG-009)
+# -------------------------------------------------------------------
+
+class TestSnowPaginationOrdering:
+    """Regression tests for PREPG-009.
+
+    get_snow() must apply a stable ORDER BY (snow_type, code, date, id)
+    before offset/limit so that whole-table pagination is complete,
+    non-overlapping, and stable across repeated calls. Without the
+    ORDER BY, OFFSET/LIMIT over a large snow table returns a
+    nondeterministic, potentially incomplete subset.
+    """
+
+    @staticmethod
+    def _expected_key(row):
+        # SnowType is a str-Enum; .value gives the stable string form.
+        snow_type = getattr(row.snow_type, "value", row.snow_type)
+        return (snow_type, row.code, row.date, row.id)
+
+    def _seed_shuffled_snow(self, db_session):
+        """Seed > 1 page of snow rows across multiple codes and years,
+        inserting them in deliberately shuffled order.
+
+        Returns the total number of seeded rows.
+        """
+        # Dummy placeholder station codes only (no real station codes).
+        codes = ["19999", "29999", "39999"]
+        years = [2020, 2021, 2022, 2023]
+        days = list(range(1, 9))
+        # 3 codes * 4 years * 8 days = 96 rows; with page_size=10 this
+        # spans many pages, well past a single page.
+
+        items = []
+        for code in codes:
+            for year in years:
+                for day in days:
+                    items.append(
+                        make_snow(
+                            snow_type="SWE",
+                            code=code,
+                            date=date(year, 1, day),
+                            value=float(year * 100 + day),
+                            norm=float(year),
+                        )
+                    )
+
+        # Deterministic shuffle so insertion order does NOT match the
+        # expected domain order (snow_type, code, date, id).
+        random.Random(1234).shuffle(items)
+
+        crud.create_snow(db_session, SnowBulkCreate(data=items))
+        return len(items)
+
+    def _paginate_all(self, db_session, page_size):
+        """Walk every page via get_snow(skip, limit) and concatenate."""
+        all_rows = []
+        skip = 0
+        while True:
+            page = crud.get_snow(db_session, skip=skip, limit=page_size)
+            if not page:
+                break
+            # A page may never exceed the requested limit.
+            assert len(page) <= page_size
+            all_rows.extend(page)
+            if len(page) < page_size:
+                break
+            skip += page_size
+        return all_rows
+
+    def test_pagination_complete_nonoverlapping_ordered(self, db_session):
+        total = self._seed_shuffled_snow(db_session)
+        page_size = 10
+        assert total > page_size  # sanity: more than one page
+
+        rows = self._paginate_all(db_session, page_size)
+
+        ids = [r.id for r in rows]
+        # Complete: every seeded row returned exactly once.
+        assert len(ids) == total
+        # Non-overlapping: no row appears in more than one page.
+        assert len(set(ids)) == total
+        # The id set matches every row actually stored.
+        stored_ids = {r.id for r in db_session.query(Snow).all()}
+        assert set(ids) == stored_ids
+
+        # Ordered by (snow_type, code, date, id).
+        keys = [self._expected_key(r) for r in rows]
+        assert keys == sorted(keys)
+
+    def test_pagination_stable_across_repeated_calls(self, db_session):
+        self._seed_shuffled_snow(db_session)
+        page_size = 10
+
+        first = [r.id for r in self._paginate_all(db_session, page_size)]
+        second = [r.id for r in self._paginate_all(db_session, page_size)]
+
+        # Repeated paginated calls return the same ordered sequence.
+        assert first == second
 
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## ⚠ Drafted for service-owner review

This touches colleague-owned `sapphire/services/`. It is **non-contract-changing** (same route, params, response model — only result ordering) but **must not be merged without the preprocessing-service owner's approval.**

## Problem

`crud.get_snow()` paginates with `.offset(skip).limit(limit)` and **no `ORDER BY`**. PostgreSQL gives no stable row order across OFFSET/LIMIT without an explicit order, so any consumer that walks the large `snow` table in pages gets a **nondeterministic, incomplete subset**. This silently corrupts snow climatology: `calculate_snow_stats_from_api` / `calculate_snow_norms_from_api` (which read the whole table in 10k-row pages) compute per-day-of-year year-counts from a random slice, so percentile/min/max/mean bands flicker and vanish between runs. Observed: a station with 26 years of Jan-1 SWE history had a stored `count=2` → bands nulled.

## Fix

One line in `get_snow()` — add a stable order before pagination:
```python
query = query.order_by(Snow.snow_type, Snow.code, Snow.date, Snow.id)
```
Once results are ordered, the existing whole-table paginated reads become deterministic and complete; no app-side change is needed. This fixes **all** paginating `get_snow()` consumers, not just snow climatology.

## Test

Adds `TestSnowPaginationOrdering` to `tests/test_crud.py`: seeds 96 rows across 3 dummy codes × 4 years × 8 days, **inserted shuffled**, paginates at `limit=10`, and asserts the page union is complete, non-overlapping, ordered by `(snow_type, code, date, id)`, and stable across repeated walks. Verified it **fails without** the `ORDER BY` and passes with it. Placeholder codes only (`19999/29999/39999`).

Service suite: **112 passed**.

## Context

Root cause behind the intermittent/missing/jumping snow bands tracked in **PREPG-009**. Its P2 remediation (recompute affected climatology) depends on this landing. Distinct from PREPG-008 (leap-year day-of-year).

🤖 Generated with [Claude Code](https://claude.com/claude-code)