### PR TITLE
fix(dashboard): snow maps — sort snow series + fix yearly snow-norm recalc

### DIFF
--- a/apps/forecast_dashboard/src/db.py
+++ b/apps/forecast_dashboard/src/db.py
@@ -332,6 +332,8 @@ def _get_snow_single(
             },
         })
 
+    sort_columns = ["date", *(["id"] if "id" in df.columns else [])]
+    df.sort_values(sort_columns, inplace=True, kind="mergesort")
     df.rename(columns={"value": col_name, **SNOW_RENAME_MAP}, inplace=True)
     df.drop(columns=["snow_type", *SNOW_VALUE_COLS, "id"], inplace=True, errors="ignore")
     for column in contract_columns:

--- a/apps/forecast_dashboard/tests/test_db.py
+++ b/apps/forecast_dashboard/tests/test_db.py
@@ -120,7 +120,7 @@ _SNOW_CONTRACT_COLUMNS = [
 ]
 
 
-def _snow_record(snow_type="HS", value=1.0):
+def _snow_record(snow_type="HS", value=1.0, **overrides):
     record = {
         "id": 1,
         "snow_type": snow_type,
@@ -140,6 +140,7 @@ def _snow_record(snow_type="HS", value=1.0):
         "current": 12.0,
     }
     record.update({f"value{i}": float(i) for i in range(1, 15)})
+    record.update(overrides)
     return record
 
 
@@ -210,6 +211,25 @@ class TestSnowData:
 
         assert {"5%", "25%", "50%", "75%", "95%"}.issubset(result.columns)
         assert {"q05", "q25", "q50", "q75", "q95"}.isdisjoint(result.columns)
+
+    def test_get_snow_single_sorts_rows_by_date(self, monkeypatch):
+        def mock_get(url, **kwargs):
+            return _make_mock_response([
+                _snow_record(id=3, date="2026-02-03", value=3.0),
+                _snow_record(id=1, date="2026-02-01", value=1.0),
+                _snow_record(id=2, date="2026-02-02", value=2.0),
+            ])
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        result = db._get_snow_single("19999", "HS", "HS")
+
+        assert result["date"].tolist() == [
+            pd.Timestamp("2026-02-01"),
+            pd.Timestamp("2026-02-02"),
+            pd.Timestamp("2026-02-03"),
+        ]
+        assert result["HS"].tolist() == [1.0, 2.0, 3.0]
 
     def test_get_snow_data_hs_converts_all_stat_columns_to_cm(self, monkeypatch):
         records_by_type = {

--- a/bin/yearly_snow_norm_recalculation.sh
+++ b/bin/yearly_snow_norm_recalculation.sh
@@ -67,7 +67,7 @@ if ! docker info > /dev/null 2>&1; then
 fi
 
 # Check if the Docker image exists, pull if not
-IMAGE_ID="mabesa/sapphire-pipeline:${ieasyhydroforecast_backend_docker_image_tag:-latest}"
+IMAGE_ID="mabesa/sapphire-prepgateway:${ieasyhydroforecast_backend_docker_image_tag:-latest}"
 if ! docker image inspect $IMAGE_ID > /dev/null 2>&1; then
     log_message "Image $IMAGE_ID not found locally, pulling..."
     docker pull $IMAGE_ID
@@ -118,6 +118,7 @@ docker run \
     --network host \
     -e ieasyhydroforecast_data_root_dir=${ieasyhydroforecast_data_root_dir} \
     -e ieasyhydroforecast_env_file_path=${ieasyhydroforecast_env_file_path} \
+    -e ieasyhydroforecast_SNOW_RECALC_YEAR=${ieasyhydroforecast_SNOW_RECALC_YEAR:-$(date +%Y)} \
     -e SAPPHIRE_OPDEV_ENV=True \
     -e IN_DOCKER=True \
     ${DOCKER_HOST_OVERRIDE} \
@@ -126,7 +127,7 @@ docker run \
     --memory=${MEMORY_LIMIT} \
     --memory-swap=${MEMORY_SWAP} \
     ${IMAGE_ID} \
-    uv run recalculate_snow_norms.py \
+    uv run --directory /app/apps/preprocessing_gateway python recalculate_snow_norms.py \
     2>&1 | tee "$SERVICE_LOG"
 
 EXIT_CODE=$?

--- a/doc/prod/update_deployment_checklist.md
+++ b/doc/prod/update_deployment_checklist.md
@@ -472,14 +472,14 @@ TODO: No need to pull them manually, they are pulled automatically when testing 
   docker pull mabesa/sapphire-dashboard:local
   ```
 
-**Optional (based on deployment configuration):**
-
-If `ieasyhydroforecast_run_ML_models=true` in your .env file:
-
-- [ ] **Pull gateway preprocessing image**
+- [ ] **Pull preprocessing gateway image** (required for gateway maintenance and yearly snow norm/stat recalculation)
   ```bash
   docker pull mabesa/sapphire-prepgateway:local
   ```
+
+**Optional (based on deployment configuration):**
+
+If `ieasyhydroforecast_run_ML_models=true` in your .env file:
 
 - [ ] **Pull ML forecasting image**
   ```bash
@@ -863,6 +863,24 @@ After updating crontabs, run each cron command manually (one by one) to verify t
   cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh skill_recalc  ${ENV_FILE_PATH}
   cd /data/SAPPHIRE_Forecast_Tools && bash bin/run_periodic_maintenance.sh snow_norms    ${ENV_FILE_PATH}
   ```
+
+- [ ] **Verify snow stat columns after snow norm/stat recalculation**
+
+  The dashboard snow panel uses `mean`, `q05`..`q95`, `previous`, and
+  `current`. If a hydrological display window crosses Jan 1 (for example
+  `ieasyhydroforecast_SNOW_DISPLAY_START_MMDD=09-01`), the current calendar
+  year must have these stat fields populated; otherwise the percentile bands,
+  mean, and previous-season line stop at Jan 1 while the current-season line
+  continues.
+
+  ```bash
+  docker exec sapphire-preprocessing-db psql -U postgres -d preprocessing_db -c \
+  "select extract(year from date) y, count(*) rows, count(mean) mean, count(q05) q05, count(previous) prev, count(current) curr from snow where code='19999' and snow_type='SWE' and date between '2025-09-01' and '2026-08-31' group by 1 order by 1;"
+  ```
+
+  Replace `19999` and the date range with a non-sensitive representative
+  station/window for the deployment. Acceptance: both years in the displayed
+  snow window have non-zero `mean`, `q05`, and `prev` counts.
 
 - [ ] **Run bimonthly long-term skill metrics recalculation**
   ```bash


### PR DESCRIPTION
## Root cause (two parts)
Broken snow "SnowMapper" panels on deployed servers, despite a fresh image and populated `snow` table.

1. **Ordering** — `_get_snow_single` (db.py) returned snow rows in API order (a `limit:10000` read with no `ORDER BY`); every sibling retrieval sorts, this one didn't → series plotted out of date order.
2. **Missing current-year stats (primary)** — `bin/yearly_snow_norm_recalculation.sh` ran the **wrong image** (`sapphire-pipeline`) with the wrong entrypoint, so `recalculate_snow_norms.py` never populated the **current calendar year**. With a display window crossing Jan 1 (`SNOW_DISPLAY_START_MMDD=09-01`), the percentile bands / mean / previous-season line **stop at Jan 1** while the current-season line continues. An aggregate stat count hides this — a *per-year* count is the right check.

## Changes
- `db.py`: sort snow rows by `(date, id)`, stable mergesort, before shaping. + regression test (`test_db.py`).
- `yearly_snow_norm_recalculation.sh`: `sapphire-prepgateway` image, `uv run --directory /app/apps/preprocessing_gateway python …`, pass `ieasyhydroforecast_SNOW_RECALC_YEAR` (verified read + unit-tested by the script).
- Checklist: prepgateway pull now **required** (not ML-gated) + a per-year snow-stat verification query.

## Deploy note (the fix isn't complete on merge)
Rebuild the **dashboard** (sort) and **prepgateway** (stats) images, then on each server **re-run the snow-norm recalc** (`bin/run_periodic_maintenance.sh snow_norms $ENV`) to backfill current-year stats, and confirm the per-year verification query shows non-zero `mean`/`q05`/`prev` for both years in the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)