### PR TITLE
fix(postprocessing): stale monthly aggregate rows corrupt per-lead skill (blank dashboard tiles)

### DIFF
--- a/apps/postprocessing_forecasts/postprocessing_maintenance_long_term.py
+++ b/apps/postprocessing_forecasts/postprocessing_maintenance_long_term.py
@@ -228,8 +228,8 @@ def postprocessing_maintenance_long_term():
             [combined, new_ensemble],
             ignore_index=True,
         )
-        # Deduplicate on (year, month, code, model_short)
-        dedup_cols = ["year", "month", "code", "model_short"]
+        # Deduplicate on (year, month, code, model_short, horizon_value)
+        dedup_cols = ["year", "month", "code", "model_short", "horizon_value"]
         available_dedup = [c for c in dedup_cols if c in merged.columns]
         merged = merged.drop_duplicates(
             subset=available_dedup,

--- a/apps/postprocessing_forecasts/postprocessing_operational_long_term.py
+++ b/apps/postprocessing_forecasts/postprocessing_operational_long_term.py
@@ -143,6 +143,7 @@ def postprocessing_operational_long_term():
                     "month",
                     "code",
                     "model_short",
+                    "horizon_value",
                 ]
                 available_dedup = [c for c in dedup_cols if c in joint.columns]
                 joint = joint.drop_duplicates(

--- a/apps/postprocessing_forecasts/src/api_writer.py
+++ b/apps/postprocessing_forecasts/src/api_writer.py
@@ -872,13 +872,25 @@ def _write_monthly_ensemble_to_api(data: pd.DataFrame) -> bool:
             model_upper = str(row["model_short"]).upper()
             model_type = MODEL_TYPE_MAP.get(model_upper, str(row["model_short"]))
 
+            if "horizon_value" in row.index and pd.notna(row.get("horizon_value")):
+                horizon_value = int(row["horizon_value"])
+            else:
+                # The calendar month is NEVER a valid horizon_value; fall
+                # back to the 0 sentinel (legacy/no-lead) instead.
+                logger.warning(
+                    "horizon_value missing for monthly ensemble row "
+                    "(code=%s, year=%s, month=%s, model=%s); using 0 "
+                    "sentinel instead of the calendar month",
+                    code,
+                    year,
+                    month,
+                    row["model_short"],
+                )
+                horizon_value = 0
+
             record = {
                 "horizon_type": "month",
-                "horizon_value": (
-                    int(row["horizon_value"])
-                    if "horizon_value" in row.index and pd.notna(row.get("horizon_value"))
-                    else month
-                ),
+                "horizon_value": horizon_value,
                 "code": code,
                 "date": (
                     str(row["date"])[:10]

--- a/apps/postprocessing_forecasts/src/data_reader.py
+++ b/apps/postprocessing_forecasts/src/data_reader.py
@@ -1352,8 +1352,10 @@ def _normalize_monthly_combined_forecasts(
     if "forecasted_discharge" not in df.columns and "q50" in df.columns:
         df["forecasted_discharge"] = df["q50"].astype(float)
 
-    # Drop API-only columns not needed internally
-    drop_cols = ["id", "horizon_type", "horizon_value", "model_type_description"]
+    # Drop API-only columns not needed internally. Preserve
+    # horizon_value so the lead carries through merge-back and skill
+    # recalc (the base normalizer already fillna(0).astype(int)s it).
+    drop_cols = ["id", "horizon_type", "model_type_description"]
     df = df.drop(
         columns=[c for c in drop_cols if c in df.columns],
         errors="ignore",

--- a/apps/postprocessing_forecasts/src/skill_metrics.py
+++ b/apps/postprocessing_forecasts/src/skill_metrics.py
@@ -11,7 +11,11 @@ from contextlib import contextmanager
 
 import numpy as np
 import pandas as pd
-from src.model_names import AGGREGATED_EM_RAW_MODELS, canonical_model_short_series
+from src.model_names import (
+    AGGREGATED_EM_RAW_MODELS,
+    AGGREGATED_ENSEMBLE_MODELS,
+    canonical_model_short_series,
+)
 from src.postprocessing_tools import enforce_quantile_monotonicity, forecast_target_date
 
 logger = logging.getLogger(__name__)
@@ -1199,6 +1203,20 @@ def calculate_monthly_skill_metrics(
     else:
         forecasts = forecasts.copy()
         forecasts["horizon_value"] = forecasts["horizon_value"].fillna(0).astype(int)
+
+    # Drop any pre-existing aggregate/baseline rows (EM, Naive Mean,
+    # Skilled Mean) so stale copies — e.g. a NAIVE_MEAN row stored at
+    # horizon_value = target month — are not scored as raw model rows.
+    # The ensemble/naive/skilled blocks below regenerate these from the
+    # raw models and re-exclude the same names from their input pools, so
+    # clean sites see identical legitimate output. Canonical matching
+    # catches both DB-form (NAIVE_MEAN) and display-form (Naive Mean).
+    if "model_short" in forecasts.columns:
+        forecasts = forecasts[
+            ~canonical_model_short_series(forecasts["model_short"]).isin(AGGREGATED_ENSEMBLE_MODELS)
+        ].copy()
+        if forecasts.empty:
+            return empty_stats, empty_joint, timing_stats
 
     # --- 1. Merge forecasts with observations on [code, year, month] ---
     merged = pd.merge(

--- a/apps/postprocessing_forecasts/tests/test_api_integration.py
+++ b/apps/postprocessing_forecasts/tests/test_api_integration.py
@@ -1464,7 +1464,13 @@ class TestWriteMonthlyEnsembleToApi:
         records = mock_client.write_long_forecasts.call_args[0][0]
         em_rec = next(r for r in records if r["model_type"] == "EM")
         assert em_rec["horizon_type"] == "month"
-        assert em_rec["horizon_value"] == 6
+        # ensemble_data has no horizon_value column, so this exercises the
+        # absent-horizon_value fallback. The correct sentinel is 0 (base-model
+        # no-lead convention), NEVER the calendar month — see the LOCKED test
+        # test_horizon_value_falls_back_to_zero_sentinel_when_absent. This
+        # assertion is incidental to the test's real purpose (LongForecast
+        # record field coverage) but must not re-lock the calendar-month bug.
+        assert em_rec["horizon_value"] == 0
         assert em_rec["code"] == "15013"
         assert em_rec["date"] == "2024-06-01"
         assert em_rec["valid_from"] == "2024-06-01"
@@ -1649,8 +1655,22 @@ class TestMonthlyEnsembleHorizonValueConsistency:
             )
 
     @patch("src.api_writer.SapphirePostprocessingClient")
-    def test_horizon_value_falls_back_to_month_when_absent(self, mock_client_class):
-        """When input lacks horizon_value column, falls back to month."""
+    def test_horizon_value_falls_back_to_zero_sentinel_when_absent(
+        self, mock_client_class
+    ):
+        """LOCKED: absent horizon_value falls back to the 0 no-lead sentinel.
+
+        The calendar month is NEVER a valid ``horizon_value``. When the input
+        lacks the column, the writer must emit the base-model no-lead sentinel
+        (0), matching the individual long-term model convention — not the
+        absolute calendar month. Emitting the month is the write-side bug that
+        plants stale aggregate rows at ``horizon_value == month``, which later
+        corrupt the monthly skill population.
+
+        Asserts the CORRECT (post-fix) behavior and therefore FAILS against the
+        current buggy ``else month`` fallback. Do NOT relax to match current
+        behavior. Placeholder station code 19999 (never a real station).
+        """
         if not SAPPHIRE_API_AVAILABLE:
             pytest.skip("sapphire-api-client not installed")
 
@@ -1661,7 +1681,7 @@ class TestMonthlyEnsembleHorizonValueConsistency:
 
         data = pd.DataFrame(
             {
-                "code": ["15013"],
+                "code": ["19999"],
                 "year": [2024],
                 "month": [6],
                 "month_in_year": [6],
@@ -1680,8 +1700,10 @@ class TestMonthlyEnsembleHorizonValueConsistency:
 
         records = mock_client.write_long_forecasts.call_args[0][0]
         record = records[0]
-        assert record["horizon_value"] == 6, (
-            "Fallback: when horizon_value absent, should use month (6)"
+        assert record["horizon_value"] == 0, (
+            "Fallback: when horizon_value absent, the writer must use the 0 "
+            "no-lead sentinel (base-model convention), never the calendar "
+            f"month; got {record['horizon_value']}"
         )
 
 

--- a/apps/postprocessing_forecasts/tests/test_monthly_skill_per_lead.py
+++ b/apps/postprocessing_forecasts/tests/test_monthly_skill_per_lead.py
@@ -569,3 +569,107 @@ class TestNPairsFloorPerLead:
         # Lead-1: n_pairs=1 dropped by the floor -> absent
         row1 = m1[m1["horizon_value"] == 1]
         assert row1.empty, "Lead-1 thin row (n_pairs=1) must be dropped by the floor"
+
+
+# ===========================================================================
+# Stale aggregate row (calendar-month horizon_value) must not be scored
+# ===========================================================================
+
+
+class TestStaleAggregateRowNotScored:
+    """A stale aggregate row at horizon_value == month must not be scored.
+
+    A previously-written aggregate (e.g. Naive Mean) can land at
+    ``horizon_value = target month`` via the buggy calendar-month
+    fallback. It must be excluded from the raw-model-skill groupby and the
+    aggregate regenerated from the base models at their own (0) lead.
+    """
+
+    def test_stale_naive_mean_at_month_not_scored(self):
+        """Stale Naive Mean at hv=8 yields no skill row at hv=8.
+
+        Two base models live at horizon_value 0 (so the ensemble path
+        activates); one stale ``Naive Mean`` row is injected at
+        horizon_value 8 (the calendar month, the bug signature). No skill
+        row may exist at horizon_value 8, and the regenerated aggregate
+        rows must follow the base-model convention (0).
+        """
+        stale_month = 8
+        obs = _make_obs(
+            [
+                (STATION, 2021, stale_month, 100.0),
+                (STATION, 2022, stale_month, 110.0),
+                (STATION, 2023, stale_month, 120.0),
+            ]
+        )
+        fcst = _make_fcst_lead(
+            [
+                # Two base models at the no-lead sentinel horizon_value = 0.
+                (STATION, 2021, stale_month, "LR_Base", 0, 83, 88, 95, 103, 111, 118, 123),
+                (STATION, 2021, stale_month, "LR_SM", 0, 81, 86, 93, 101, 109, 116, 121),
+                (STATION, 2022, stale_month, "LR_Base", 0, 89, 94, 101, 109, 117, 124, 129),
+                (STATION, 2022, stale_month, "LR_SM", 0, 87, 92, 99, 107, 115, 122, 127),
+                (STATION, 2023, stale_month, "LR_Base", 0, 100, 105, 112, 122, 130, 137, 142),
+                (STATION, 2023, stale_month, "LR_SM", 0, 98, 103, 110, 120, 128, 135, 140),
+                # STALE aggregate row at the calendar-month horizon_value = 8.
+                (
+                    STATION,
+                    2021,
+                    stale_month,
+                    "Naive Mean",
+                    stale_month,
+                    82,
+                    87,
+                    94,
+                    102,
+                    110,
+                    117,
+                    122,
+                ),
+                (
+                    STATION,
+                    2022,
+                    stale_month,
+                    "Naive Mean",
+                    stale_month,
+                    88,
+                    93,
+                    100,
+                    108,
+                    116,
+                    123,
+                    128,
+                ),
+                (
+                    STATION,
+                    2023,
+                    stale_month,
+                    "Naive Mean",
+                    stale_month,
+                    99,
+                    104,
+                    111,
+                    121,
+                    129,
+                    136,
+                    141,
+                ),
+            ]
+        )
+
+        stats, _, _ = calculate_monthly_skill_metrics(obs, fcst)
+
+        # (1) No skill row may exist at the stale calendar-month lead.
+        at_month = stats[stats["horizon_value"] == stale_month]
+        assert at_month.empty, (
+            "stale aggregate row at horizon_value == month must not be "
+            f"scored; found stray rows:\n{at_month.to_string()}"
+        )
+
+        # (2) Regenerated aggregate skill uses the base-model lead (0).
+        aggregates = stats[stats["model_short"].isin({"EM", "Naive Mean", "Skilled Mean"})]
+        assert not aggregates.empty, "expected regenerated aggregate skill rows"
+        assert (aggregates["horizon_value"] == 0).all(), (
+            "aggregate skill must follow the base-model horizon_value "
+            f"convention (0); got {sorted(aggregates['horizon_value'].unique())}"
+        )

--- a/apps/postprocessing_forecasts/tests/test_monthly_skill_stale_aggregate_regression.py
+++ b/apps/postprocessing_forecasts/tests/test_monthly_skill_stale_aggregate_regression.py
@@ -1,0 +1,194 @@
+"""LOCKED regression tests: stale aggregate rows must not corrupt monthly skill.
+
+Bug: on the dashboard month view some hydroposts show forecasts but ALL skill
+columns blank for every model, while other sites display fully. The skill IS
+computed and stored, but a *stray duplicate* population of skill_metrics rows
+is produced at ``horizon_value == target_month``. That stray population later
+activates a dashboard filter that discards the correct ``horizon_value == 0``
+skill.
+
+Root cause exercised here: stale aggregate forecast rows
+(NAIVE_MEAN / ENSEMBLE_MEAN / SKILLED_MEAN) arrive at
+``horizon_value = target month`` (an invalid convention) and are scored as if
+they were ordinary base-model rows by the first raw-model-skill groupby in
+``calculate_monthly_skill_metrics``. They must instead be excluded from that
+groupby, so the aggregate skill is regenerated from the base models using the
+base-model ``horizon_value`` convention (0 = no-lead sentinel here).
+
+Convention (locked): monthly ``horizon_value`` is the lead offset when known;
+0 is the legacy/no-lead sentinel; the *calendar month is never* a valid
+``horizon_value``. Ensemble/aggregate models MUST use the same convention as
+base models.
+
+These tests assert the CORRECT (post-fix) behavior and therefore FAIL against
+the current buggy code. Do NOT relax them to match current behavior.
+
+Placeholder station code 19999 is used (never a real station code).
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.skill_metrics import calculate_monthly_skill_metrics
+
+# Placeholder station code — never a real station.
+STATION = "19999"
+
+# Target month of the forecast; also the (INVALID) horizon_value a stale
+# aggregate row would carry under the buggy calendar-month fallback.
+TARGET_MONTH = 8
+
+# Base-model horizon_value convention in this scenario (no-lead sentinel).
+BASE_HV = 0
+
+QUANTILE_COLS = ["q05", "q10", "q25", "q50", "q75", "q90", "q95"]
+AGGREGATE_MODELS = {"EM", "Naive Mean", "Skilled Mean"}
+
+
+def _make_observations():
+    """Observations for station 19999, month 8, three years.
+
+    Returns a frame with the columns the monthly skill routine consumes:
+    ``code, year, month, month_in_year, discharge_avg, delta``.
+    """
+    rows = [
+        (STATION, 2021, TARGET_MONTH, 100.0),
+        (STATION, 2022, TARGET_MONTH, 110.0),
+        (STATION, 2023, TARGET_MONTH, 120.0),
+    ]
+    df = pd.DataFrame(rows, columns=["code", "year", "month", "discharge_avg"])
+    df["month_in_year"] = df["month"]
+
+    delta_df = (
+        df.groupby(["code", "month_in_year"])
+        .agg(std_discharge=("discharge_avg", "std"))
+        .reset_index()
+    )
+    delta_df["delta"] = 0.674 * delta_df["std_discharge"].fillna(0.0)
+    df = df.merge(
+        delta_df[["code", "month_in_year", "delta"]],
+        on=["code", "month_in_year"],
+        how="left",
+    )
+    return df
+
+
+def _fcst_row(year, model_short, horizon_value, center):
+    """Build one forecast row with a symmetric quantile spread around center."""
+    offsets = [-20, -15, -8, 0, 8, 15, 20]
+    row = {
+        "code": STATION,
+        "year": year,
+        "month": TARGET_MONTH,
+        "model_short": model_short,
+        "horizon_value": horizon_value,
+    }
+    for qcol, off in zip(QUANTILE_COLS, offsets, strict=True):
+        row[qcol] = float(center + off)
+    return row
+
+
+def _make_forecasts_with_stale_aggregate():
+    """Two base models at hv=0 plus a STALE Naive Mean row at hv=month.
+
+    The stale ``Naive Mean`` rows imitate previously-written aggregate rows
+    that landed at ``horizon_value = target month`` (8) via the buggy
+    calendar-month fallback. A correct recalc must ignore them for scoring and
+    regenerate the aggregate from the base models at the base convention (0).
+    """
+    rows = []
+    for year, base in [(2021, 102.0), (2022, 108.0), (2023, 121.0)]:
+        # Base models at the no-lead sentinel horizon_value = 0.
+        rows.append(_fcst_row(year, "LR_Base", BASE_HV, base + 1.0))
+        rows.append(_fcst_row(year, "LR_SM", BASE_HV, base - 1.0))
+        # STALE aggregate row at the calendar-month horizon_value = 8.
+        rows.append(_fcst_row(year, "Naive Mean", TARGET_MONTH, base))
+    return pd.DataFrame(rows)
+
+
+def test_stale_aggregate_row_at_month_produces_no_skill_at_month():
+    """No skill row may exist at horizon_value == target month.
+
+    Any skill_metrics row at ``horizon_value == 8`` is a stray artifact of
+    scoring a stale aggregate row as a base model. The correct output contains
+    no such row for any model.
+    """
+    obs = _make_observations()
+    fcst = _make_forecasts_with_stale_aggregate()
+
+    skill_stats, _joint, _timing = calculate_monthly_skill_metrics(obs, fcst)
+
+    assert not skill_stats.empty, "expected non-empty skill metrics"
+    at_month = skill_stats[skill_stats["horizon_value"] == TARGET_MONTH]
+    assert at_month.empty, (
+        "stale aggregate row at horizon_value == target month must not be "
+        f"scored; found stray skill rows:\n{at_month.to_string()}"
+    )
+
+
+def test_aggregate_skill_uses_base_model_horizon_convention():
+    """Regenerated aggregate skill must use the base-model horizon_value (0).
+
+    The aggregate ("Naive Mean") is rebuilt from the base models, which live at
+    horizon_value == 0, so its skill row must land at horizon_value == 0 — never
+    at the calendar month.
+    """
+    obs = _make_observations()
+    fcst = _make_forecasts_with_stale_aggregate()
+
+    skill_stats, _joint, _timing = calculate_monthly_skill_metrics(obs, fcst)
+
+    aggregate_rows = skill_stats[skill_stats["model_short"].isin(AGGREGATE_MODELS)]
+    assert not aggregate_rows.empty, "expected a regenerated aggregate (Naive Mean) skill row"
+    assert (aggregate_rows["horizon_value"] == BASE_HV).all(), (
+        "aggregate skill must follow the base-model horizon_value convention "
+        f"(0); got horizon_values {sorted(aggregate_rows['horizon_value'].unique())}"
+    )
+
+
+def test_no_duplicate_aggregate_skill_population():
+    """Each (code, model, month_in_year) aggregate appears at exactly one hv.
+
+    The bug yields two populations of the aggregate skill: the correct one at
+    hv==0 and a stray one at hv==month. Deduping across horizon_value must leave
+    a single row per aggregate model.
+    """
+    obs = _make_observations()
+    fcst = _make_forecasts_with_stale_aggregate()
+
+    skill_stats, _joint, _timing = calculate_monthly_skill_metrics(obs, fcst)
+
+    aggregate_rows = skill_stats[skill_stats["model_short"].isin(AGGREGATE_MODELS)]
+    counts = aggregate_rows.groupby(["code", "model_short", "month_in_year"])[
+        "horizon_value"
+    ].nunique()
+    assert (counts == 1).all(), (
+        "aggregate skill must not span multiple horizon_value populations; "
+        f"per-group horizon_value counts:\n{counts.to_string()}"
+    )
+
+
+def test_base_model_skill_preserved_at_zero():
+    """Base-model skill stays at horizon_value == 0 and is fully populated.
+
+    Guards against a fix that would drop the correct base-model skill along with
+    the stray aggregate rows.
+    """
+    obs = _make_observations()
+    fcst = _make_forecasts_with_stale_aggregate()
+
+    skill_stats, _joint, _timing = calculate_monthly_skill_metrics(obs, fcst)
+
+    for model in ("LR_Base", "LR_SM"):
+        rows = skill_stats[skill_stats["model_short"] == model]
+        assert not rows.empty, f"expected skill rows for base model {model}"
+        assert (rows["horizon_value"] == BASE_HV).all(), (
+            f"{model} skill must stay at horizon_value == 0"
+        )
+        assert rows["mae"].notna().all(), f"{model} MAE must be populated"
+        assert not np.isinf(rows["mae"]).any(), f"{model} MAE must be finite"


### PR DESCRIPTION
## Problem
On the forecast dashboard (month view), some hydroposts showed forecasts but **blank skill** (δ, s/σ, MAE, accuracy) for every model, while others displayed fully. The skill was computed and present in the DB — it was being discarded at display time.

## Root cause
- `api_writer._write_monthly_ensemble_to_api` fell back to the **calendar month** when `horizon_value` was missing (instead of the `0` sentinel), writing stale aggregate forecast rows at `horizon_value = target month`.
- `data_reader._normalize_monthly_combined_forecasts` dropped `horizon_value`, causing the loss.
- `skill_metrics.calculate_monthly_skill_metrics` then scored those stale aggregate rows as raw model rows (they were only excluded *later* from ensemble input pools), producing a stray population of skill rows at `horizon_value = horizon_in_year`.
- The dashboard's lead-aware filter (`forecast_dashboard/src/db.py`) filters month skill to `horizon_value == 1` when any such row exists; the stray rows tripped it and discarded the correct skill → blank tiles.

## Fix
- **api_writer.py**: absent `horizon_value` → `0` sentinel + warning, never the calendar month.
- **data_reader.py**: preserve `horizon_value` through normalization.
- **skill_metrics.py**: drop pre-existing aggregate rows before the raw-skill groupby (canonical match for DB- and display-form names); ensembles are regenerated downstream, so clean sites are unaffected.
- **operational/maintenance long-term**: include `horizon_value` in the monthly dedup keys.
- Corrected the bad test that asserted the calendar-month fallback; added a locked regression test.

## Validation
- Full `postprocessing_forecasts` suite green (**1421 passed, 0 skipped, 0 failed**); the locked regression test fails on pre-fix code and passes on the fix.
- Local Tajik run: per-lead month skill restored (a previously-blank site now has skill at hv=0/1/2), zero stray `hv≥4` aggregate rows, dashboard tiles confirmed rendering.

## Blast radius
Affects any PP-038/MIG-008-era deployment (not Tajik-only; Kyrgyz likely too).

## Follow-ups (NOT in this PR)
- **DB cleanup (per deployment):** existing stray rows won't be overwritten by the fixed recalc (the `skill_metrics` unique key includes `horizon_value`) — delete the aggregate rows and re-run the long-term skill recalc.
- **Dashboard hardening:** make the lead-aware filter prefer `hv=0` when the exact operational lead is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
