### PR TITLE
fix(ci): pin base image digest + pre-push runtime smoke gate (dashboard GLIBC break)

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -69,7 +69,38 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # Build and push with attestation for supply chain security
+      # PRE-PUSH GATE (step 1/3): build single-arch amd64 and LOAD it into the local daemon
+      # (push:false, load:true) so the image can be smoke-tested before publishing. Reuses the
+      # gha cache; cache-to seeds it so the push build below is a cache hit. load => single platform.
+      - name: Build base image for smoke-test (load, amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/docker_base_image/Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: ${{ env.BASE_IMAGE_NAME }}:smoke-test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # PRE-PUSH GATE (step 2/3): runtime smoke-test the loaded image. This would have caught the
+      # 2026-07-01 upstream regression (bash needing GLIBC_2.38 on a glibc-2.36 base, crash-looping
+      # every container) BEFORE any broken :latest reached Docker Hub. Any error fails the job.
+      - name: Smoke-test base image (pre-push gate)
+        run: |
+          echo "Verifying Python version..."
+          docker run --rm "${{ env.BASE_IMAGE_NAME }}:smoke-test" python --version
+          echo "Verifying uv is available..."
+          docker run --rm "${{ env.BASE_IMAGE_NAME }}:smoke-test" uv --version
+          echo "Runtime smoke-test: bash runs without glibc/linker errors..."
+          docker run --rm "${{ env.BASE_IMAGE_NAME }}:smoke-test" bash -lc 'echo SMOKE_OK'
+          echo "Runtime smoke-test: python + libc loader (uv itself covered by 'uv --version' above)..."
+          docker run --rm "${{ env.BASE_IMAGE_NAME }}:smoke-test" python -c "print('PY_OK')"
+          # Note: base image only provides Python + uv. Packages are installed by child images via uv sync.
+
+      # PRE-PUSH GATE (step 3/3): only reached if the smoke-test passed. Publishes the real image
+      # with SLSA provenance + SBOM (fast gha cache hit from the test build; same single-arch bits).
       - name: Build and push Docker image with attestation
         uses: docker/build-push-action@v7
         with:
@@ -83,15 +114,6 @@ jobs:
           # Use cache for faster builds
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Verify image
-        run: |
-          docker pull "${{ env.BASE_IMAGE_NAME }}:${{ env.IMAGE_TAG }}"
-          echo "Verifying Python version..."
-          docker run --rm "${{ env.BASE_IMAGE_NAME }}:${{ env.IMAGE_TAG }}" python --version
-          echo "Verifying uv is available..."
-          docker run --rm "${{ env.BASE_IMAGE_NAME }}:${{ env.IMAGE_TAG }}" uv --version
-          # Note: base image only provides Python + uv. Packages are installed by child images via uv sync.
 
 
   # Test pipeline with Python 3.12 + uv
@@ -503,6 +525,36 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # PRE-PUSH GATE (step 1/3): build single-arch amd64 and LOAD locally for smoke-testing
+      # before publishing. Reuses gha cache; cache-to seeds it for the push build below.
+      - name: Build dashboard image for smoke-test (load, amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/forecast_dashboard/Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: ${{ env.DASHBOARD_IMAGE_NAME }}:smoke-test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # PRE-PUSH GATE (step 2/3): runtime smoke-test the loaded dashboard image. Fails the job
+      # (blocking the push below) on any glibc/loader break like the 2026-07-01 crash-loop regression.
+      - name: Smoke-test dashboard image (pre-push gate)
+        run: |
+          echo "Runtime smoke-test: bash runs without glibc/linker errors..."
+          docker run --rm "${{ env.DASHBOARD_IMAGE_NAME }}:smoke-test" bash -lc 'echo SMOKE_OK'
+          echo "Runtime smoke-test: uv + python + libc loader..."
+          docker run --rm "${{ env.DASHBOARD_IMAGE_NAME }}:smoke-test" uv run python -c "print('PY_OK')"
+          # NOTE: we intentionally do NOT start `panel serve` here. The dashboard CMD initializes
+          # against runtime env/API/DB that CI does not provision, so a detached-startup check would
+          # be flaky (false negatives on missing env, not image defects). The bash + `uv run python`
+          # loader checks fully cover the 2026-07-01 glibc/loader crash-loop class; a full
+          # panel-serve health gate needs provisioned runtime env and is deferred.
+
+      # PRE-PUSH GATE (step 3/3): only reached if the smoke-test passed. Publishes the real image
+      # with provenance + SBOM (fast gha cache hit from the test build above).
       - name: Build and push Docker image with attestation
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/scheduled_security_rebuild.yml
+++ b/.github/workflows/scheduled_security_rebuild.yml
@@ -91,8 +91,46 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # Build with --pull to get fresh upstream base images (security updates)
-      # Using --no-cache ensures all layers are rebuilt with latest packages
+      # PRE-PUSH GATE (step 1/3): build a single-arch amd64 image and LOAD it into the local
+      # daemon (push:false, load:true) so it can be smoke-tested before anything is published.
+      # pull:true + no-cache:true preserves the monthly fresh-upstream security intent;
+      # cache-to warms the gha cache so the push build below is a fast cache hit (identical bits)
+      # rather than a second full rebuild. load requires a single platform (amd64).
+      - name: Build base image for smoke-test (load, amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/docker_base_image/Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: ${{ env.BASE_IMAGE_NAME }}:smoke-test
+          # Pull fresh base image to get security patches
+          pull: true
+          # Disable cache to ensure fresh build with latest packages
+          no-cache: true
+          # Seed the gha cache so the push build below is a cache hit
+          cache-to: type=gha,mode=max
+
+      # PRE-PUSH GATE (step 2/3): runtime smoke-test the loaded image. This would have caught the
+      # 2026-07-01 upstream regression (a fresh python:3.12-slim-bookworm base shipped a bash binary
+      # requiring GLIBC_2.38 on a glibc-2.36 image, crash-looping every container) BEFORE any broken
+      # :latest reached Docker Hub. Any error here fails the job and blocks the push below.
+      - name: Smoke-test base image (pre-push gate)
+        run: |
+          echo "Verifying Python version..."
+          docker run --rm "${{ env.BASE_IMAGE_NAME }}:smoke-test" python --version
+          echo "Verifying uv is available..."
+          docker run --rm "${{ env.BASE_IMAGE_NAME }}:smoke-test" uv --version
+          echo "Runtime smoke-test: bash runs without glibc/linker errors..."
+          docker run --rm "${{ env.BASE_IMAGE_NAME }}:smoke-test" bash -lc 'echo SMOKE_OK'
+          echo "Runtime smoke-test: python + libc loader (uv itself covered by 'uv --version' above)..."
+          docker run --rm "${{ env.BASE_IMAGE_NAME }}:smoke-test" python -c "print('PY_OK')"
+
+      # PRE-PUSH GATE (step 3/3): only reached if the smoke-test passed. Publishes the real
+      # multi-tag image with SLSA provenance + SBOM. The warm gha cache from the test build makes
+      # this a fast cache hit producing the same bits that were just tested (single-arch amd64,
+      # same as before this change).
       - name: Build and push base image with attestation
         uses: docker/build-push-action@v7
         with:
@@ -102,21 +140,13 @@ jobs:
           tags: |
             ${{ env.BASE_IMAGE_NAME }}:latest
             ${{ env.BASE_IMAGE_NAME }}:${{ needs.setup.outputs.monthly_tag }}
-          # Pull fresh base image to get security patches
-          pull: true
-          # Disable cache to ensure fresh build with latest packages
-          no-cache: true
+          cache-from: type=gha
           # Enable SLSA provenance attestation
           provenance: true
           sbom: true
 
-      - name: Verify base image
+      - name: Confirm base image published
         run: |
-          docker pull "${{ env.BASE_IMAGE_NAME }}:latest"
-          echo "Verifying Python version..."
-          docker run --rm "${{ env.BASE_IMAGE_NAME }}:latest" python --version
-          echo "Verifying uv is available..."
-          docker run --rm "${{ env.BASE_IMAGE_NAME }}:latest" uv --version
           echo "Pushed ${{ env.BASE_IMAGE_NAME }}:latest"
           echo "Pushed ${{ env.BASE_IMAGE_NAME }}:${{ needs.setup.outputs.monthly_tag }}"
 
@@ -175,6 +205,38 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # PRE-PUSH GATE (step 1/3): build single-arch amd64 and LOAD locally for smoke-testing
+      # before publishing. pull:true + no-cache:true keeps the monthly fresh-upstream intent;
+      # cache-to seeds the gha cache so the push build below is a cache hit. load => single platform.
+      - name: Build dashboard image for smoke-test (load, amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/forecast_dashboard/Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: ${{ env.DASHBOARD_IMAGE_NAME }}:smoke-test
+          pull: true
+          no-cache: true
+          cache-to: type=gha,mode=max
+
+      # PRE-PUSH GATE (step 2/3): runtime smoke-test the loaded dashboard image. Fails the job
+      # (blocking the push below) on any glibc/loader break like the 2026-07-01 crash-loop regression.
+      - name: Smoke-test dashboard image (pre-push gate)
+        run: |
+          echo "Runtime smoke-test: bash runs without glibc/linker errors..."
+          docker run --rm "${{ env.DASHBOARD_IMAGE_NAME }}:smoke-test" bash -lc 'echo SMOKE_OK'
+          echo "Runtime smoke-test: uv + python + libc loader..."
+          docker run --rm "${{ env.DASHBOARD_IMAGE_NAME }}:smoke-test" uv run python -c "print('PY_OK')"
+          # NOTE: we intentionally do NOT start `panel serve` here. The dashboard CMD initializes
+          # against runtime env/API/DB that CI does not provision, so a detached-startup check would
+          # be flaky (false negatives on missing env, not image defects). The bash + `uv run python`
+          # loader checks fully cover the 2026-07-01 glibc/loader crash-loop class; a full
+          # panel-serve health gate needs provisioned runtime env and is deferred.
+
+      # PRE-PUSH GATE (step 3/3): only reached if the smoke-test passed. Publishes the real
+      # multi-tag image with provenance + SBOM (fast gha cache hit from the test build above).
       - name: Build and push with attestation
         uses: docker/build-push-action@v7
         with:
@@ -184,8 +246,7 @@ jobs:
           tags: |
             ${{ env.DASHBOARD_IMAGE_NAME }}:latest
             ${{ env.DASHBOARD_IMAGE_NAME }}:${{ needs.setup.outputs.monthly_tag }}
-          pull: true
-          no-cache: true
+          cache-from: type=gha
           provenance: true
           sbom: true
 

--- a/apps/docker_base_image/Dockerfile
+++ b/apps/docker_base_image/Dockerfile
@@ -5,7 +5,8 @@
 # See: doc/plans/archive/uv_migration_plan_COMPLETED_2026-01-29.md
 
 ARG PYTHON_VERSION=3.12
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base
+# Pinned to a known-good digest after a 2026-07-01 upstream regression shipped a glibc-mismatched bash. Re-verify digest when bumping.
+FROM python:${PYTHON_VERSION}-slim-bookworm@sha256:8a7e7cc04fd3e2bd787f7f24e22d5d119aa590d429b50c95dfe12b3abe52f48b AS base
 
 # Prevents Python from writing pyc files.
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -27,6 +28,9 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv from the official image
+# uv binaries are statically linked (so uv was NOT the glibc culprit on 2026-07-01;
+# the regression was in bash, not uv). Tag is kept at :latest for now.
+# TODO: pin uv to a released version tag (e.g. ghcr.io/astral-sh/uv:0.x.y) for full reproducibility.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 # Upgrade pip to fix CVE vulnerability (pip 25.0.1 -> 25.3+)


### PR DESCRIPTION
## Summary

Fixes the crash-looping `mabesa/sapphire-dashboard:latest` (built 2026-07-01) that failed on `bash: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.38' not found`, taking down the dashboard on any deployment that recreated its container.

## Root cause

- `apps/docker_base_image/Dockerfile` pinned the **mutable** tag `python:3.12-slim-bookworm` (no digest).
- The 1st-of-month `scheduled_security_rebuild.yml` rebuilds with `pull: true` + `no-cache: true` and pulled a **transient broken upstream** base whose `bash` needs glibc 2.38 on a glibc-2.36 image.
- CI only ran `python --version` / `uv --version` — **never `bash`** — so the broken image passed as "success" and was pushed to `:latest` (silent failure). Only the dashboard uses `:latest` (pipeline images use `:local`), so only it broke.

## Changes

1. **Pin the base image** — `apps/docker_base_image/Dockerfile` now pins `python:3.12-slim-bookworm@sha256:8a7e7cc04fd3…` (verified good on amd64: bash runs, glibc 2.36). A mutable-tag upstream regression can no longer slip through.
2. **Pre-push runtime smoke gate** in `scheduled_security_rebuild.yml` and `deploy_production.yml`, for both the base and dashboard images:
   - build single-arch amd64 with `load: true` (nothing published),
   - run `bash -lc 'echo SMOKE_OK'` + a python/loader check (dashboard also runs `uv run python`),
   - **only push if the smoke test passes.** This is the gate whose absence let the broken image ship.

`uv:latest` copy is left with a `TODO` to pin (static binary, was not the culprit).

## Required after merge

The broken `:latest` is still live on Docker Hub. After merge, **re-run the rebuild** (`scheduled_security_rebuild` via workflow_dispatch, or `deploy_production`) to overwrite `:latest` with a good, smoke-tested image, confirm it is bash-OK, **then** dashboards are safe to recreate on all servers.

## Known limitations / follow-ups

- `ghcr.io/astral-sh/uv:latest` still unpinned (low impact — static binary).
- Only base + dashboard are gated; the other pipeline images push unguarded, but the digest pin + base gate cover the shared-base failure mode.
- gha cache uses the default scope for both jobs — safe only because they run sequentially via `needs`.
- Dashboard gate is loader-level (bash + python), not a full `panel serve` health check — deliberately deferred to avoid CI flakiness (the app CMD needs runtime env/DB/API CI does not provision).

## Testing

- Both workflow YAMLs validate.
- Base digest verified good on **amd64** via emulation (`bash` + `python -c` both OK, glibc 2.36).
- No unit-test surface (CI/Docker-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
