### PR TITLE
PP-038: month long-term skill metrics per forecast lead (horizon_value)

### DIFF
--- a/apps/forecast_dashboard/src/db.py
+++ b/apps/forecast_dashboard/src/db.py
@@ -544,7 +544,13 @@ def get_forecast_stats(horizon, station) -> pd.DataFrame:
         "model_type_description": "model_long",
     }, inplace=True)
     df.sort_values("date", inplace=True)  # keep only the latest recalculation run per key
-    df.drop_duplicates(subset=["code", _horizon_in_year_col(horizon), "model_short"], keep="last", inplace=True)
+    # PP-038: month skill metrics include per-lead rows (one per horizon_value).
+    # Include horizon_value in the dedup subset when present so that distinct
+    # leads are NOT collapsed to a single arbitrary row.
+    dedup_cols = ["code", _horizon_in_year_col(horizon), "model_short"]
+    if "horizon_value" in df.columns:
+        dedup_cols = dedup_cols + ["horizon_value"]
+    df.drop_duplicates(subset=dedup_cols, keep="last", inplace=True)
     df.drop(columns=["horizon_type", "date", "id"], inplace=True, errors="ignore")
     return _convert_na_to_nan(df)
 
@@ -843,6 +849,16 @@ def _get_data_monthly(
 
     forecasts_all = i18n_models(add_labels(get_long_forecasts(station, horizon_value=1)))
     forecast_stats = i18n_models(get_forecast_stats("month", station))
+
+    # PP-038: get_forecast_stats now preserves per-lead rows (one per horizon_value).
+    # Filter to the operational lead (horizon_value=1) that matches the displayed
+    # forecasts so the tile merge is 1:1 and forecast rows are not duplicated.
+    # This mirrors season's single-lead selection via _resolve_seasonal_horizon_value.
+    if not forecast_stats.empty and "horizon_value" in forecast_stats.columns:
+        _op_lead = 1
+        _op_mask = forecast_stats["horizon_value"] == _op_lead
+        if _op_mask.any():
+            forecast_stats = forecast_stats[_op_mask].copy()
 
     # Merge skill metrics into forecasts (same pattern as pentad/decad in get_data)
     hin = "month_in_year"

--- a/apps/forecast_dashboard/tests/test_db.py
+++ b/apps/forecast_dashboard/tests/test_db.py
@@ -575,6 +575,102 @@ class TestGetForecastStatsAll:
         assert "pentad_in_year" not in result.columns
 
 
+# ── PP-038: get_forecast_stats month per-lead dedup ───────────────────────
+
+
+def _skill_metric_record_with_lead(horizon_in_year, model_type, horizon_value, delta=1.0):
+    """Skill metric record that includes horizon_value (post-PP-038 API response)."""
+    return {
+        "id": 200 + int(delta * 10) + horizon_value,
+        "horizon_type": "month",
+        "horizon_in_year": horizon_in_year,
+        "code": "19999",
+        "model_type": model_type,
+        "model_type_description": model_type,
+        "date": "2026-03-15",
+        "horizon_value": horizon_value,
+        "sdivsigma": 0.5 + delta,
+        "nse": 0.8,
+        "delta": delta,
+        "accuracy": 90.0 + delta,
+        "mae": 1.0 + delta,
+        "n_pairs": 12,
+        "crps": None,
+        "pbias": None,
+        "kgelf": None,
+        "nse_log": None,
+        "fhv": None,
+        "flv": None,
+    }
+
+
+class TestGetForecastStatsPP038:
+    """PP-038: get_forecast_stats preserves per-lead rows when horizon_value is present.
+
+    After PP-038, the API returns multiple rows per (month_in_year, code, model_short)
+    — one per lead (horizon_value 0, 1, 2, 3).  get_forecast_stats must NOT collapse
+    them to one row.
+    """
+
+    def test_month_per_lead_rows_preserved(self, monkeypatch):
+        """Two rows differing only in horizon_value survive the dedup.
+
+        This guards the regression where drop_duplicates on
+        (code, month_in_year, model_short) collapses 4 leads to 1.
+        """
+        records = [
+            _skill_metric_record_with_lead(3, "GBT", 0, delta=1.0),
+            _skill_metric_record_with_lead(3, "GBT", 1, delta=1.5),
+        ]
+
+        def mock_get(url, **kwargs):
+            return _make_mock_response(records)
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        result = db.get_forecast_stats("month", "19999")
+
+        # Both leads must survive — not collapsed to one
+        assert len(result) == 2, (
+            f"Expected 2 rows (one per lead), got {len(result)}: {result[['month_in_year','model_short','horizon_value']].to_dict('records') if not result.empty else '(empty)'}"
+        )
+        assert "horizon_value" in result.columns
+        assert set(result["horizon_value"].unique()) == {0, 1}
+
+    def test_month_same_lead_dedup_keeps_latest_date(self, monkeypatch):
+        """Two rows with the same lead but different recalc dates → keep the later date."""
+        records = [
+            {**_skill_metric_record_with_lead(4, "GBT", 0, delta=1.0), "date": "2026-03-01"},
+            {**_skill_metric_record_with_lead(4, "GBT", 0, delta=2.0), "date": "2026-03-15"},
+        ]
+
+        def mock_get(url, **kwargs):
+            return _make_mock_response(records)
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        result = db.get_forecast_stats("month", "19999")
+
+        assert len(result) == 1
+        assert result["delta"].iloc[0] == 2.0
+
+    def test_non_month_horizons_unchanged(self, monkeypatch):
+        """Quarter and season records without horizon_value field still deduplicate correctly."""
+        records = [
+            _skill_metric_record_19999("quarter", 2, "LR_Base", 1.0),
+        ]
+
+        def mock_get(url, **kwargs):
+            return _make_mock_response(records)
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        result = db.get_forecast_stats("quarter", "19999")
+
+        assert len(result) == 1
+        assert "quarter_in_year" in result.columns
+
+
 # ── _get_data_monthly / get_data ──────────────────────────────────────────
 
 

--- a/apps/postprocessing_forecasts/src/api_writer.py
+++ b/apps/postprocessing_forecasts/src/api_writer.py
@@ -583,14 +583,28 @@ def _write_skill_metrics_to_api(data: pd.DataFrame, horizon_type: str, year: int
             season_start = get_season_months()[0]
             df_rec["_date"] = dt_module.date(year, season_start, 1).strftime("%Y-%m-%d")
 
+        # --- Normalize horizon_value ---
+        # Month skill DataFrames (Phase 2a) carry the actual forecast lead in
+        # horizon_value.  Other horizons have no such column.  Always emit a
+        # concrete int (sentinel 0 for non-month) so the crud upsert tuple
+        # never contains NULL — a NULL in a tuple_ IN comparison evaluates to
+        # NULL (never TRUE), causing pile-up duplicate inserts for every recalc
+        # run across ALL horizons (cross-horizon NULL-tuple hazard).
+        if "horizon_value" in df_rec.columns:
+            df_rec["horizon_value"] = df_rec["horizon_value"].fillna(0).astype(int)
+        else:
+            df_rec["horizon_value"] = 0
+
         # --- Deduplicate on DB upsert key ---
         # The DB unique constraint is (horizon_type, code, model_type, date,
-        # horizon_in_year).  composition is NOT part of the constraint.
-        # Monthly/quarterly/seasonal ensemble baselines (EM, Naive Mean,
-        # Skilled Mean) produce multiple rows per key with different
-        # composition values due to the CRPS merge fan-out.  Retain the row
-        # with a non-None composition (the true ensemble record).
-        upsert_key = ["code", "model_type", "_date", horizon_in_year_col]
+        # horizon_in_year, horizon_value).  composition is NOT part of the
+        # constraint.  Monthly/quarterly/seasonal ensemble baselines (EM,
+        # Naive Mean, Skilled Mean) produce multiple rows per key with
+        # different composition values due to the CRPS merge fan-out.  Retain
+        # the row with a non-None composition (the true ensemble record).
+        # horizon_value is included so that distinct month leads (0, 1, 2, 3)
+        # are NOT collapsed — each lead is a distinct upsert key.
+        upsert_key = ["code", "model_type", "_date", horizon_in_year_col, "horizon_value"]
         n_before = len(df_rec)
         df_rec = df_rec.sort_values("_composition", na_position="first")
         df_rec = df_rec.drop_duplicates(subset=upsert_key, keep="last")
@@ -634,6 +648,7 @@ def _write_skill_metrics_to_api(data: pd.DataFrame, horizon_type: str, year: int
                 "model_type": df_rec["model_type"],
                 "date": df_rec["_date"],
                 "horizon_in_year": df_rec[horizon_in_year_col].astype(int),
+                "horizon_value": df_rec["horizon_value"],
                 "composition": df_rec["_composition"],
                 **metric_cols,
             }

--- a/apps/postprocessing_forecasts/src/data_reader.py
+++ b/apps/postprocessing_forecasts/src/data_reader.py
@@ -298,7 +298,9 @@ def read_monthly_skill_metrics(
 
     Returns:
         DataFrame with columns: [month_in_year, code, model_short,
-        sdivsigma, nse, delta, accuracy, mae, n_pairs]
+        horizon_value, sdivsigma, nse, delta, accuracy, mae, n_pairs].
+        horizon_value is the forecast lead (0–3 for real models; sentinel 0
+        for baselines and pre-PP-038 legacy rows).
     """
     # API-first: try the authoritative source
     df = _read_monthly_skill_metrics_api(codes)
@@ -432,12 +434,15 @@ def _normalize_api_monthly_skill_metrics(
 ) -> pd.DataFrame:
     """Convert API column names to CSV-compatible names for monthly.
 
-    API returns: horizon_in_year, model_type, code, sdivsigma, nse,
-                 delta, accuracy, mae, n_pairs, crps, pbias, kgelf,
-                 nse_log
-    CSV expects: month_in_year, model_short, code, sdivsigma, nse,
-                 delta, accuracy, mae, n_pairs, crps, pbias, kgelf,
-                 nse_log
+    API returns: horizon_in_year, model_type, code, horizon_value,
+                 sdivsigma, nse, delta, accuracy, mae, n_pairs, crps,
+                 pbias, kgelf, nse_log
+    CSV expects: month_in_year, model_short, code, horizon_value,
+                 sdivsigma, nse, delta, accuracy, mae, n_pairs, crps,
+                 pbias, kgelf, nse_log
+
+    horizon_value is passed through unchanged (it is NOT renamed).
+    Legacy rows with horizon_value=NULL are coerced to sentinel 0.
     """
     rename_map = {
         "horizon_in_year": "month_in_year",
@@ -447,6 +452,11 @@ def _normalize_api_monthly_skill_metrics(
 
     if "code" in df.columns:
         df["code"] = df["code"].astype(str).str.replace(r"\.0$", "", regex=True)
+
+    # Coerce NaN horizon_value (legacy rows with NULL from pre-PP-038 DB) to
+    # sentinel 0 so callers can safely group or filter on the column.
+    if "horizon_value" in df.columns:
+        df["horizon_value"] = df["horizon_value"].fillna(0).astype(int)
 
     return df
 
@@ -1128,6 +1138,11 @@ def _normalize_monthly_forecasts(df: pd.DataFrame) -> pd.DataFrame:
     # Ensure code is string
     if "code" in df.columns:
         df["code"] = df["code"].astype(str).str.replace(r"\.0$", "", regex=True)
+
+    # Normalize horizon_value: coerce NaN (legacy / NULL rows from API) to
+    # sentinel 0 so subsequent groupby operations do not silently drop rows.
+    if "horizon_value" in df.columns:
+        df["horizon_value"] = df["horizon_value"].fillna(0).astype(int)
 
     return df
 

--- a/apps/postprocessing_forecasts/src/skill_metrics.py
+++ b/apps/postprocessing_forecasts/src/skill_metrics.py
@@ -98,6 +98,16 @@ THRESHOLD_METRICS = {
     name: entry for name, entry in METRIC_REGISTRY.items() if entry["env_var"] is not None
 }
 
+# ---------------------------------------------------------------------------
+# Monthly skill groupby keys (PP-038: per-lead stratification)
+# These constants define the groupby keys for all monthly skill groupbys and
+# the ensemble aggregation groupby.  Threading them through every site avoids
+# missed spots and makes future changes to the key set a single-line edit.
+# ---------------------------------------------------------------------------
+
+GROUP_COLS = ["month_in_year", "horizon_value", "code", "model_short"]
+ENSEMBLE_KEY = ["year", "month", "horizon_value", "code"]
+
 
 # ---------------------------------------------------------------------------
 # Individual metric helpers
@@ -1167,7 +1177,7 @@ def calculate_monthly_skill_metrics(
     )
 
     empty_stats = pd.DataFrame(
-        columns=["month_in_year", "code", "model_short"]
+        columns=["month_in_year", "horizon_value", "code", "model_short"]
         + METRIC_ORDER
         + ["crps", "reliability_score", "sharpness_90", "sharpness_50"]
     )
@@ -1176,6 +1186,19 @@ def calculate_monthly_skill_metrics(
     # Guard: empty inputs
     if observations.empty or forecasts.empty:
         return empty_stats, empty_joint, timing_stats
+
+    # Normalise horizon_value: ensure the column exists and contains integers.
+    # Real-model rows from the DB carry horizon_value ∈ {0,1,2,3}; baseline
+    # rows (NAIVE_MEAN, SKILLED_MEAN, ENSEMBLE_MEAN) store target-month
+    # numbers (1–12) which must NOT be trusted as leads — they are derived
+    # from real-model grouping below.  Legacy inputs without the column default
+    # to 0 so all downstream groupbys continue to work unchanged.
+    if "horizon_value" not in forecasts.columns:
+        forecasts = forecasts.copy()
+        forecasts["horizon_value"] = 0
+    else:
+        forecasts = forecasts.copy()
+        forecasts["horizon_value"] = forecasts["horizon_value"].fillna(0).astype(int)
 
     # --- 1. Merge forecasts with observations on [code, year, month] ---
     merged = pd.merge(
@@ -1201,11 +1224,9 @@ def calculate_monthly_skill_metrics(
             empty_joint,
         )
 
-    # --- 2. Point metrics per (month_in_year, code, model_short) ---
+    # --- 2. Point metrics per (month_in_year, horizon_value, code, model_short) ---
     skill_stats = (
-        merged.groupby(["month_in_year", "code", "model_short"])[
-            ["discharge_avg", "forecasted_discharge", "delta"]
-        ]
+        merged.groupby(GROUP_COLS)[["discharge_avg", "forecasted_discharge", "delta"]]
         .apply(
             calculate_all_skill_metrics,
             observed_col="discharge_avg",
@@ -1217,7 +1238,7 @@ def calculate_monthly_skill_metrics(
 
     # --- 3. CRPS per group ---
     crps_records = []
-    for (miy, code, model), grp in merged.groupby(["month_in_year", "code", "model_short"]):
+    for (miy, hv, code, model), grp in merged.groupby(GROUP_COLS):
         obs_arr = grp["discharge_avg"].to_numpy(dtype=np.float64)
         qf_cols = [c for c in _QUANTILE_COLS if c in grp.columns]
         if len(qf_cols) == len(_QUANTILE_COLS):
@@ -1232,6 +1253,7 @@ def calculate_monthly_skill_metrics(
         crps_records.append(
             {
                 "month_in_year": miy,
+                "horizon_value": hv,
                 "code": code,
                 "model_short": model,
                 "crps": crps_val,
@@ -1244,7 +1266,7 @@ def calculate_monthly_skill_metrics(
     crps_df = pd.DataFrame(crps_records)
     skill_stats = skill_stats.merge(
         crps_df,
-        on=["month_in_year", "code", "model_short"],
+        on=GROUP_COLS,
         how="left",
     )
 
@@ -1255,7 +1277,7 @@ def calculate_monthly_skill_metrics(
         joint_forecasts["month_in_year"] = joint_forecasts["month"]
     skill_stats_filtered = filter_for_highly_skilled_forecasts(skill_stats)
 
-    merge_keys = ["month_in_year", "code", "model_short"]
+    merge_keys = GROUP_COLS
     skilled_merged = merged.merge(
         skill_stats_filtered[merge_keys].drop_duplicates(),
         on=merge_keys,
@@ -1282,7 +1304,7 @@ def calculate_monthly_skill_metrics(
             if dcol in skilled_merged.columns:
                 em_agg_dict[dcol] = "first"
 
-        em_avg = skilled_merged.groupby(["year", "month", "code"]).agg(em_agg_dict).reset_index()
+        em_avg = skilled_merged.groupby(ENSEMBLE_KEY).agg(em_agg_dict).reset_index()
         em_avg = enforce_quantile_monotonicity(
             em_avg, [c for c in _QUANTILE_COLS if c in em_avg.columns]
         )
@@ -1306,9 +1328,9 @@ def calculate_monthly_skill_metrics(
                 em_with_obs = em_with_obs.drop(columns=["month_in_year_obs"])
 
             em_skill = (
-                em_with_obs.groupby(["month_in_year", "code", "model_short", "composition"])[
-                    ["discharge_avg", "forecasted_discharge", "delta"]
-                ]
+                em_with_obs.groupby(
+                    ["month_in_year", "horizon_value", "code", "model_short", "composition"]
+                )[["discharge_avg", "forecasted_discharge", "delta"]]
                 .apply(
                     calculate_all_skill_metrics,
                     observed_col="discharge_avg",
@@ -1322,9 +1344,7 @@ def calculate_monthly_skill_metrics(
             qf_cols = [c for c in _QUANTILE_COLS if c in em_with_obs.columns]
             if len(qf_cols) == len(_QUANTILE_COLS):
                 em_crps = []
-                for (miy, code, model), grp in em_with_obs.groupby(
-                    ["month_in_year", "code", "model_short"]
-                ):
+                for (miy, hv, code, model), grp in em_with_obs.groupby(GROUP_COLS):
                     obs_arr = grp["discharge_avg"].to_numpy(dtype=np.float64)
                     qf = grp[qf_cols].to_numpy(dtype=np.float64)
                     crps_val = calculate_crps(obs_arr, qf, _QUANTILE_LEVELS)
@@ -1333,6 +1353,7 @@ def calculate_monthly_skill_metrics(
                     em_crps.append(
                         {
                             "month_in_year": miy,
+                            "horizon_value": hv,
                             "code": code,
                             "model_short": model,
                             "crps": crps_val,
@@ -1344,7 +1365,7 @@ def calculate_monthly_skill_metrics(
                 em_crps_df = pd.DataFrame(em_crps)
                 em_skill = em_skill.merge(
                     em_crps_df,
-                    on=["month_in_year", "code", "model_short"],
+                    on=GROUP_COLS,
                     how="left",
                 )
             else:
@@ -1421,7 +1442,7 @@ def _add_naive_mean(
         if dcol in pool.columns:
             agg_dict[dcol] = "first"
 
-    naive_avg = pool.groupby(["year", "month", "code"]).agg(agg_dict).reset_index()
+    naive_avg = pool.groupby(ENSEMBLE_KEY).agg(agg_dict).reset_index()
     naive_avg = enforce_quantile_monotonicity(
         naive_avg, [c for c in _QUANTILE_COLS if c in naive_avg.columns]
     )
@@ -1450,9 +1471,9 @@ def _add_naive_mean(
 
     # Compute point metrics
     naive_skill = (
-        naive_with_obs.groupby(["month_in_year", "code", "model_short", "composition"])[
-            ["discharge_avg", "forecasted_discharge", "delta"]
-        ]
+        naive_with_obs.groupby(
+            ["month_in_year", "horizon_value", "code", "model_short", "composition"]
+        )[["discharge_avg", "forecasted_discharge", "delta"]]
         .apply(
             calculate_all_skill_metrics,
             observed_col="discharge_avg",
@@ -1466,9 +1487,7 @@ def _add_naive_mean(
     qf_cols = [c for c in _QUANTILE_COLS if c in naive_with_obs.columns]
     if len(qf_cols) == len(_QUANTILE_COLS):
         crps_records = []
-        for (miy, code, model), grp in naive_with_obs.groupby(
-            ["month_in_year", "code", "model_short"]
-        ):
+        for (miy, hv, code, model), grp in naive_with_obs.groupby(GROUP_COLS):
             obs_arr = grp["discharge_avg"].to_numpy(dtype=np.float64)
             qf = grp[qf_cols].to_numpy(dtype=np.float64)
             crps_val = calculate_crps(obs_arr, qf, _QUANTILE_LEVELS)
@@ -1477,6 +1496,7 @@ def _add_naive_mean(
             crps_records.append(
                 {
                     "month_in_year": miy,
+                    "horizon_value": hv,
                     "code": code,
                     "model_short": model,
                     "crps": crps_val,
@@ -1488,7 +1508,7 @@ def _add_naive_mean(
         crps_df = pd.DataFrame(crps_records)
         naive_skill = naive_skill.merge(
             crps_df,
-            on=["month_in_year", "code", "model_short"],
+            on=GROUP_COLS,
             how="left",
         )
     else:
@@ -1543,8 +1563,8 @@ def _add_skilled_mean(
     if filtered.empty:
         return skill_stats, joint_forecasts
 
-    # 3. Extract MAE per (month_in_year, code, model_short)
-    mae_df = filtered[["month_in_year", "code", "model_short", "mae"]].copy()
+    # 3. Extract MAE per (month_in_year, horizon_value, code, model_short)
+    mae_df = filtered[["month_in_year", "horizon_value", "code", "model_short", "mae"]].copy()
     mae_df = mae_df.dropna(subset=["mae"])
     if mae_df.empty:
         return skill_stats, joint_forecasts
@@ -1554,13 +1574,15 @@ def _add_skilled_mean(
     eps = mean_mae / 100.0 if mean_mae > 0 else 1e-10
     mae_df["weight"] = 1.0 / (mae_df["mae"] + eps)
 
-    # Get qualifying models per (month_in_year, code)
-    qualifying_keys = mae_df[["month_in_year", "code", "model_short"]].drop_duplicates()
+    # Get qualifying models per (month_in_year, horizon_value, code)
+    qualifying_keys = mae_df[
+        ["month_in_year", "horizon_value", "code", "model_short"]
+    ].drop_duplicates()
 
     # Filter merged to qualifying models only
     sm_merged = merged.merge(
         qualifying_keys,
-        on=["month_in_year", "code", "model_short"],
+        on=["month_in_year", "horizon_value", "code", "model_short"],
         how="inner",
     )
     sm_merged = sm_merged.dropna(subset=["forecasted_discharge"]).copy()
@@ -1569,8 +1591,8 @@ def _add_skilled_mean(
 
     # Attach weights from mae_df
     sm_merged = sm_merged.merge(
-        mae_df[["month_in_year", "code", "model_short", "weight"]],
-        on=["month_in_year", "code", "model_short"],
+        mae_df[["month_in_year", "horizon_value", "code", "model_short", "weight"]],
+        on=["month_in_year", "horizon_value", "code", "model_short"],
         how="left",
     )
 
@@ -1604,7 +1626,7 @@ def _add_skilled_mean(
             sm_agg_dict[dcol] = (dcol, "first")
 
     sm_avg = (
-        sm_merged.groupby(["year", "month", "code"])
+        sm_merged.groupby(ENSEMBLE_KEY)
         .agg(
             **sm_agg_dict,
         )
@@ -1633,9 +1655,9 @@ def _add_skilled_mean(
         sm_with_obs = sm_with_obs.drop(columns=["month_in_year_obs"])
 
     sm_skill = (
-        sm_with_obs.groupby(["month_in_year", "code", "model_short", "composition"])[
-            ["discharge_avg", "forecasted_discharge", "delta"]
-        ]
+        sm_with_obs.groupby(
+            ["month_in_year", "horizon_value", "code", "model_short", "composition"]
+        )[["discharge_avg", "forecasted_discharge", "delta"]]
         .apply(
             calculate_all_skill_metrics,
             observed_col="discharge_avg",
@@ -1649,9 +1671,7 @@ def _add_skilled_mean(
     qf_cols = [c for c in _QUANTILE_COLS if c in sm_with_obs.columns]
     if len(qf_cols) == len(_QUANTILE_COLS):
         sm_crps = []
-        for (miy, code, model), grp in sm_with_obs.groupby(
-            ["month_in_year", "code", "model_short"]
-        ):
+        for (miy, hv, code, model), grp in sm_with_obs.groupby(GROUP_COLS):
             obs_arr = grp["discharge_avg"].to_numpy(dtype=np.float64)
             qf = grp[qf_cols].to_numpy(dtype=np.float64)
             crps_val = calculate_crps(obs_arr, qf, _QUANTILE_LEVELS)
@@ -1660,6 +1680,7 @@ def _add_skilled_mean(
             sm_crps.append(
                 {
                     "month_in_year": miy,
+                    "horizon_value": hv,
                     "code": code,
                     "model_short": model,
                     "crps": crps_val,
@@ -1671,7 +1692,7 @@ def _add_skilled_mean(
         sm_crps_df = pd.DataFrame(sm_crps)
         sm_skill = sm_skill.merge(
             sm_crps_df,
-            on=["month_in_year", "code", "model_short"],
+            on=GROUP_COLS,
             how="left",
         )
     else:

--- a/apps/postprocessing_forecasts/tests/test_monthly_skill_per_lead.py
+++ b/apps/postprocessing_forecasts/tests/test_monthly_skill_per_lead.py
@@ -1,0 +1,571 @@
+"""Tests for per-lead (horizon_value) grouping in calculate_monthly_skill_metrics.
+
+PP-038: month skill stratified by forecast lead so each
+(month_in_year, code, model_short) no longer pools leads 0-3.
+
+Tests are written before implementation (TDD).
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.skill_metrics import calculate_monthly_skill_metrics
+
+# Use station code following convention (no real codes)
+STATION = "19999"
+
+
+# ===========================================================================
+# Shared helpers
+# ===========================================================================
+
+
+def _make_obs(rows):
+    """Create observations DataFrame from (code, year, month, discharge_avg).
+
+    Automatically computes month_in_year and delta (0.674 * std).
+    """
+    df = pd.DataFrame(rows, columns=["code", "year", "month", "discharge_avg"])
+    df["month_in_year"] = df["month"]
+    delta_df = (
+        df.groupby(["code", "month_in_year"])
+        .agg(std_discharge=("discharge_avg", "std"))
+        .reset_index()
+    )
+    delta_df["delta"] = 0.674 * delta_df["std_discharge"].fillna(0.0)
+    return df.merge(
+        delta_df[["code", "month_in_year", "delta"]],
+        on=["code", "month_in_year"],
+        how="left",
+    )
+
+
+def _make_fcst_lead(rows):
+    """Create forecasts DataFrame WITH horizon_value.
+
+    Each row: (code, year, month, model_short, horizon_value,
+               q05, q10, q25, q50, q75, q90, q95)
+    """
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "code",
+            "year",
+            "month",
+            "model_short",
+            "horizon_value",
+            "q05",
+            "q10",
+            "q25",
+            "q50",
+            "q75",
+            "q90",
+            "q95",
+        ],
+    )
+
+
+def _make_fcst_no_lead(rows):
+    """Create forecasts DataFrame WITHOUT horizon_value (legacy / no-lead format)."""
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "code",
+            "year",
+            "month",
+            "model_short",
+            "q05",
+            "q10",
+            "q25",
+            "q50",
+            "q75",
+            "q90",
+            "q95",
+        ],
+    )
+
+
+# ===========================================================================
+# Per-lead model rows
+# ===========================================================================
+
+
+class TestPerLeadModelRows:
+    """calculate_monthly_skill_metrics groups by horizon_value for model rows."""
+
+    @pytest.fixture
+    def obs_3yr(self):
+        """Three years of observations for station STATION, month 1."""
+        return _make_obs(
+            [
+                (STATION, 2020, 1, 100.0),
+                (STATION, 2021, 1, 110.0),
+                (STATION, 2022, 1, 105.0),
+            ]
+        )
+
+    @pytest.fixture
+    def fcst_two_leads(self):
+        """Single model M1 with leads 0 and 1, 3 years.
+
+        lead=0: q50=[102, 108, 104], obs=[100, 110, 105] -> MAE=(2+2+1)/3 = 5/3
+        lead=1: q50=[ 88,  94,  90], obs=[100, 110, 105] -> MAE=(12+16+15)/3 = 43/3
+        """
+        return _make_fcst_lead(
+            [
+                # lead 0 — close to obs
+                (STATION, 2020, 1, "M1", 0, 80, 85, 92, 102, 112, 118, 125),
+                (STATION, 2021, 1, "M1", 0, 88, 93, 100, 108, 116, 123, 130),
+                (STATION, 2022, 1, "M1", 0, 84, 89, 97, 104, 113, 120, 128),
+                # lead 1 — further from obs
+                (STATION, 2020, 1, "M1", 1, 72, 77, 83, 88, 94, 100, 106),
+                (STATION, 2021, 1, "M1", 1, 79, 84, 89, 94, 100, 106, 112),
+                (STATION, 2022, 1, "M1", 1, 75, 80, 85, 90, 97, 103, 109),
+            ]
+        )
+
+    def test_output_has_horizon_value_column(self, obs_3yr, fcst_two_leads):
+        """skill_stats must carry a horizon_value column."""
+        stats, _, _ = calculate_monthly_skill_metrics(obs_3yr, fcst_two_leads)
+        assert "horizon_value" in stats.columns, "horizon_value column missing from skill_stats"
+
+    def test_two_leads_produce_two_rows_per_model(self, obs_3yr, fcst_two_leads):
+        """Two distinct leads produce two rows for the same (month, code, model)."""
+        stats, _, _ = calculate_monthly_skill_metrics(obs_3yr, fcst_two_leads)
+        m1_rows = stats[stats["model_short"] == "M1"]
+        assert len(m1_rows) == 2, f"Expected 2 rows (one per lead), got {len(m1_rows)}"
+        assert set(m1_rows["horizon_value"].unique()) == {0, 1}
+
+    def test_per_lead_metrics_differ(self, obs_3yr, fcst_two_leads):
+        """Lead-0 and lead-1 have distinct MAE (not pooled)."""
+        stats, _, _ = calculate_monthly_skill_metrics(obs_3yr, fcst_two_leads)
+        m1 = stats[stats["model_short"] == "M1"]
+        mae0 = m1[m1["horizon_value"] == 0]["mae"].iloc[0]
+        mae1 = m1[m1["horizon_value"] == 1]["mae"].iloc[0]
+        assert mae0 != mae1, "Lead-0 and lead-1 MAE must differ when forecasts differ"
+        # Lead-0 is closer to obs -> lower MAE
+        assert mae0 < mae1
+
+    def test_per_lead_n_pairs_correct(self, obs_3yr, fcst_two_leads):
+        """Each lead accumulates only its own pairs (3 years -> n_pairs=3)."""
+        stats, _, _ = calculate_monthly_skill_metrics(obs_3yr, fcst_two_leads)
+        m1 = stats[stats["model_short"] == "M1"]
+        for _, row in m1.iterrows():
+            assert row["n_pairs"] == 3, (
+                f"Expected n_pairs=3 for lead={row['horizon_value']}, got {row['n_pairs']}"
+            )
+
+    def test_lead0_mae_value_correct(self, obs_3yr, fcst_two_leads):
+        """Lead-0 MAE = (|100-102|+|110-108|+|105-104|)/3 = 5/3."""
+        stats, _, _ = calculate_monthly_skill_metrics(obs_3yr, fcst_two_leads)
+        m1 = stats[stats["model_short"] == "M1"]
+        row0 = m1[m1["horizon_value"] == 0].iloc[0]
+        expected_mae = (abs(100.0 - 102.0) + abs(110.0 - 108.0) + abs(105.0 - 104.0)) / 3.0
+        assert row0["mae"] == pytest.approx(expected_mae, rel=1e-5)
+
+
+# ===========================================================================
+# Backward compatibility — no horizon_value in input
+# ===========================================================================
+
+
+class TestNoHorizonValueBackwardCompat:
+    """Inputs without horizon_value still work; output defaults to horizon_value=0."""
+
+    def test_no_horizon_value_col_works(self):
+        """Legacy input (no horizon_value) does not raise."""
+        obs = _make_obs(
+            [
+                (STATION, 2020, 1, 100.0),
+                (STATION, 2021, 1, 110.0),
+            ]
+        )
+        fcst = _make_fcst_no_lead(
+            [
+                (STATION, 2020, 1, "M1", 80, 85, 92, 102, 112, 118, 125),
+                (STATION, 2021, 1, "M1", 88, 93, 100, 108, 116, 123, 130),
+            ]
+        )
+        stats, _, _ = calculate_monthly_skill_metrics(obs, fcst)
+        assert not stats.empty
+
+    def test_no_horizon_value_defaults_to_zero(self):
+        """Output has horizon_value=0 when input has no horizon_value column."""
+        obs = _make_obs(
+            [
+                (STATION, 2020, 1, 100.0),
+                (STATION, 2021, 1, 110.0),
+            ]
+        )
+        fcst = _make_fcst_no_lead(
+            [
+                (STATION, 2020, 1, "M1", 80, 85, 92, 102, 112, 118, 125),
+                (STATION, 2021, 1, "M1", 88, 93, 100, 108, 116, 123, 130),
+            ]
+        )
+        stats, _, _ = calculate_monthly_skill_metrics(obs, fcst)
+        m1 = stats[stats["model_short"] == "M1"]
+        assert len(m1) == 1
+        assert "horizon_value" in m1.columns
+        assert int(m1.iloc[0]["horizon_value"]) == 0
+
+    def test_single_lead_regression_metrics(self):
+        """Single-lead (horizon_value=0) produces same metrics as the old grouping.
+
+        Reference values match test_monthly_skill_metrics.py TestMonthlyMetricsBasic:
+          obs=[100,110], q50=[102,108] -> MAE=2.0, NSE=0.84, sdivsigma=0.4
+        """
+        obs = _make_obs(
+            [
+                (STATION, 2020, 1, 100.0),
+                (STATION, 2021, 1, 110.0),
+            ]
+        )
+        fcst = _make_fcst_lead(
+            [
+                (STATION, 2020, 1, "M1", 0, 80, 85, 92, 102, 112, 118, 125),
+                (STATION, 2021, 1, "M1", 0, 88, 93, 100, 108, 116, 123, 130),
+            ]
+        )
+        stats, _, _ = calculate_monthly_skill_metrics(obs, fcst)
+        m1 = stats[(stats["model_short"] == "M1") & (stats["horizon_value"] == 0)]
+        assert len(m1) == 1
+        row = m1.iloc[0]
+        assert row["mae"] == pytest.approx(2.0, rel=1e-6)
+        assert row["n_pairs"] == 2
+        assert row["sdivsigma"] == pytest.approx(0.4, rel=1e-6)
+        assert row["nse"] == pytest.approx(0.84, rel=1e-6)
+
+    def test_nan_horizon_value_defaults_to_zero(self):
+        """Rows with NaN horizon_value are coerced to 0, not dropped."""
+        obs = _make_obs(
+            [
+                (STATION, 2020, 1, 100.0),
+                (STATION, 2021, 1, 110.0),
+            ]
+        )
+        fcst = pd.DataFrame(
+            {
+                "code": [STATION, STATION],
+                "year": [2020, 2021],
+                "month": [1, 1],
+                "model_short": ["M1", "M1"],
+                "horizon_value": [np.nan, np.nan],
+                "q05": [80, 88],
+                "q10": [85, 93],
+                "q25": [92, 100],
+                "q50": [102, 108],
+                "q75": [112, 116],
+                "q90": [118, 123],
+                "q95": [125, 130],
+            }
+        )
+        stats, _, _ = calculate_monthly_skill_metrics(obs, fcst)
+        m1 = stats[stats["model_short"] == "M1"]
+        assert not m1.empty, "NaN horizon_value rows should not be dropped"
+        assert int(m1.iloc[0]["horizon_value"]) == 0
+
+
+# ===========================================================================
+# EM per-lead
+# ===========================================================================
+
+
+class TestEMPerLead:
+    """EM rows are computed per lead, not pooled across leads."""
+
+    @pytest.fixture
+    def obs_2yr(self):
+        return _make_obs(
+            [
+                (STATION, 2020, 1, 100.0),
+                (STATION, 2021, 1, 110.0),
+            ]
+        )
+
+    @pytest.fixture
+    def two_model_two_lead_fcst(self):
+        """Two models (M1, M2), two leads (0, 1), 2 years.
+
+        Both leads use forecasts close to obs so both pass skill thresholds
+        (NSE > 0.8, sdivsigma < 0.6, accuracy > 0.8).
+
+        obs=[100, 110], obs_mean=105, sigma=7.071, delta=4.766
+        NSE threshold: sum_sq_errors < 50 * (1-0.8) = 10
+
+        Lead-0: M1 q50=[102,108], M2 q50=[101,109]
+          EM q50 = [101.5, 108.5], MAE = 1.5
+        Lead-1: M1 q50=[101,109], M2 q50=[100,111]
+          EM q50 = [100.5, 110.0], MAE = (0.5+0)/2 = 0.25
+        """
+        return _make_fcst_lead(
+            [
+                # M1, lead 0 — close to obs
+                (STATION, 2020, 1, "M1", 0, 80, 85, 92, 102, 112, 118, 125),
+                (STATION, 2021, 1, "M1", 0, 88, 93, 100, 108, 116, 123, 130),
+                # M2, lead 0 — close to obs
+                (STATION, 2020, 1, "M2", 0, 82, 87, 94, 101, 108, 114, 120),
+                (STATION, 2021, 1, "M2", 0, 90, 95, 102, 109, 117, 124, 131),
+                # M1, lead 1 — also close to obs (NSE = 1 - 2/50 = 0.96)
+                (STATION, 2020, 1, "M1", 1, 79, 84, 91, 101, 111, 117, 124),
+                (STATION, 2021, 1, "M1", 1, 87, 92, 99, 109, 117, 124, 131),
+                # M2, lead 1 — also close to obs (NSE = 1 - 1/50 = 0.98)
+                (STATION, 2020, 1, "M2", 1, 78, 83, 90, 100, 108, 114, 120),
+                (STATION, 2021, 1, "M2", 1, 89, 94, 101, 111, 119, 126, 133),
+            ]
+        )
+
+    def test_em_has_one_row_per_lead(self, obs_2yr, two_model_two_lead_fcst):
+        """EM produces one row per lead present in input, not one pooled row."""
+        stats, _, _ = calculate_monthly_skill_metrics(obs_2yr, two_model_two_lead_fcst)
+        em_rows = stats[stats["model_short"] == "EM"]
+        assert len(em_rows) == 2, f"Expected 2 EM rows (one per lead), got {len(em_rows)}"
+        assert set(em_rows["horizon_value"].unique()) == {0, 1}
+
+    def test_em_lead0_mae_from_lead0_models_only(self, obs_2yr, two_model_two_lead_fcst):
+        """EM lead-0 averages only lead-0 model forecasts.
+
+        M1 q50=[102,108], M2 q50=[101,109] -> EM q50=[101.5,108.5]
+        obs=[100,110] -> MAE = 1.5
+        """
+        stats, _, _ = calculate_monthly_skill_metrics(obs_2yr, two_model_two_lead_fcst)
+        em_lead0 = stats[(stats["model_short"] == "EM") & (stats["horizon_value"] == 0)]
+        assert len(em_lead0) == 1
+        assert em_lead0.iloc[0]["mae"] == pytest.approx(1.5, rel=1e-6)
+
+    def test_em_lead0_differs_from_lead1(self, obs_2yr, two_model_two_lead_fcst):
+        """EM has different MAE per lead (leads not mixed).
+
+        Lead-0 EM: MAE=1.5, Lead-1 EM: MAE=0.25 (different values confirm no pooling).
+        """
+        stats, _, _ = calculate_monthly_skill_metrics(obs_2yr, two_model_two_lead_fcst)
+        em = stats[stats["model_short"] == "EM"]
+        assert len(em) == 2, "Both leads must produce EM for this comparison"
+        mae0 = em[em["horizon_value"] == 0]["mae"].iloc[0]
+        mae1 = em[em["horizon_value"] == 1]["mae"].iloc[0]
+        assert mae0 != mae1, "EM MAE must differ across leads (leads not pooled)"
+
+    def test_em_joint_forecasts_carries_horizon_value(self, obs_2yr, two_model_two_lead_fcst):
+        """EM rows appended to joint_forecasts carry horizon_value for each lead."""
+        _, joint, _ = calculate_monthly_skill_metrics(obs_2yr, two_model_two_lead_fcst)
+        em_joint = joint[joint["model_short"] == "EM"]
+        assert not em_joint.empty
+        if "horizon_value" in em_joint.columns:
+            # Both leads should be present in joint_forecasts
+            leads = set(em_joint["horizon_value"].dropna().astype(int).unique())
+            assert 0 in leads
+            assert 1 in leads
+
+
+# ===========================================================================
+# Naive Mean per-lead
+# ===========================================================================
+
+
+class TestNaiveMeanPerLead:
+    """Naive Mean rows are computed per lead, not pooled across leads."""
+
+    @pytest.fixture
+    def obs_3yr(self):
+        return _make_obs(
+            [
+                (STATION, 2020, 1, 100.0),
+                (STATION, 2021, 1, 110.0),
+                (STATION, 2022, 1, 105.0),
+            ]
+        )
+
+    @pytest.fixture
+    def two_model_two_lead_fcst(self):
+        """Two models, two leads, 3 years.
+
+        Lead-0 q50: M1=[102,108,104], M2=[104,112,108]
+          Naive Mean lead-0 q50: [103, 110, 106]
+          obs=[100,110,105] -> MAE = (3+0+1)/3 = 4/3
+
+        Lead-1 q50: M1=[88,94,90], M2=[86,92,88]
+          Naive Mean lead-1 q50: [87, 93, 89]
+          obs=[100,110,105] -> MAE = (13+17+16)/3 = 46/3
+        """
+        return _make_fcst_lead(
+            [
+                # M1, lead 0
+                (STATION, 2020, 1, "M1", 0, 80, 85, 92, 102, 112, 118, 125),
+                (STATION, 2021, 1, "M1", 0, 88, 93, 100, 108, 116, 123, 130),
+                (STATION, 2022, 1, "M1", 0, 84, 89, 97, 104, 113, 120, 128),
+                # M1, lead 1
+                (STATION, 2020, 1, "M1", 1, 72, 77, 83, 88, 94, 100, 106),
+                (STATION, 2021, 1, "M1", 1, 79, 84, 89, 94, 100, 106, 112),
+                (STATION, 2022, 1, "M1", 1, 75, 80, 85, 90, 97, 103, 109),
+                # M2, lead 0
+                (STATION, 2020, 1, "M2", 0, 82, 87, 94, 104, 114, 120, 127),
+                (STATION, 2021, 1, "M2", 0, 90, 95, 102, 112, 120, 127, 134),
+                (STATION, 2022, 1, "M2", 0, 86, 91, 99, 108, 116, 122, 130),
+                # M2, lead 1
+                (STATION, 2020, 1, "M2", 1, 70, 75, 81, 86, 92, 98, 104),
+                (STATION, 2021, 1, "M2", 1, 77, 82, 87, 92, 98, 104, 110),
+                (STATION, 2022, 1, "M2", 1, 73, 78, 83, 88, 95, 101, 107),
+            ]
+        )
+
+    def test_naive_mean_has_one_row_per_lead(self, obs_3yr, two_model_two_lead_fcst):
+        """Naive Mean produces one row per lead, not one pooled row."""
+        stats, _, _ = calculate_monthly_skill_metrics(obs_3yr, two_model_two_lead_fcst)
+        naive_rows = stats[stats["model_short"] == "Naive Mean"]
+        assert len(naive_rows) == 2, (
+            f"Expected 2 Naive Mean rows (one per lead), got {len(naive_rows)}"
+        )
+        assert set(naive_rows["horizon_value"].unique()) == {0, 1}
+
+    def test_naive_mean_lead0_mae_correct(self, obs_3yr, two_model_two_lead_fcst):
+        """Naive Mean lead-0 uses only lead-0 forecasts.
+
+        Naive Mean lead-0 q50 = [103, 110, 106], obs=[100, 110, 105]
+        MAE = (3+0+1)/3 = 4/3
+        """
+        stats, _, _ = calculate_monthly_skill_metrics(obs_3yr, two_model_two_lead_fcst)
+        naive_lead0 = stats[(stats["model_short"] == "Naive Mean") & (stats["horizon_value"] == 0)]
+        assert len(naive_lead0) == 1
+        expected_mae = (abs(100.0 - 103.0) + abs(110.0 - 110.0) + abs(105.0 - 106.0)) / 3.0
+        assert naive_lead0.iloc[0]["mae"] == pytest.approx(expected_mae, rel=1e-4)
+
+    def test_naive_mean_lead0_differs_from_lead1(self, obs_3yr, two_model_two_lead_fcst):
+        """Naive Mean MAE differs per lead (leads not mixed)."""
+        stats, _, _ = calculate_monthly_skill_metrics(obs_3yr, two_model_two_lead_fcst)
+        naive = stats[stats["model_short"] == "Naive Mean"]
+        mae0 = naive[naive["horizon_value"] == 0]["mae"].iloc[0]
+        mae1 = naive[naive["horizon_value"] == 1]["mae"].iloc[0]
+        assert mae0 < mae1, "Lead-0 Naive Mean should have lower MAE (closer to obs)"
+
+
+# ===========================================================================
+# Skilled Mean per-lead
+# ===========================================================================
+
+
+class TestSkilledMeanPerLead:
+    """Skilled Mean rows are computed per lead."""
+
+    @pytest.fixture
+    def obs_2yr(self):
+        return _make_obs(
+            [
+                (STATION, 2020, 1, 100.0),
+                (STATION, 2021, 1, 110.0),
+            ]
+        )
+
+    @pytest.fixture
+    def two_model_two_lead_fcst_skilled(self):
+        """Two skilled models (both close to obs), two leads.
+
+        Both M1 and M2 pass default thresholds on lead-0.
+        Lead-1 models are further away (may or may not pass thresholds).
+        """
+        return _make_fcst_lead(
+            [
+                # M1, lead 0
+                (STATION, 2020, 1, "M1", 0, 80, 85, 92, 102, 112, 118, 125),
+                (STATION, 2021, 1, "M1", 0, 88, 93, 100, 108, 116, 123, 130),
+                # M2, lead 0
+                (STATION, 2020, 1, "M2", 0, 82, 87, 94, 101, 108, 114, 120),
+                (STATION, 2021, 1, "M2", 0, 90, 95, 102, 109, 117, 124, 131),
+                # M1, lead 1
+                (STATION, 2020, 1, "M1", 1, 80, 85, 92, 102, 112, 118, 125),
+                (STATION, 2021, 1, "M1", 1, 88, 93, 100, 108, 116, 123, 130),
+                # M2, lead 1
+                (STATION, 2020, 1, "M2", 1, 82, 87, 94, 101, 108, 114, 120),
+                (STATION, 2021, 1, "M2", 1, 90, 95, 102, 109, 117, 124, 131),
+            ]
+        )
+
+    def test_skilled_mean_per_lead_present(self, obs_2yr, two_model_two_lead_fcst_skilled):
+        """Skilled Mean carries horizon_value when produced."""
+        stats, _, _ = calculate_monthly_skill_metrics(obs_2yr, two_model_two_lead_fcst_skilled)
+        sm_rows = stats[stats["model_short"] == "Skilled Mean"]
+        if not sm_rows.empty:
+            assert "horizon_value" in sm_rows.columns
+            # Each Skilled Mean row must have a valid horizon_value
+            assert sm_rows["horizon_value"].notna().all()
+
+    def test_skilled_mean_per_lead_count(self, obs_2yr, two_model_two_lead_fcst_skilled):
+        """Skilled Mean has at most one row per lead (not pooled)."""
+        stats, _, _ = calculate_monthly_skill_metrics(obs_2yr, two_model_two_lead_fcst_skilled)
+        sm_rows = stats[stats["model_short"] == "Skilled Mean"]
+        if not sm_rows.empty:
+            # At most one Skilled Mean row per (month_in_year, horizon_value, code)
+            key_cols = [
+                c for c in ["month_in_year", "horizon_value", "code"] if c in sm_rows.columns
+            ]
+            dupes = sm_rows.duplicated(subset=key_cols)
+            assert not dupes.any(), (
+                "Skilled Mean must not have duplicate (month_in_year, horizon_value, code) rows"
+            )
+
+
+# ===========================================================================
+# n_pairs floor preserved per lead
+# ===========================================================================
+
+
+class TestNPairsFloorPerLead:
+    """n_pairs >= 2 constraint applies per (lead, month, code, model)."""
+
+    def test_single_year_per_lead_dropped_by_floor(self):
+        """A per-lead group with only 1 year (n_pairs=1) is dropped by the
+        n_pairs >= 2 floor applied at the end of the function.
+
+        n_pairs=1 < 2, so the M1 lead-0 row is removed entirely.
+        """
+        obs = _make_obs(
+            [
+                (STATION, 2020, 1, 100.0),
+            ]
+        )
+        fcst = _make_fcst_lead(
+            [
+                (STATION, 2020, 1, "M1", 0, 80, 85, 92, 102, 112, 118, 125),
+            ]
+        )
+        stats, _, _ = calculate_monthly_skill_metrics(obs, fcst)
+        m1 = stats[stats["model_short"] == "M1"]
+        # n_pairs=1 < 2 floor drops the thin per-lead row entirely
+        assert m1.empty, "M1 lead-0 row with n_pairs=1 must be dropped by the floor"
+
+    def test_thin_lead_dropped_qualifying_lead_kept(self):
+        """The n_pairs >= 2 floor drops thin per-lead rows but keeps qualifying leads.
+
+        lead-0 has 2 years (n_pairs=2, SURVIVES); lead-1 has 1 year
+        (n_pairs=1, DROPPED by the floor).
+        """
+        obs = _make_obs(
+            [
+                (STATION, 2020, 1, 100.0),
+                (STATION, 2021, 1, 110.0),
+            ]
+        )
+        fcst = _make_fcst_lead(
+            [
+                (STATION, 2020, 1, "M1", 0, 80, 85, 92, 102, 112, 118, 125),
+                (STATION, 2021, 1, "M1", 0, 88, 93, 100, 108, 116, 123, 130),
+                # lead 1: single year -> n_pairs=1 -> dropped by floor
+                (STATION, 2020, 1, "M1", 1, 72, 77, 83, 88, 94, 100, 106),
+            ]
+        )
+        stats, _, _ = calculate_monthly_skill_metrics(obs, fcst)
+        m1 = stats[stats["model_short"] == "M1"]
+        # Lead-0: n_pairs=2 survives, sdivsigma computable
+        row0 = m1[m1["horizon_value"] == 0]
+        assert len(row0) == 1
+        assert row0.iloc[0]["n_pairs"] == 2
+        assert not np.isnan(row0.iloc[0]["sdivsigma"])
+
+        # Lead-1: n_pairs=1 dropped by the floor -> absent
+        row1 = m1[m1["horizon_value"] == 1]
+        assert row1.empty, "Lead-1 thin row (n_pairs=1) must be dropped by the floor"

--- a/apps/postprocessing_forecasts/tests/test_pp038_writer_reader.py
+++ b/apps/postprocessing_forecasts/tests/test_pp038_writer_reader.py
@@ -1,0 +1,456 @@
+"""PP-038 writer + reader wiring tests.
+
+Tests that:
+1. Writer (_write_skill_metrics_to_api) sends horizon_value in the payload
+   and that distinct leads are NOT collapsed by drop_duplicates.
+2. Non-month horizons (no horizon_value column in input) send sentinel 0 —
+   never NULL — so the cross-horizon crud tuple hazard cannot trigger.
+3. _normalize_api_monthly_skill_metrics passes horizon_value through and
+   coerces NaN to 0.
+4. _normalize_monthly_forecasts coerces horizon_value NaN to 0.
+5. read_monthly_skill_metrics returns a DataFrame that carries horizon_value.
+
+TDD: these tests were written before the implementation changes.
+"""
+
+import os
+import sys
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "iEasyHydroForecast"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.api_writer import SAPPHIRE_API_AVAILABLE, _write_skill_metrics_to_api
+from src.data_reader import (
+    _normalize_api_monthly_skill_metrics,
+    _normalize_monthly_forecasts,
+    read_monthly_skill_metrics,
+)
+
+STATION = "19999"
+
+
+# ============================================================================
+# Writer — horizon_value in payload and dedup key
+# ============================================================================
+
+
+@pytest.mark.skipif(not SAPPHIRE_API_AVAILABLE, reason="sapphire-api-client not installed")
+class TestWriterHorizonValue:
+    """_write_skill_metrics_to_api sends horizon_value and preserves per-lead rows."""
+
+    @pytest.fixture(autouse=True)
+    def _api_enabled(self, monkeypatch):
+        monkeypatch.setenv("SAPPHIRE_API_ENABLED", "true")
+
+    @patch("src.api_writer.SapphirePostprocessingClient")
+    def test_month_two_leads_not_collapsed(self, mock_client_class):
+        """Month rows with horizon_value 0 and 1 both survive dedup — not collapsed.
+
+        The upsert_key must include horizon_value so that (code, model_type,
+        date, month_in_year, horizon_value=0) and (..., horizon_value=1) are
+        treated as distinct rows.
+        """
+        mock_client = Mock()
+        mock_client.readiness_check.return_value = True
+        mock_client.write_skill_metrics.return_value = 2
+        mock_client_class.return_value = mock_client
+
+        data = pd.DataFrame(
+            {
+                "code": [STATION, STATION],
+                "month_in_year": [3, 3],
+                "model_short": ["LR_Base", "LR_Base"],
+                "horizon_value": [0, 1],
+                "sdivsigma": [0.40, 0.50],
+                "nse": [0.85, 0.78],
+                "delta": [0.10, 0.12],
+                "accuracy": [0.90, 0.87],
+                "mae": [4.0, 5.5],
+                "n_pairs": [10, 10],
+            }
+        )
+
+        _write_skill_metrics_to_api(data, "month", 2025)
+
+        call_args = mock_client.write_skill_metrics.call_args[0][0]
+
+        assert len(call_args) == 2, (
+            f"Expected 2 records (one per lead), got {len(call_args)}"
+        )
+        leads = {r["horizon_value"] for r in call_args}
+        assert leads == {0, 1}, f"Expected leads {{0, 1}}, got {leads}"
+
+    @patch("src.api_writer.SapphirePostprocessingClient")
+    def test_month_horizon_value_present_in_each_record(self, mock_client_class):
+        """Every written record carries a concrete integer horizon_value."""
+        mock_client = Mock()
+        mock_client.readiness_check.return_value = True
+        mock_client.write_skill_metrics.return_value = 1
+        mock_client_class.return_value = mock_client
+
+        data = pd.DataFrame(
+            {
+                "code": [STATION],
+                "month_in_year": [6],
+                "model_short": ["GBT"],
+                "horizon_value": [2],
+                "sdivsigma": [0.35],
+                "nse": [0.88],
+                "delta": [0.09],
+                "accuracy": [0.92],
+                "mae": [3.5],
+                "n_pairs": [8],
+            }
+        )
+
+        _write_skill_metrics_to_api(data, "month", 2025)
+
+        call_args = mock_client.write_skill_metrics.call_args[0][0]
+
+        assert len(call_args) == 1
+        rec = call_args[0]
+        assert "horizon_value" in rec, "horizon_value must be present in the written record"
+        assert rec["horizon_value"] == 2
+        assert isinstance(rec["horizon_value"], int)
+
+    @patch("src.api_writer.SapphirePostprocessingClient")
+    def test_pentad_no_horizon_value_col_sends_zero(self, mock_client_class):
+        """Pentad input without horizon_value column → horizon_value=0 in payload (never NULL).
+
+        This prevents the cross-horizon NULL-tuple corruption hazard in the
+        shared crud upsert, which evaluates NULL-containing tuples as never
+        matching existing rows.
+        """
+        mock_client = Mock()
+        mock_client.readiness_check.return_value = True
+        mock_client.write_skill_metrics.return_value = 1
+        mock_client_class.return_value = mock_client
+
+        data = pd.DataFrame(
+            {
+                "code": [STATION],
+                "pentad_in_year": [5],
+                "model_short": ["LR"],
+                # deliberately no horizon_value column
+                "sdivsigma": [0.45],
+                "nse": [0.82],
+                "delta": [0.11],
+                "accuracy": [0.89],
+                "mae": [4.8],
+                "n_pairs": [14],
+            }
+        )
+
+        _write_skill_metrics_to_api(data, "pentad", 2025)
+
+        call_args = mock_client.write_skill_metrics.call_args[0][0]
+
+        assert len(call_args) == 1
+        rec = call_args[0]
+        assert "horizon_value" in rec, (
+            "horizon_value must be present even when the input has no column"
+        )
+        assert rec["horizon_value"] == 0, (
+            f"Non-month horizons must send sentinel 0, got {rec['horizon_value']!r}"
+        )
+        assert rec["horizon_value"] is not None, "horizon_value must never be NULL"
+
+    @patch("src.api_writer.SapphirePostprocessingClient")
+    def test_quarter_no_horizon_value_col_sends_zero(self, mock_client_class):
+        """Quarter input without horizon_value column → sentinel 0 in payload."""
+        mock_client = Mock()
+        mock_client.readiness_check.return_value = True
+        mock_client.write_skill_metrics.return_value = 1
+        mock_client_class.return_value = mock_client
+
+        data = pd.DataFrame(
+            {
+                "code": [STATION],
+                "quarter_in_year": [2],
+                "model_short": ["LR_Base"],
+                # no horizon_value column
+                "sdivsigma": [0.40],
+                "nse": [0.85],
+                "delta": [0.10],
+                "accuracy": [0.91],
+                "mae": [3.9],
+                "n_pairs": [12],
+            }
+        )
+
+        _write_skill_metrics_to_api(data, "quarter", 2025)
+
+        call_args = mock_client.write_skill_metrics.call_args[0][0]
+
+        assert len(call_args) == 1
+        rec = call_args[0]
+        assert "horizon_value" in rec
+        assert rec["horizon_value"] == 0
+
+    @patch("src.api_writer.SapphirePostprocessingClient")
+    def test_month_nan_horizon_value_coerced_to_zero(self, mock_client_class):
+        """NaN horizon_value in month input is coerced to 0 (not sent as NULL)."""
+        mock_client = Mock()
+        mock_client.readiness_check.return_value = True
+        mock_client.write_skill_metrics.return_value = 1
+        mock_client_class.return_value = mock_client
+
+        data = pd.DataFrame(
+            {
+                "code": [STATION],
+                "month_in_year": [1],
+                "model_short": ["LR_Base"],
+                "horizon_value": [np.nan],
+                "sdivsigma": [0.42],
+                "nse": [0.83],
+                "delta": [0.10],
+                "accuracy": [0.90],
+                "mae": [4.1],
+                "n_pairs": [10],
+            }
+        )
+
+        _write_skill_metrics_to_api(data, "month", 2025)
+
+        call_args = mock_client.write_skill_metrics.call_args[0][0]
+
+        assert len(call_args) == 1
+        rec = call_args[0]
+        assert rec["horizon_value"] == 0, (
+            f"NaN horizon_value must be coerced to sentinel 0, got {rec['horizon_value']!r}"
+        )
+
+    @patch("src.api_writer.SapphirePostprocessingClient")
+    def test_composition_dedup_still_works_with_same_lead(self, mock_client_class):
+        """Same (code, model, month, horizon_value) with two compositions → keep non-None.
+
+        The composition-based dedup must still collapse fan-out duplicates when
+        horizon_value is the same (i.e., the leads are the same).
+        """
+        mock_client = Mock()
+        mock_client.readiness_check.return_value = True
+        mock_client.write_skill_metrics.return_value = 1
+        mock_client_class.return_value = mock_client
+
+        data = pd.DataFrame(
+            {
+                "code": [STATION, STATION],
+                "month_in_year": [4, 4],
+                "model_short": ["Naive Mean", "Naive Mean"],
+                "horizon_value": [0, 0],   # same lead → upsert_key collision
+                "composition": [None, "GBT, LR"],
+                "sdivsigma": [0.5, 0.5],
+                "nse": [0.8, 0.8],
+                "delta": [0.1, 0.1],
+                "accuracy": [0.9, 0.9],
+                "mae": [5.0, 5.0],
+                "n_pairs": [10, 10],
+            }
+        )
+
+        _write_skill_metrics_to_api(data, "month", 2025)
+
+        call_args = mock_client.write_skill_metrics.call_args[0][0]
+
+        # Two same-lead rows collapse to one; non-None composition retained
+        assert len(call_args) == 1
+        assert call_args[0]["composition"] == "GBT, LR"
+
+
+# ============================================================================
+# Reader — _normalize_api_monthly_skill_metrics
+# ============================================================================
+
+
+class TestNormalizeApiMonthlySkillMetrics:
+    """_normalize_api_monthly_skill_metrics passes horizon_value through."""
+
+    def test_horizon_value_preserved_when_present(self):
+        """horizon_value column is preserved (not renamed or dropped)."""
+        df = pd.DataFrame(
+            {
+                "horizon_in_year": [3, 6],
+                "model_type": ["GBT", "LR"],
+                "code": [STATION, STATION],
+                "horizon_value": [1, 2],
+                "sdivsigma": [0.4, 0.5],
+                "nse": [0.85, 0.78],
+                "mae": [3.5, 4.2],
+                "n_pairs": [10, 10],
+            }
+        )
+
+        result = _normalize_api_monthly_skill_metrics(df)
+
+        assert "horizon_value" in result.columns, (
+            "horizon_value must be present after normalization"
+        )
+        assert list(result["horizon_value"]) == [1, 2]
+
+    def test_nan_horizon_value_coerced_to_zero(self):
+        """NaN horizon_value (legacy rows) is coerced to 0 after normalization."""
+        df = pd.DataFrame(
+            {
+                "horizon_in_year": [3],
+                "model_type": ["GBT"],
+                "code": [STATION],
+                "horizon_value": [np.nan],
+                "sdivsigma": [0.4],
+                "nse": [0.85],
+                "mae": [3.5],
+                "n_pairs": [10],
+            }
+        )
+
+        result = _normalize_api_monthly_skill_metrics(df)
+
+        assert "horizon_value" in result.columns
+        assert int(result["horizon_value"].iloc[0]) == 0
+
+    def test_horizon_in_year_renamed_to_month_in_year(self):
+        """horizon_in_year → month_in_year rename is unchanged."""
+        df = pd.DataFrame(
+            {
+                "horizon_in_year": [4],
+                "model_type": ["GBT"],
+                "code": [STATION],
+                "horizon_value": [0],
+                "nse": [0.85],
+                "n_pairs": [10],
+            }
+        )
+
+        result = _normalize_api_monthly_skill_metrics(df)
+
+        assert "month_in_year" in result.columns
+        assert "horizon_in_year" not in result.columns
+        assert result["month_in_year"].iloc[0] == 4
+
+    def test_no_horizon_value_col_does_not_raise(self):
+        """DataFrame without horizon_value column still normalizes without error."""
+        df = pd.DataFrame(
+            {
+                "horizon_in_year": [3],
+                "model_type": ["GBT"],
+                "code": [STATION],
+                "nse": [0.85],
+                "n_pairs": [10],
+            }
+        )
+
+        result = _normalize_api_monthly_skill_metrics(df)
+
+        assert "month_in_year" in result.columns
+
+
+# ============================================================================
+# Reader — _normalize_monthly_forecasts
+# ============================================================================
+
+
+class TestNormalizeMonthlyForecasts:
+    """_normalize_monthly_forecasts coerces horizon_value NaN to sentinel 0."""
+
+    def _make_raw(self, horizon_value):
+        """Minimal API-like raw forecast DataFrame."""
+        return pd.DataFrame(
+            {
+                "horizon_type": ["month"],
+                "horizon_value": [horizon_value],
+                "code": [STATION],
+                "model_type": ["GBT"],
+                "valid_from": ["2025-03-01"],
+                "valid_to": ["2025-03-31"],
+                "date": ["2025-02-01"],
+                "flag": [0],
+                "q50": [120.0],
+                "q05": [90.0],
+                "q10": [95.0],
+                "q25": [105.0],
+                "q75": [135.0],
+                "q90": [145.0],
+                "q95": [150.0],
+            }
+        )
+
+    def test_nan_horizon_value_coerced_to_zero(self):
+        """NaN horizon_value is coerced to 0 so groupby doesn't drop it."""
+        raw = self._make_raw(np.nan)
+        result = _normalize_monthly_forecasts(raw)
+
+        assert "horizon_value" in result.columns
+        assert int(result["horizon_value"].iloc[0]) == 0
+
+    def test_integer_horizon_value_preserved(self):
+        """Concrete horizon_value is preserved as int."""
+        raw = self._make_raw(2)
+        result = _normalize_monthly_forecasts(raw)
+
+        assert "horizon_value" in result.columns
+        assert result["horizon_value"].iloc[0] == 2
+
+    def test_model_type_renamed_to_model_short(self):
+        """model_type → model_short rename is unchanged."""
+        raw = self._make_raw(1)
+        result = _normalize_monthly_forecasts(raw)
+
+        assert "model_short" in result.columns
+        assert "model_type" not in result.columns
+
+
+# ============================================================================
+# Reader — read_monthly_skill_metrics exposes horizon_value
+# ============================================================================
+
+
+class TestReadMonthlySkillMetricsHorizonValue:
+    """read_monthly_skill_metrics returns horizon_value in the result columns."""
+
+    def test_horizon_value_in_result_columns_when_api_returns_it(self, monkeypatch):
+        """When the API response includes horizon_value, it appears in the result."""
+        api_response = pd.DataFrame(
+            {
+                "horizon_in_year": [3, 3],
+                "model_type": ["GBT", "LR"],
+                "code": [STATION, STATION],
+                "horizon_value": [0, 1],
+                "sdivsigma": [0.4, 0.5],
+                "nse": [0.85, 0.78],
+                "delta": [0.10, 0.12],
+                "accuracy": [0.90, 0.87],
+                "mae": [3.5, 4.2],
+                "n_pairs": [10, 10],
+            }
+        )
+
+        with patch("src.data_reader._read_monthly_skill_metrics_api") as mock_api:
+            mock_api.return_value = api_response
+            result = read_monthly_skill_metrics(codes=[STATION])
+
+        assert "horizon_value" in result.columns, (
+            "read_monthly_skill_metrics must expose horizon_value when the API returns it"
+        )
+
+    def test_horizon_value_preserved_values(self, monkeypatch):
+        """horizon_value values are preserved correctly (0 and 1)."""
+        api_response = pd.DataFrame(
+            {
+                "horizon_in_year": [5, 5],
+                "model_type": ["GBT", "GBT"],
+                "code": [STATION, STATION],
+                "horizon_value": [0, 1],
+                "nse": [0.82, 0.79],
+                "n_pairs": [8, 8],
+            }
+        )
+
+        with patch("src.data_reader._read_monthly_skill_metrics_api") as mock_api:
+            mock_api.return_value = api_response
+            result = read_monthly_skill_metrics(codes=[STATION])
+
+        assert set(result["horizon_value"].unique()) == {0, 1}

--- a/sapphire/services/postprocessing/alembic/versions/a1b2c3d4e5f6_add_horizon_value_to_skill_metrics.py
+++ b/sapphire/services/postprocessing/alembic/versions/a1b2c3d4e5f6_add_horizon_value_to_skill_metrics.py
@@ -1,0 +1,100 @@
+"""Add horizon_value to skill_metrics (PP-038 Phase 1)
+
+Staged migration:
+  1. Add nullable column with server_default=0 so in-flight writes during
+     the migration window do not 500.
+  2. Backfill existing rows to 0 (sentinel for all non-month horizons).
+  3. Promote column to NOT NULL.
+  4. Swap the unique constraint to include horizon_value.
+
+Lock / downtime notes (Postgres):
+  - ALTER COLUMN … NOT NULL and CREATE UNIQUE CONSTRAINT both take
+    ACCESS EXCLUSIVE on skill_metrics.  Schedule a maintenance window;
+    the table may be large after historical recalc.
+  - Pause the operational and recalc cron during migrate + backfill.
+    Reference: doc/prod/historical_backfill_runbook.md
+
+Backfill value for existing MONTH rows:
+  All existing skill_metrics rows (including MONTH rows written before
+  Phase 2) are set to 0.  After Phase 2 ships, the apps writer will emit
+  the real lead (0–3) for new month rows.  The first post-Phase-2 recalc
+  will upsert those rows, updating the sentinel-0 rows to the correct lead.
+  Run the month-skill recalc on each environment after deploying Phase 2.
+
+Downgrade note:
+  downgrade() drops the new constraint and column only.  It does NOT
+  recreate the old narrower unique constraint
+  (uq_skill_metrics_horizon_code_model_date_horizon) because per-lead rows
+  written after Phase 2 would violate it.
+
+Revision ID: a1b2c3d4e5f6
+Revises: 34b227f37299
+Create Date: 2026-06-29
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, Sequence[str], None] = '34b227f37299'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Step 1: add nullable column with server_default so in-flight writes
+    # during the migration window do not 500.
+    op.add_column(
+        "skill_metrics",
+        sa.Column(
+            "horizon_value",
+            sa.Integer(),
+            nullable=True,
+            server_default="0",
+        ),
+    )
+
+    # Step 2: backfill — set all existing rows to sentinel 0.
+    # Run as a single UPDATE to avoid lock contention on large tables.
+    op.execute(
+        "UPDATE skill_metrics SET horizon_value = 0 WHERE horizon_value IS NULL"
+    )
+
+    # Step 3: promote to NOT NULL after backfill is complete.
+    op.alter_column("skill_metrics", "horizon_value", nullable=False)
+
+    # Step 4: swap unique constraint.
+    # Alembic cannot extend a constraint in-place — must DROP old and CREATE new.
+    op.drop_constraint(
+        "uq_skill_metrics_horizon_code_model_date_horizon",
+        "skill_metrics",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_skill_metrics_horizon_code_model_date_horizon_value",
+        "skill_metrics",
+        [
+            "horizon_type",
+            "code",
+            "model_type",
+            "date",
+            "horizon_in_year",
+            "horizon_value",
+        ],
+    )
+
+
+def downgrade() -> None:
+    # Drop new constraint and column only.
+    # Do NOT recreate the old narrower unique constraint — it would raise
+    # IntegrityError if per-lead rows (distinct horizon_value) already exist
+    # for the same (horizon_type, code, model_type, date, horizon_in_year).
+    op.drop_constraint(
+        "uq_skill_metrics_horizon_code_model_date_horizon_value",
+        "skill_metrics",
+        type_="unique",
+    )
+    op.drop_column("skill_metrics", "horizon_value")

--- a/sapphire/services/postprocessing/app/crud.py
+++ b/sapphire/services/postprocessing/app/crud.py
@@ -275,17 +275,40 @@ def get_lr_forecast(
 
 
 def create_skill_metric(db: Session, bulk_data: SkillMetricBulkCreate) -> List[SkillMetric]:
-    """Create or update multiple skill metrics in bulk (upsert based on horizon_type, code, model_type, date, horizon_in_year)"""
+    """Create or update multiple skill metrics in bulk.
+
+    Upsert key: (horizon_type, code, model_type, date, horizon_in_year, horizon_value).
+
+    PP-038 NULL-tuple hazard: SQLite and Postgres both evaluate
+    (a, NULL) IN ((a, NULL)) as NULL (never TRUE), so a NULL horizon_value
+    in the match tuple would cause every non-month row to miss its existing
+    row and insert a duplicate on every recalc.  horizon_value is coalesced
+    to 0 immediately after model_dump() so the tuple never contains NULL.
+    """
     try:
         incoming = [item.model_dump() for item in bulk_data.data]
-        keys = {(i["horizon_type"], i["code"], i["model_type"], i["date"], i["horizon_in_year"]) for i in incoming}
 
+        # Coalesce horizon_value None → 0 on every incoming row before any key
+        # construction or DB insert.  Non-month horizons (pentad/decade/quarter/
+        # season) send None; month sends an explicit lead integer (0–3).
+        for i in incoming:
+            if i.get("horizon_value") is None:
+                i["horizon_value"] = 0
+
+        # Spot 1: build the set of keys for the IN-filter query
+        keys = {
+            (i["horizon_type"], i["code"], i["model_type"], i["date"], i["horizon_in_year"], i["horizon_value"])
+            for i in incoming
+        }
+
+        # Spot 2: fetch existing rows and key them by the full 6-tuple
         existing_map = {
-            (r.horizon_type, r.code, r.model_type, r.date, r.horizon_in_year): r
+            (r.horizon_type, r.code, r.model_type, r.date, r.horizon_in_year, r.horizon_value): r
             for r in db.query(SkillMetric).filter(
+                # Spot 3: tuple-IN filter now includes horizon_value
                 tuple_(
                     SkillMetric.horizon_type, SkillMetric.code, SkillMetric.model_type,
-                    SkillMetric.date, SkillMetric.horizon_in_year
+                    SkillMetric.date, SkillMetric.horizon_in_year, SkillMetric.horizon_value
                 ).in_(keys)
             ).all()
         }
@@ -293,7 +316,8 @@ def create_skill_metric(db: Session, bulk_data: SkillMetricBulkCreate) -> List[S
         db_skill_metrics = []
         changed = []
         for data in incoming:
-            key = (data["horizon_type"], data["code"], data["model_type"], data["date"], data["horizon_in_year"])
+            # Spot 4: per-row lookup key includes horizon_value
+            key = (data["horizon_type"], data["code"], data["model_type"], data["date"], data["horizon_in_year"], data["horizon_value"])
             existing = existing_map.get(key)
 
             if existing:

--- a/sapphire/services/postprocessing/app/models.py
+++ b/sapphire/services/postprocessing/app/models.py
@@ -204,6 +204,7 @@ class SkillMetric(Base):
     model_type = Column(SQLEnum(ModelType), nullable=False)
     date = Column(Date, nullable=False)
     horizon_in_year = Column(Integer, nullable=False)
+    horizon_value = Column(Integer, nullable=False, server_default="0")  # PP-038: lead for month; sentinel 0 for pentad/decade/quarter/season
     composition = Column(String(100))  # Tracks which models compose ensemble (e.g., "LR,TFT,TiDE")
 
     # Skill metrics
@@ -231,7 +232,8 @@ class SkillMetric(Base):
             "model_type",
             "date",
             "horizon_in_year",
-            name="uq_skill_metrics_horizon_code_model_date_horizon",
+            "horizon_value",
+            name="uq_skill_metrics_horizon_code_model_date_horizon_value",
         ),
     )
 

--- a/sapphire/services/postprocessing/app/schemas.py
+++ b/sapphire/services/postprocessing/app/schemas.py
@@ -164,6 +164,7 @@ class SkillMetricBase(BaseModel):
     model_type: ModelType
     date: DateType
     horizon_in_year: int
+    horizon_value: int | None = None  # PP-038: lead for month skill; sentinel 0 for all other horizons
     composition: str | None = None
 
     sdivsigma: float | None = None

--- a/sapphire/services/postprocessing/tests/test_crud.py
+++ b/sapphire/services/postprocessing/tests/test_crud.py
@@ -391,6 +391,133 @@ class TestMonthlySkillMetricCRUD:
 
 
 # -------------------------------------------------------------------
+# SkillMetric horizon_value CRUD (PP-038 Phase 1)
+# -------------------------------------------------------------------
+
+class TestSkillMetricHorizonValueCRUD:
+    """Tests for the horizon_value column on SkillMetric (PP-038 Phase 1).
+
+    Verifies that:
+    - Two rows differing only in horizon_value both persist as distinct rows.
+    - Re-upserting the same (…, horizon_value=1) row twice leaves exactly one row.
+    - A legacy payload that omits horizon_value validates and is coalesced to 0;
+      re-upserting it stays at count 1 (no NULL-tuple duplicate).
+    - The NULL-tuple hazard is avoided: the match key never contains NULL.
+
+    Note on SQLite vs Postgres NULL semantics:
+      SQLite: (a, NULL) IN ((a, NULL)) evaluates to NULL (never TRUE).
+      Postgres: same semantics — tuple-IN with NULL element never matches.
+      Both databases are guarded by coalescing horizon_value to 0 before building
+      the match tuple, ensuring all key elements are concrete integers.
+    """
+
+    def test_two_distinct_horizon_values_both_persist(self, db_session):
+        """Rows differing only in horizon_value are stored as two separate rows."""
+        item0 = make_skill_metric(
+            horizon_type="month", horizon_in_year=6,
+            model_type="GBT", nse=0.80, horizon_value=0,
+        )
+        item1 = make_skill_metric(
+            horizon_type="month", horizon_in_year=6,
+            model_type="GBT", nse=0.70, horizon_value=1,
+        )
+        crud.create_skill_metric(
+            db_session, SkillMetricBulkCreate(data=[item0, item1])
+        )
+        assert db_session.query(SkillMetric).count() == 2
+        # Both horizon values are stored
+        hvs = {r.horizon_value for r in db_session.query(SkillMetric).all()}
+        assert hvs == {0, 1}
+
+    def test_re_upsert_same_horizon_value_stays_at_count_one(self, db_session):
+        """Re-upserting the identical (…, horizon_value=1) row updates, not inserts."""
+        item = make_skill_metric(
+            horizon_type="month", horizon_in_year=6,
+            model_type="GBT", nse=0.70, horizon_value=1,
+        )
+        # First insert
+        crud.create_skill_metric(
+            db_session, SkillMetricBulkCreate(data=[item])
+        )
+        # Second upsert with updated nse — same key including horizon_value=1
+        item_updated = make_skill_metric(
+            horizon_type="month", horizon_in_year=6,
+            model_type="GBT", nse=0.95, horizon_value=1,
+        )
+        results = crud.create_skill_metric(
+            db_session, SkillMetricBulkCreate(data=[item_updated])
+        )
+
+        assert len(results) == 1
+        assert results[0].nse == 0.95
+        # Must still be exactly one row — upsert, not a second insert
+        assert db_session.query(SkillMetric).count() == 1
+
+    def test_legacy_payload_omitting_horizon_value_coalesced_to_zero(
+        self, db_session
+    ):
+        """A pentad-style payload without horizon_value validates, coalesces to 0,
+        and re-upserting stays at count 1 (no NULL-tuple duplicate insert).
+        """
+        # make_skill_metric without horizon_value → schema default None → coalesced to 0
+        item = make_skill_metric(
+            horizon_type="pentad", horizon_in_year=33,
+            model_type="LR", nse=0.60,
+            # horizon_value intentionally omitted → defaults to None in schema
+        )
+        assert item.horizon_value is None  # verify schema default
+
+        crud.create_skill_metric(
+            db_session, SkillMetricBulkCreate(data=[item])
+        )
+        assert db_session.query(SkillMetric).count() == 1
+
+        # Fetch and confirm horizon_value was coalesced to 0, not stored as NULL
+        row = db_session.query(SkillMetric).one()
+        assert row.horizon_value == 0
+
+        # Re-upsert the same logical row — must stay at count 1
+        item_v2 = make_skill_metric(
+            horizon_type="pentad", horizon_in_year=33,
+            model_type="LR", nse=0.75,
+        )
+        results = crud.create_skill_metric(
+            db_session, SkillMetricBulkCreate(data=[item_v2])
+        )
+        assert len(results) == 1
+        assert results[0].nse == 0.75
+        # The NULL-tuple hazard would produce count == 2 here if not fixed
+        assert db_session.query(SkillMetric).count() == 1
+
+    def test_horizon_value_zero_explicit_matches_coalesced_zero(self, db_session):
+        """Explicit horizon_value=0 and omitted horizon_value (coalesced to 0)
+        resolve to the same match key and upsert correctly.
+        """
+        # Insert with explicit 0
+        item_explicit = make_skill_metric(
+            horizon_type="pentad", horizon_in_year=33,
+            model_type="LR", nse=0.50, horizon_value=0,
+        )
+        crud.create_skill_metric(
+            db_session, SkillMetricBulkCreate(data=[item_explicit])
+        )
+        assert db_session.query(SkillMetric).count() == 1
+
+        # Re-upsert with omitted horizon_value (coalesces to 0) — same key
+        item_implicit = make_skill_metric(
+            horizon_type="pentad", horizon_in_year=33,
+            model_type="LR", nse=0.88,
+            # horizon_value omitted → None → coalesced to 0
+        )
+        results = crud.create_skill_metric(
+            db_session, SkillMetricBulkCreate(data=[item_implicit])
+        )
+        assert len(results) == 1
+        assert results[0].nse == 0.88
+        assert db_session.query(SkillMetric).count() == 1
+
+
+# -------------------------------------------------------------------
 # Bulletin CRUD
 # -------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements **PP-038**: make **month** long-term skill metrics per-forecast-lead. Real-model month forecasts carry 4 distinct leads (`horizon_value ∈ {0,1,2,3}`), but `calculate_monthly_skill_metrics` pooled them into one row per `(month, code, model)`. This stratifies month skill by lead, mirroring what P-PIPE already did for season.

Plan: `doc/plans/issues/high_prio_gi_draft_pp_month_skill_lead.md` (merged via #389).

## ⚠️ For the service owner (@maxatp) — colleague-owned schema change

This PR edits `sapphire/services/postprocessing` (model + schema + crud + alembic migration). Key review points:
- **`SkillMetric.horizon_value`** column added (NOT NULL, `server_default=0`), unique constraint extended to include it.
- **Cross-horizon NULL-tuple hazard handled**: `create_skill_metric` is the single upsert path for *all* horizons; `horizon_value` is **coalesced None→0 before the match tuple is built** (all 4 match sites) so a NULL can never enter `tuple_(...).in_(...)` and cause duplicate inserts. Non-month writers send sentinel `0`; month sends the lead.
- **Staged migration** `a1b2c3d4e5f6`: add nullable+server_default → backfill → NOT NULL → drop/recreate unique constraint; downgrade drops new constraint+column only (does not recreate the narrower one).

## Apps changes
- `skill_metrics.py`: `GROUP_COLS`/`ENSEMBLE_KEY` thread `horizon_value` through all month groupby/CRPS/merge sites incl. the EM/Naive/Skilled-Mean aggregation groupbys (changed first so baselines derive per-lead). n_pairs<2 floor preserved.
- `api_writer.py`: skill writer always emits a concrete `horizon_value` (month→lead, else `0`); added to payload + upsert key.
- `data_reader.py`: normalize `horizon_value` (fillna→int); month skill reader is lead-aware.
- `forecast_dashboard/src/db.py`: month tile keeps per-lead rows but filters to the operational lead so the merge stays 1:1.

## Validation (kyg, local)
- Service migrated locally; full `run_locally.sh all` + `maintenance` + `recalculate_skill_metrics` — **all modules PASS**; recalc wrote 22 724 month + 952 quarter + 912 season skill records with **no 422 / no NULL-tuple errors**.
- DB confirms month skill is **per-lead**: real models carry `horizon_value {0,1,2,3}`, leads 1–3 min n_pairs=2 (floor held), median ~18–20.
- Tests: `postprocessing_forecasts` 1416, `service:postprocessing` 114, `forecast_dashboard` unit 375 — all green.

## Deployment note
Before the first per-lead month recalc on a deployed DB, **delete existing pooled month skill rows** (the migration backfills them to `horizon_value=0`; the recalc won't overwrite every one), to avoid stale `hv=0` / old-baseline rows. Migration + backfill + recalc run **once per environment** (kyg/taj/uzb) during a maintenance window with the recalc cron paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
