### PR TITLE
Remove 3-day-mean annotation from snow current-season legend

### DIFF
--- a/apps/forecast_dashboard/src/vizualization.py
+++ b/apps/forecast_dashboard/src/vizualization.py
@@ -2312,35 +2312,8 @@ def plot_daily_snow_data(_, wm, snow_data, variable, station, date_picker,
     # Get the forecasts for the selected date
     forecasts = current_year[current_year['date'] >= date_picker].copy()
 
-    # Get predictor period data — predictor data is only available for short
-    # horizons. Under month/quarter/season the caller passes an empty
-    # DataFrame, so leave predictor_snow empty (the label below already falls
-    # back to "Current year" when the mean is NaN).
-    horizon = wm.horizon_selector.value
-    linreg_predictor = processing.add_predictor_dates(horizon, linreg_predictor, station, date_picker)
-    if (
-        not linreg_predictor.empty
-        and 'predictor_start_date' in linreg_predictor.columns
-    ):
-        predictor_start_date = linreg_predictor['predictor_start_date'].values[0]
-        predictor_end_date = linreg_predictor['predictor_end_date'].values[0]
-        predictor_snow = current_year[(current_year['date'] >= predictor_start_date) &
-                                      (current_year['date'] <= predictor_end_date)].copy()
-    else:
-        predictor_snow = current_year.iloc[0:0].copy()
-
-    # horizon = os.getenv("sapphire_forecast_horizon", "pentad")
-    if horizon == "pentad":
-        current_period = _("3 day mean")
-        forecast_period = _("5 day mean")
-    else:
-        current_period = _("10 day mean")
-        forecast_period = _("10 day mean")
-
     # Plot title and labels
     title_text = f"{config['label']} {_('for basin of')} {station} {_('on')} {date_picker.strftime('%Y-%m-%d')}"
-    mean_value = predictor_snow[variable].mean()
-    decimals = config['decimals']
 
     # Forecast label
     forecast_text = _('Forecast')
@@ -2362,7 +2335,7 @@ def plot_daily_snow_data(_, wm, snow_data, variable, station, date_picker,
     else:
         current_year_label = _("Current year")
         last_year_label = _("Last year legend entry")
-    current_year_text = f"{current_year_label}, {current_period}: {mean_value:.{decimals}f} {config['unit']}" if not pd.isna(mean_value) else current_year_label
+    current_year_text = current_year_label
 
     # Calculate y-axis limits safely
     y_axis_cols = [

--- a/apps/forecast_dashboard/tests/test_snow_plot.py
+++ b/apps/forecast_dashboard/tests/test_snow_plot.py
@@ -197,7 +197,36 @@ def test_snow_plot_labels_use_calendar_year_wording_when_start_is_jan_1():
 
     labels = _labels(plot, hv.Curve)
     assert "Last year legend entry" in labels
-    assert "Current year, 3 day mean: 16.0 cm" in labels
+    assert "Current year" in labels
+
+
+def test_snow_plot_current_season_label_has_no_mean_annotation():
+    # Calendar-year (non-hydrological) display: label is plain "Current year"
+    # with no ", 3 day mean: <value> <unit>" suffix.
+    calendar_plot = _plot_for_display_window(
+        _snow_frame(),
+        date_picker="2026-01-04",
+        display_start_month=1,
+        display_start_day=1,
+    )
+    calendar_labels = _labels(calendar_plot, hv.Curve)
+    assert "Current year" in calendar_labels
+    assert all("3 day mean" not in label for label in calendar_labels)
+    assert all("10 day mean" not in label for label in calendar_labels)
+
+    # Hydrological-year (season) display: label is the bare season string.
+    season_plot = _plot_for_display_window(
+        _snow_frame(overrides={
+            "date": pd.date_range("2025-12-11", periods=5, freq="D"),
+        }),
+        date_picker="2025-12-15",
+        display_start_month=9,
+        display_start_day=1,
+    )
+    season_labels = _labels(season_plot, hv.Curve)
+    assert "Current season 2025/26" in season_labels
+    assert all("3 day mean" not in label for label in season_labels)
+    assert all("10 day mean" not in label for label in season_labels)
 
 
 def test_snow_plot_labels_use_season_wording_when_start_is_sept_1():


### PR DESCRIPTION
## Summary

The snow plot's current-season legend appended `, 3 day mean: <value> <unit>` (the predictor-window mean) to the season label. That annotation isn't wanted — drop it so the legend reads just the season, e.g. **"Current season 2025/2026"** (or "Current year" in the non-hydrological case).

## Changes

- `apps/forecast_dashboard/src/vizualization.py` — in `plot_daily_snow_data`, `current_year_text = current_year_label` (was the f-string with `current_period`/`mean_value`). Removed the now-dead locals that only fed that label (`current_period`/`forecast_period`, `mean_value`, `decimals`, the predictor-window block, and the `add_predictor_dates` call). The plotted current-season line and all other series/overlays are unchanged. The other "3 day mean"/"3 day sum" labels in different plots are untouched.
- `apps/forecast_dashboard/tests/test_snow_plot.py` — updated the calendar-year-wording test to the new label and added a test asserting the current-season legend carries no "3 day mean" / mean-value annotation (both hydrological-season and calendar-year cases). Placeholder code `19999` only.

## Testing

`SAPPHIRE_TEST_ENV=True bash run_tests.sh forecast_dashboard` → all pass (374), only the documented chromium operator-gate error, which is environmental and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)