### PR TITLE
fix(deps): bump starlette 0.52->1.3 in forecast_dashboard (CVE)

### DIFF
--- a/apps/forecast_dashboard/uv.lock
+++ b/apps/forecast_dashboard/uv.lock
@@ -1986,15 +1986,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Bumps `starlette` from 0.52.1 to 1.3.1 in `apps/forecast_dashboard`, clearing **two** high-severity Dependabot advisories (patched `>=1.1.0` and `>=1.3.1`).

- **Lock-only change (3 lines).** starlette is transitive via `marimo` (`starlette>=0.37.2`, open upper bound) — the earlier assumption that a parent pins it `<1.x` was wrong. `uv lock --upgrade-package starlette` resolves straight to 1.3.1; no `pyproject.toml` change, no other package bumps.

## Testing (on current maxat_sapphire_2)
- `run_tests.sh forecast_dashboard`: **428 passed, 0 failures.** The 1 error is the env-gated Playwright integration test (`test_local[chromium]` needs `SAPPHIRE_SNOW_STATS_AVAILABLE`), unrelated to this bump.
- Synced env confirms `starlette 1.3.1` importable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)