### PR TITLE
docs(deploy): Docker/backup housekeeping to prevent disk-full

### DIFF
--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -872,6 +872,18 @@ Add the following to the crontab file:
 # the cron user. See doc/operations/backup_restore.md for setup and restore drills.
 0 1 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/backup_sapphire_db.sh --env-file /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_backup_$(date +\%Y\%m\%d).log 2>&1
 #
+# Weekly Docker cleanup at 00:30 UTC Sundays: prune dangling images and build
+# cache so /var/lib/docker does not grow unbounded across deploys (each deploy
+# pulls fresh :local images and rebuilds microservices, orphaning old layers).
+# Volume-safe: never removes named volumes (the four Postgres DBs) or tagged
+# images. Do NOT add `-a` to image prune or `--volumes` to any prune here.
+30 0 * * 0 docker image prune -f && docker builder prune -f >> /home/ubuntu/logs/sapphire_docker_prune_$(date +\%Y\%m\%d).log 2>&1
+#
+# Weekly prune at 01:30 UTC Sundays of stale pre-update DB backup dirs (>30
+# days). The daily backup's own retention only prunes the top-level dumps it
+# writes, not the pre_update_*/ subdirs created before each deployment update.
+30 1 * * 0 find /var/backups/sapphire -maxdepth 1 -type d -name 'pre_update_*' -mtime +30 -exec rm -rf {} + >> /home/ubuntu/logs/sapphire_backup_prune_$(date +\%Y\%m\%d).log 2>&1
+#
 # (1) Gateway Preprocessing at 03:00 UTC. Independent of daily data.
 0 3 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_preprocessing_gateway.sh /data/<data_folder>/config/<env_file> >> /home/ubuntu/logs/sapphire_gateway_$(date +\%Y\%m\%d).log 2>&1
 #

--- a/doc/prod/first_deploy_checklist.md
+++ b/doc/prod/first_deploy_checklist.md
@@ -62,6 +62,25 @@ docker ps
 
 The last command must succeed without `sudo` for the deploy user, and without `permission denied` errors.
 
+- [ ] Configure Docker log rotation so container logs cannot grow unbounded.
+  Without this, the per-container `*-json.log` files under
+  `/var/lib/docker/containers/` grow without limit and will eventually fill the
+  disk. Create `/etc/docker/daemon.json`:
+  ```json
+  {
+    "log-driver": "json-file",
+    "log-opts": { "max-size": "10m", "max-file": "3" }
+  }
+  ```
+  Then restart Docker and confirm the driver is active:
+  ```bash
+  sudo systemctl restart docker
+  docker info --format '{{.LoggingDriver}}'   # expect: json-file
+  ```
+  The limits apply only to containers created *after* the restart, so configure
+  this before the stack is first brought up (section 7 onward). Retrofitting an
+  existing deployment is covered in `doc/prod/update_deployment_checklist.md`.
+
 ### 1.4 Clone the repository
 
 - [ ] Clone the repository into a predictable directory (commonly `/data/SAPPHIRE_Forecast_Tools`):

--- a/doc/prod/update_deployment_checklist.md
+++ b/doc/prod/update_deployment_checklist.md
@@ -559,6 +559,21 @@ The stack is defined in `sapphire/docker-compose.yml` and includes:
 > bootstraps the preprocessing DB with historical site data. For routine updates,
 > the schema is already populated.
 
+- [ ] **One-time: configure Docker log rotation if not already present.** Without
+  `/etc/docker/daemon.json`, per-container `*-json.log` files grow unbounded and
+  can fill the disk over time. Check and, if missing, apply it now — the daemon
+  restart only affects containers created afterward, so doing it here (stack down
+  from §2.1) means the `up -d` below picks up the new limits cleanly:
+  ```bash
+  if [ ! -f /etc/docker/daemon.json ]; then
+    echo '{ "log-driver": "json-file", "log-opts": { "max-size": "10m", "max-file": "3" } }' \
+      | sudo tee /etc/docker/daemon.json
+    sudo systemctl restart docker
+  fi
+  docker info --format '{{.LoggingDriver}}'   # expect: json-file
+  ```
+  This is the retrofit counterpart to `first_deploy_checklist.md` §1.3.
+
 - [ ] **Start the microservices stack**
   ```bash
   cd /data/SAPPHIRE_Forecast_Tools
@@ -679,6 +694,17 @@ The canonical schedule below follows the post-S1-2026 consolidated Luigi-wrapper
 
   # Daily DB backup at 01:00 UTC (pg_dump-based, 3-day retention)
   0 1 * * * bash /data/SAPPHIRE_Forecast_Tools/bin/backup_sapphire_db.sh -e ${ENV_FILE_PATH} -d /var/backups/sapphire -r 3 >> ${LOG_DIR}/sapphire_db_backup_$(date +\%Y\%m\%d).log 2>&1
+
+  # Weekly Docker cleanup at 00:30 UTC Sundays: prune dangling images + build
+  # cache so /var/lib/docker does not grow unbounded across deploys. Volume-safe:
+  # never removes named volumes (the four Postgres DBs) or tagged images. Do NOT
+  # add `-a` to image prune or `--volumes` to any prune here.
+  30 0 * * 0 docker image prune -f && docker builder prune -f >> ${LOG_DIR}/sapphire_docker_prune_$(date +\%Y\%m\%d).log 2>&1
+
+  # Weekly prune at 01:30 UTC Sundays of stale pre-update DB backup dirs (>30
+  # days). The daily backup's retention only prunes top-level dumps, not the
+  # pre_update_*/ subdirs created before each deployment update (see §1.5).
+  30 1 * * 0 find /var/backups/sapphire -maxdepth 1 -type d -name 'pre_update_*' -mtime +30 -exec rm -rf {} + >> ${LOG_DIR}/sapphire_backup_prune_$(date +\%Y\%m\%d).log 2>&1
 
   # (1) Gateway Preprocessing at 03:00 UTC. Independent of daily data.
   0 3 * * * cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_preprocessing_gateway.sh ${ENV_FILE_PATH} >> ${LOG_DIR}/sapphire_gateway_preprocessing_$(date +\%Y\%m\%d).log 2>&1
@@ -1123,11 +1149,17 @@ Docker container logs can also grow large over time.
 
 ### 4.3 Prune Docker System [Optional]
 
+> **Now largely automated.** The weekly cron added in §2.5
+> (`docker image prune -f && docker builder prune -f`, Sundays 00:30 UTC) keeps
+> dangling images and build cache from accumulating across deploys — the usual
+> cause of the disk filling on these hosts. Run the manual prune below only if
+> the disk is under pressure between weekly runs.
+
 Remove unused Docker resources:
 
-- [ ] Remove dangling images and unused containers:
+- [ ] Remove dangling images and build cache (volume-safe — never add `--volumes`):
   ```bash
-  docker system prune -f
+  docker image prune -f && docker builder prune -f
   ```
 
 - [ ] Check disk space recovered:


### PR DESCRIPTION
## Summary

Adds preventive housekeeping to the canonical deployment runbooks after a kghm server hit 100% disk (blocking `git pull`; daily pg_dump backups had been silently half-failing for days). Root cause was Docker images + build cache accumulating unbounded across deploys, with no log rotation and no pruning of pre-update DB backup dirs.

## Changes (docs only)
- **`deployment.md`** (canonical cron block) + **`update_deployment_checklist.md` §2.5**: two weekly cron lines — volume-safe `docker image prune` + `builder prune` (Sun 00:30 UTC), and prune of stale `pre_update_*/` DB-backup dirs >30d (Sun 01:30 UTC).
- **`first_deploy_checklist.md` §1.3**: Docker log rotation via `/etc/docker/daemon.json` (`max-size 10m`, `max-file 3`) as a first-deploy step.
- **`update_deployment_checklist.md` §2.4.5**: retrofit step to apply the same `daemon.json` on existing hosts; §4.3 rewritten to point at the new cron and drop the broader `docker system prune` for the volume-safe pair.

No code or service changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)