### PR TITLE
forecast_skill_eval: below-norm(1.0) event + module-correctness review

### DIFF
--- a/apps/forecast_skill_eval/src/forecast_skill_eval/api_readers.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/api_readers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from datetime import date
 from typing import Any, Final, Literal
 
 import numpy as np
@@ -98,6 +99,7 @@ def read_lr_forecasts(
     start_date: str | None,
     end_date: str | None,
     limit: int = DEFAULT_PAGE_SIZE,
+    repair_issue_indexing: bool = False,
 ) -> ReaderResult:
     """Read LR forecasts and normalize them for the short-term pair path.
 
@@ -105,6 +107,11 @@ def read_lr_forecasts(
     linear_regression.py:925-933); date is the issue date; target := date+1
     recovers the target year only; period_key derives from horizon_in_year,
     never from date+1.
+
+    When ``repair_issue_indexing`` is True an optional, default-off repair-on-read
+    corrects historical issue-indexed LR pentad/decade forecasts to target-indexed
+    (see :func:`_repair_lr_issue_indexing`); the default (False) leaves the read
+    byte-identical.
     """
     normalized_horizon = normalize_horizon(horizon)
     data = _read_all_pages(
@@ -118,7 +125,11 @@ def read_lr_forecasts(
         ),
         limit=limit,
     )
-    data = _normalize_lr_forecasts(data)
+    data = _normalize_lr_forecasts(
+        data,
+        horizon=normalized_horizon,
+        repair_issue_indexing=repair_issue_indexing,
+    )
     data, dropped_sentinels = _drop_short_term_sentinels(data, normalized_horizon)
     enriched = _add_point_values(data, forecast_type="short")
     enriched = _add_quantile_band(enriched, forecast_type="short")
@@ -292,7 +303,12 @@ def _drop_short_term_sentinels(data: pd.DataFrame, horizon: str) -> tuple[pd.Dat
     return filtered, dropped_count
 
 
-def _normalize_lr_forecasts(data: pd.DataFrame) -> pd.DataFrame:
+def _normalize_lr_forecasts(
+    data: pd.DataFrame,
+    *,
+    horizon: str = "",
+    repair_issue_indexing: bool = False,
+) -> pd.DataFrame:
     normalized = data.copy()
     normalized["model"] = "LR"
     if "date" in normalized.columns:
@@ -300,6 +316,8 @@ def _normalize_lr_forecasts(data: pd.DataFrame) -> pd.DataFrame:
         normalized["target"] = issue_dates + pd.Timedelta(days=1)
     else:
         normalized["target"] = pd.Series(pd.NaT, index=normalized.index, dtype="datetime64[ns]")
+    if repair_issue_indexing and horizon in ("pentad", "decade"):
+        normalized = _repair_lr_issue_indexing(normalized, horizon)
     return normalized
 
 
@@ -351,3 +369,89 @@ def _add_long_calendar_periods(data: pd.DataFrame, horizon: str) -> pd.DataFrame
     enriched["calendar_period"] = [period[0] for period in periods]
     enriched["is_calendar_aligned"] = [period[1] for period in periods]
     return enriched
+
+
+# ---------------------------------------------------------------------------
+# LR issue-indexing repair-on-read helpers (optional, default off)
+#
+# Period conventions mirror apps/iEasyHydroForecast/tag_library.py
+# (get_pentad_in_year / get_decad_for_date).  Implemented locally to avoid a
+# cross-package import of iEasyHydroForecast.
+# ---------------------------------------------------------------------------
+
+
+def _pentad_of_year(d: date) -> int:
+    """Return the 1..72 pentad-of-year index for a calendar date.
+
+    Convention (tag_library.py get_pentad_in_year): days 1-5 -> 1, 6-10 -> 2,
+    ... 26-end -> 6 within each month; pentad_of_year = (month - 1) * 6 + pentad.
+    """
+    pentad_in_month = min((d.day - 1) // 5 + 1, 6)
+    return (d.month - 1) * 6 + pentad_in_month
+
+
+def _decad_of_year(d: date) -> int:
+    """Return the 1..36 decad-of-year index for a calendar date.
+
+    Convention (tag_library.py get_decad_for_date): day <= 10 -> 1, <= 20 -> 2,
+    else 3 within each month; decad_of_year = (month - 1) * 3 + decad.
+    """
+    decad_in_month = 1 if d.day <= 10 else 2 if d.day <= 20 else 3
+    return (d.month - 1) * 3 + decad_in_month
+
+
+def _issue_period_of_year(d: date, horizon: str) -> int:
+    """Dispatch to the pentad/decad in-year period index for the given horizon."""
+    if horizon == "pentad":
+        return _pentad_of_year(d)
+    return _decad_of_year(d)
+
+
+def _repair_lr_issue_indexing(data: pd.DataFrame, horizon: str) -> pd.DataFrame:
+    """Remap issue-indexed LR pentad/decade forecasts to target-indexed.
+
+    Historical (pre-2024) LR short-term forecasts store ``horizon_in_year`` as the
+    ISSUE period; new forecasts are already target-indexed, so the DB is a mix.
+    Detection is bimodal: for an LR row with issue date ``D`` and stored period
+    ``H``, if ``H`` equals the issue period computed from ``D`` the row is
+    issue-indexed and is remapped to ``issue_period + 1`` (with wrap 72->1 /
+    36->1).  Every other case (already target-indexed, sentinel, uncomputable) is
+    left completely unchanged.
+
+    Args:
+        data: Normalized LR frame (must retain the raw ``date`` and
+            ``horizon_in_year`` columns).
+        horizon: ``"pentad"`` or ``"decade"``.
+
+    Returns:
+        A copy of ``data`` with only the issue-indexed rows remapped.
+    """
+    if data.empty or "horizon_in_year" not in data.columns or "date" not in data.columns:
+        return data
+
+    period_max = 72 if horizon == "pentad" else 36
+    periods_per_month = 6 if horizon == "pentad" else 3
+
+    repaired = data.copy()
+    for idx in repaired.index:
+        issue_date = pd.to_datetime(repaired.at[idx, "date"], errors="coerce")
+        h_value = pd.to_numeric(repaired.at[idx, "horizon_in_year"], errors="coerce")
+        if pd.isna(issue_date) or pd.isna(h_value):
+            continue
+        issue_period = _issue_period_of_year(issue_date.date(), horizon)
+        h_int = int(h_value)
+        # Only issue-indexed rows (H == issue period) are remapped; this cleanly
+        # leaves already-target-indexed rows, sentinels, and anything else alone.
+        if h_int != issue_period:
+            continue
+        # WRAP: pentad 72 / decade 36 -> period 1 of the next year.
+        target = 1 if issue_period == period_max else issue_period + 1
+        repaired.at[idx, "horizon_in_year"] = target
+        if "horizon_value" in repaired.columns:
+            repaired.at[idx, "horizon_value"] = ((target - 1) % periods_per_month) + 1
+        if issue_period == period_max:
+            # WRAP: the target period (pentad 1 / decade 1) lives in issue_year + 1.
+            # Downstream only reads the YEAR of `target` (_year_or_none), so set the
+            # cell to Jan 1 of the following year to carry the correct target year.
+            repaired.at[idx, "target"] = pd.Timestamp(year=issue_date.year + 1, month=1, day=1)
+    return repaired

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/artifacts.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/artifacts.py
@@ -520,9 +520,11 @@ def _prob_metrics_section(prob_metrics: pd.DataFrame) -> list[str]:
     if "event" in prob_metrics.columns:
         n_dist = int((prob_metrics["event"] == "distribution").sum())
         n_brier = int((prob_metrics["event"] == "below_norm").sum())
+        n_brier_100 = int((prob_metrics["event"] == "below_norm_100").sum())
     else:
         n_dist = len(prob_metrics)
         n_brier = 0
+        n_brier_100 = 0
 
     grid_ids: list[str] = []
     if "fc_grid_id" in prob_metrics.columns:
@@ -530,6 +532,8 @@ def _prob_metrics_section(prob_metrics: pd.DataFrame) -> list[str]:
 
     lines.append(f"Distribution score rows: {n_dist}")
     lines.append(f"Below-norm Brier rows: {n_brier}")
+    if n_brier_100 > 0:
+        lines.append(f"Below-norm (1.0x norm) Brier rows: {n_brier_100}")
     if grid_ids:
         lines.append(f"Forecast grids scored: {', '.join(grid_ids)}")
     lines.append(

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/baselines.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/baselines.py
@@ -22,17 +22,26 @@ BASELINE_EXTRA_COLUMNS: Final = (
     "comparison_model",
     "is_proxy",
     "n_matched",
+    "event",
 )
 BASELINE_COLUMNS: Final = (*OUTPUT_COLUMNS, *METRIC_COLUMNS, *BASELINE_EXTRA_COLUMNS)
 
 _MATCH_COLUMNS: Final = ("horizon", "code", "period_key", "year", "model", "regime", "lead")
 
 
-def build_climatology_baseline(pairs: pd.DataFrame) -> pd.DataFrame:
+def build_climatology_baseline(
+    pairs: pd.DataFrame,
+    *,
+    event: str = "below_norm",
+) -> pd.DataFrame:
     """Build always-normal climatology rows on each model's available samples.
 
     Args:
         pairs: P4 pair DataFrame.
+        event: Event label tagged onto the emitted rows.  Defaults to
+            ``"below_norm"`` (the 0.80 × norm classification embedded in the
+            pairs).  Pass ``"below_norm_100"`` when building from pairs
+            reclassified at 1.0 × norm.
 
     Returns:
         Tidy count and metric rows for an always-normal reference forecast.
@@ -49,6 +58,7 @@ def build_climatology_baseline(pairs: pd.DataFrame) -> pd.DataFrame:
                 baseline=CLIMATOLOGY_BASELINE,
                 comparison_model=model,
                 is_proxy=False,
+                event=event,
             )
         )
     return _concat_baselines(frames)
@@ -59,6 +69,7 @@ def build_operational_proxy_baseline(
     *,
     short_term_proxy: str = SHORT_TERM_PROXY_MODEL,
     long_term_proxy: str = LONG_TERM_PROXY_MODEL,
+    event: str = "below_norm",
 ) -> pd.DataFrame:
     """Build matched-sample model and LR/LR_Base operational proxy rows.
 
@@ -66,6 +77,10 @@ def build_operational_proxy_baseline(
         pairs: P4 pair DataFrame.
         short_term_proxy: Proxy model name used for short-term horizons.
         long_term_proxy: Proxy model name used for long-term horizons.
+        event: Event label tagged onto the emitted rows.  Defaults to
+            ``"below_norm"`` (the 0.80 × norm classification embedded in the
+            pairs).  Pass ``"below_norm_100"`` when building from pairs
+            reclassified at 1.0 × norm.
 
     Returns:
         Tidy rows for each non-proxy model and its matched proxy row. Matching
@@ -97,6 +112,7 @@ def build_operational_proxy_baseline(
                     baseline=OPERATIONAL_BASELINE,
                     comparison_model=model,
                     is_proxy=False,
+                    event=event,
                 )
             )
             frames.append(
@@ -105,6 +121,7 @@ def build_operational_proxy_baseline(
                     baseline=OPERATIONAL_BASELINE,
                     comparison_model=model,
                     is_proxy=True,
+                    event=event,
                 )
             )
     return _concat_baselines(frames)
@@ -114,6 +131,7 @@ def build_persistence_baseline(
     pairs: pd.DataFrame,
     *,
     threshold: float = 0.80,
+    event: str = "below_norm",
 ) -> pd.DataFrame:
     """Build lag-1 persistence baseline rows on each model's available samples.
 
@@ -133,6 +151,9 @@ def build_persistence_baseline(
             ``obs_class`` columns.
         threshold: Below-norm threshold fraction (default 0.80, matching the
             operational ``config.threshold``).
+        event: Event label tagged onto the emitted rows.  Defaults to
+            ``"below_norm"``.  Pass ``"below_norm_100"`` together with
+            ``threshold=1.0`` when building the 1.0 × norm persistence set.
 
     Returns:
         Tidy count and metric rows tagged ``baseline="persistence"``.  Returns
@@ -199,6 +220,7 @@ def build_persistence_baseline(
                 baseline=PERSISTENCE_BASELINE,
                 comparison_model=model,
                 is_proxy=False,
+                event=event,
             )
         )
 
@@ -291,6 +313,7 @@ def _baseline_table(
     baseline: str,
     comparison_model: str,
     is_proxy: bool,
+    event: str = "below_norm",
 ) -> pd.DataFrame:
     counts = count_contingencies(pairs)
     if counts.empty:
@@ -301,6 +324,7 @@ def _baseline_table(
     table["comparison_model"] = comparison_model
     table["is_proxy"] = pd.Series([bool(is_proxy)] * len(table), dtype="object")
     table["n_matched"] = table["n_pairs"].astype("int64")
+    table["event"] = event
     return table.loc[:, BASELINE_COLUMNS]
 
 
@@ -346,7 +370,52 @@ def _filter_to_keys(
 ) -> pd.DataFrame:
     tagged_keys = keys.assign(_matched_key=True)
     matched = pairs.merge(tagged_keys, on=key_columns, how="inner")
-    return matched.drop(columns=["_matched_key"])
+    matched = matched.drop(columns=["_matched_key"])
+    # The operational_proxy baseline is a PAIRED comparison: the model row and
+    # the proxy row must be scored on the same sample. Matching on unique keys
+    # (``_matched_keys``) equalises *which* keys appear on each side, but a side
+    # can still carry several pairs per key (re-issued forecasts). Left as-is,
+    # the two emitted rows would have unequal n_pairs. Collapse each side to one
+    # representative pair per matched key so both sides contribute exactly one
+    # pair per key group and their n_pairs are equal.
+    return _collapse_to_one_per_key(matched, key_columns)
+
+
+def _collapse_to_one_per_key(
+    matched: pd.DataFrame,
+    key_columns: list[str],
+) -> pd.DataFrame:
+    """Keep exactly one representative pair per ``key_columns`` group.
+
+    The representative is the row with the latest parseable ``issue_date`` in
+    the group. Missing or unparseable ``issue_date`` values sort first (as
+    ``NaT``), so any real date wins; pure ties (or an absent ``issue_date``
+    column) fall back to the frame's existing stable order. This keeps
+    single-pair-per-key groups byte-identical to the pre-collapse frame.
+    """
+    if matched.empty:
+        return matched
+
+    working = matched.reset_index(drop=True)
+    # Preserve the original row order so we can restore it after collapsing and
+    # break issue_date ties deterministically.
+    working["_stable_order"] = range(len(working))
+    if "issue_date" in working.columns:
+        working["_issue_order"] = pd.to_datetime(working["issue_date"], errors="coerce")
+    else:
+        working["_issue_order"] = pd.NaT
+
+    # Sort so the latest issue_date sits last within each key group (NaT first),
+    # then keep the last row per group.
+    ranked = working.sort_values(
+        by=["_issue_order", "_stable_order"],
+        kind="stable",
+        na_position="first",
+    )
+    kept = ranked.drop_duplicates(subset=key_columns, keep="last")
+    # Restore the original row order so a no-multiplicity frame is unchanged.
+    kept = kept.sort_values("_stable_order", kind="stable")
+    return kept.drop(columns=["_issue_order", "_stable_order"]).reset_index(drop=True)
 
 
 def _model_names(frame: pd.DataFrame) -> list[str]:

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/cli.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/cli.py
@@ -94,6 +94,16 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--min-years", type=int, default=10)
     parser.add_argument("--operational-start", default="2024-01-01")
     parser.add_argument(
+        "--regime-source",
+        choices=["auto", "flag", "date"],
+        default="auto",
+        help=(
+            "Regime selection strategy. 'auto' (default) auto-picks flags when "
+            "flag presence is meaningful, else issue date; 'flag' forces "
+            "flag-based assignment; 'date' forces issue-date-based assignment."
+        ),
+    )
+    parser.add_argument(
         "--operational-flags",
         nargs="+",
         default=list(DEFAULT_OPERATIONAL_FLAGS),
@@ -132,7 +142,8 @@ def _parser() -> argparse.ArgumentParser:
         help=(
             "Binary events to evaluate. "
             "Valid values: below_norm low_p10 low_p5 high_p90 high_p95. "
-            "Default: all five events."
+            "Default: all five events. "
+            "Optional: below_norm_100 (plain below-norm at 1.0x norm)."
         ),
     )
     parser.add_argument(
@@ -145,11 +156,41 @@ def _parser() -> argparse.ArgumentParser:
             "'irrigation' restricts to Apr–Sep, 'non_irrigation' restricts to Oct–Mar."
         ),
     )
+    parser.add_argument(
+        "--short-term-issue-before-target",
+        action="store_true",
+        help=(
+            "Short-term correctness gate (default off): drop day/pentad/decade "
+            "forecasts issued on or after their target period start (leakage / "
+            "mislabelled rows)."
+        ),
+    )
+    parser.add_argument(
+        "--short-term-dedup-one-per-target",
+        action="store_true",
+        help=(
+            "Short-term correctness gate (default off): keep only the latest "
+            "issue per (code, period_key, year, model) for day/pentad/decade."
+        ),
+    )
+    parser.add_argument(
+        "--short-term-lr-repair",
+        action="store_true",
+        help=(
+            "LR repair-on-read (default off): correct historical issue-indexed LR "
+            "pentad/decade forecasts to target-indexed at read time."
+        ),
+    )
     parser.add_argument("--run-id")
     return parser
 
 
 def _config_from_args(args: argparse.Namespace) -> ForecastSkillEvalConfig:
+    # SAPPHIRE_SKILL_FORECAST_ONLY=1/true turns BOTH short-term correctness gates
+    # on, mirroring the existing SAPPHIRE_SKILL_* env-flag convention.  The CLI
+    # flags are OR-ed with it so either mechanism can enable a gate.
+    forecast_only = _env_flag("SAPPHIRE_SKILL_FORECAST_ONLY")
+    lr_repair = _env_flag("SAPPHIRE_SKILL_LR_REPAIR")
     return ForecastSkillEvalConfig(
         base_url=args.base_url,
         threshold=args.threshold,
@@ -162,6 +203,7 @@ def _config_from_args(args: argparse.Namespace) -> ForecastSkillEvalConfig:
         provenance_by_horizon=_provenance_overrides(args.provenance),
         min_years=args.min_years,
         operational_start=args.operational_start,
+        regime_source=args.regime_source,
         operational_flags=_split_int_values(args.operational_flags),
         hindcast_flags=_split_int_values(args.hindcast_flags),
         nan_exclude_flags=_split_int_values(args.nan_exclude_flags),
@@ -169,7 +211,18 @@ def _config_from_args(args: argparse.Namespace) -> ForecastSkillEvalConfig:
         operational_issue_days=_split_int_values(args.operational_issue_days),
         events_filter=_split_values(args.events_filter),
         season_filter=args.season_filter,
+        short_term_issue_before_target=(bool(args.short_term_issue_before_target) or forecast_only),
+        short_term_dedup_one_per_target=(
+            bool(args.short_term_dedup_one_per_target) or forecast_only
+        ),
+        short_term_lr_repair_issue_indexing=(bool(args.short_term_lr_repair) or lr_repair),
     )
+
+
+def _env_flag(name: str) -> bool:
+    import os
+
+    return os.environ.get(name, "").strip().lower() in {"1", "true"}
 
 
 def _split_optional_values(values: Sequence[str] | None) -> list[str] | None:

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/cli.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/cli.py
@@ -181,6 +181,17 @@ def _parser() -> argparse.ArgumentParser:
             "pentad/decade forecasts to target-indexed at read time."
         ),
     )
+    parser.add_argument(
+        "--long-term-derive-lead",
+        action="store_true",
+        help=(
+            "Long-term correctness gate (default off): for quarter/season, derive "
+            "the true forecast lead (months from issue date to target-period start) "
+            "instead of the overloaded stored horizon_value, dedup to one forecast "
+            "per (code, target, year, model) at the smallest lead, and stratify "
+            "quarter output per target quarter (Q1–Q4). Month is unchanged."
+        ),
+    )
     parser.add_argument("--run-id")
     return parser
 
@@ -191,6 +202,7 @@ def _config_from_args(args: argparse.Namespace) -> ForecastSkillEvalConfig:
     # flags are OR-ed with it so either mechanism can enable a gate.
     forecast_only = _env_flag("SAPPHIRE_SKILL_FORECAST_ONLY")
     lr_repair = _env_flag("SAPPHIRE_SKILL_LR_REPAIR")
+    lt_lead = _env_flag("SAPPHIRE_SKILL_LT_LEAD")
     return ForecastSkillEvalConfig(
         base_url=args.base_url,
         threshold=args.threshold,
@@ -216,6 +228,7 @@ def _config_from_args(args: argparse.Namespace) -> ForecastSkillEvalConfig:
             bool(args.short_term_dedup_one_per_target) or forecast_only
         ),
         short_term_lr_repair_issue_indexing=(bool(args.short_term_lr_repair) or lr_repair),
+        long_term_derive_lead=(bool(args.long_term_derive_lead) or lt_lead),
     )
 
 

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/config.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/config.py
@@ -87,6 +87,16 @@ class ForecastSkillEvalConfig:
     #     pentad/decade forecasts to target-indexed at read time.  Default False so
     #     the default read behaviour is byte-identical.
     short_term_lr_repair_issue_indexing: bool = False
+    # Long-term (quarter/season) lead-handling correctness gate.  Default False so
+    # the default long-term pairing behaviour is byte-identical.
+    #   * long_term_derive_lead: for quarter/season forecasts, derive the true
+    #     forecast lead (months from issue date to target-period start) instead of
+    #     using the overloaded stored ``horizon_value`` (quarter-of-year / constant
+    #     1).  Under the flag, quarter/season pairs are also deduped to one forecast
+    #     per (code, period_key, year, model) keeping the smallest derived lead, and
+    #     the quarter ``lead`` output is set to the target quarter (period_key) so
+    #     contingency stratifies per target quarter (Q1–Q4).  Month is unchanged.
+    long_term_derive_lead: bool = False
 
     def __post_init__(self) -> None:
         if not self.base_url:

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/config.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/config.py
@@ -74,6 +74,19 @@ class ForecastSkillEvalConfig:
     operational_issue_days: Sequence[int] = DEFAULT_OPERATIONAL_ISSUE_DAYS
     events_filter: Sequence[str] = DEFAULT_EVENTS
     season_filter: str = "all"
+    regime_source: str = "auto"
+    # Short-term (day/pentad/decade) forecast-pairing correctness gates.
+    # Both default False so the default pairing behaviour is byte-identical.
+    #   * short_term_issue_before_target: drop short-term forecasts issued on or
+    #     after their target period start (observation leakage / mislabelled rows).
+    #   * short_term_dedup_one_per_target: keep only the latest genuine pre-period
+    #     issue per (code, period_key, year, model) for short-term horizons.
+    short_term_issue_before_target: bool = False
+    short_term_dedup_one_per_target: bool = False
+    #   * short_term_lr_repair_issue_indexing: correct historical issue-indexed LR
+    #     pentad/decade forecasts to target-indexed at read time.  Default False so
+    #     the default read behaviour is byte-identical.
+    short_term_lr_repair_issue_indexing: bool = False
 
     def __post_init__(self) -> None:
         if not self.base_url:
@@ -130,6 +143,7 @@ class ForecastSkillEvalConfig:
             tuple(self.events_filter),
         )
         _validate_season_filter(self.season_filter)
+        _validate_regime_source(self.regime_source)
 
 
 def _freeze_optional_strings(values: Sequence[str] | None) -> tuple[str, ...] | None:
@@ -194,6 +208,14 @@ _VALID_SEASON_FILTERS: Final = ("all", "irrigation", "non_irrigation")
 def _validate_season_filter(value: str) -> None:
     if value not in _VALID_SEASON_FILTERS:
         raise ValueError(f"season_filter must be one of {_VALID_SEASON_FILTERS!r}, got {value!r}")
+
+
+_VALID_REGIME_SOURCES: Final = ("auto", "flag", "date")
+
+
+def _validate_regime_source(value: str) -> None:
+    if value not in _VALID_REGIME_SOURCES:
+        raise ValueError(f"regime_source must be one of {_VALID_REGIME_SOURCES!r}, got {value!r}")
 
 
 def _validate_events_filter(events: Sequence[str]) -> None:

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/dashboard/aggregates.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/dashboard/aggregates.py
@@ -99,7 +99,7 @@ _H_DISPLAY_MAP: dict[str, str] = {
     "pentad": "pentad",
     "decade": "decade",
     "month": "month\nL0",
-    "quarter": "quarter\nL1",
+    "quarter": "quarter\nQ1",
     "season": "season\nL0",
 }
 
@@ -165,15 +165,41 @@ def base_horizon(h_label: str) -> str:
     """Return the base horizon string from a display label.
 
     Args:
-        h_label: Display label such as "month L0" or "pentad".
+        h_label: Display label such as "month L0", "quarter Q1", or "pentad".
 
     Returns:
-        Base horizon string, e.g. "month" for "month L0", "pentad" for "pentad".
+        Base horizon string, e.g. "month" for "month L0", "quarter" for
+        "quarter Q1", "pentad" for "pentad".
     """
     for h in HORIZONS:
-        if h_label == h or h_label.startswith(h + " L"):
+        # Match the bare horizon or "<horizon> <lead-label>"; the lead label may
+        # start with "L" (month/season lead) or "Q" (quarter target quarter).
+        if h_label == h or h_label.startswith(h + " "):
             return h
     return h_label
+
+
+def lead_display(horizon: str, lead_int: int) -> str:
+    """Return the display label for a lead value, horizon-aware.
+
+    For the ``quarter`` horizon the ``lead`` value is the *target quarter*
+    (1-4), so it is displayed as ``"Q{n}"``.  All other long-term horizons
+    display a genuine forecast lead as ``"L{n}"``.  The short-term sentinel
+    ``lead_int == -1`` renders as ``"—"``.
+
+    Args:
+        horizon: Horizon string (e.g. ``"quarter"``, ``"month"``).
+        lead_int: Integer lead value, or ``-1`` for the short-term sentinel.
+
+    Returns:
+        Display label: ``"—"`` for the sentinel, ``"Q{n}"`` for quarter,
+        ``"L{n}"`` otherwise.
+    """
+    if lead_int == -1:
+        return "—"
+    if horizon == "quarter":
+        return f"Q{lead_int}"
+    return f"L{lead_int}"
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +235,7 @@ def _add_h_label(df: pd.DataFrame) -> pd.DataFrame:
         lead_val = row["lead"]
         if isinstance(lead_val, float) and math.isnan(lead_val):
             return str(row["horizon"])
-        return f"{row['horizon']} L{int(lead_val)}"
+        return f"{row['horizon']} {lead_display(str(row['horizon']), int(lead_val))}"
 
     if df.empty:
         df["lead_int"] = pd.Series(dtype=int)
@@ -330,7 +356,9 @@ def prep_performance_diagram(
     df["family_color"] = df["family"].map(FAMILY_COLOR).fillna("#888888")
     df["family_label"] = df["family"].map(FAMILY_LABEL).fillna("Other")
     df["horizon_color"] = df["horizon"].map(HCOLORS).fillna("#888888")
-    df["lead_label"] = df["lead_int"].apply(lambda li: "—" if li == -1 else f"L{li}")
+    df["lead_label"] = df.apply(
+        lambda row: lead_display(str(row["horizon"]), int(row["lead_int"])), axis=1
+    )
     return df
 
 
@@ -745,7 +773,7 @@ def prep_op_vs_hindcast(
                 {
                     "horizon": horizon,
                     "lead_int": lead_i,
-                    "lead_label": f"L{lead_i}",
+                    "lead_label": lead_display(horizon, lead_i),
                     "regime": str(row["regime"]),
                     "hss": float(hss_val),
                     "n_pairs": int(row.get("n_pairs", 0)),

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/dashboard/app.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/dashboard/app.py
@@ -63,7 +63,28 @@ alt.data_transformers.disable_max_rows()
 # apps/forecast_skill_eval project.  Walk up 3 levels to reach the project
 # root (apps/forecast_skill_eval/) where the artifacts/ directory lives.
 _APP_DIR = Path(__file__).resolve().parents[3]
-_DEFAULT_CSV = _APP_DIR / "artifacts" / "rerun_2026-06-30_phase2" / "contingency_metrics.csv"
+_ARTIFACTS_DIR = _APP_DIR / "artifacts"
+
+
+def _resolve_default_csv() -> Path:
+    """Pick a sensible default contingency_metrics.csv.
+
+    Prefer the latest corrected run; otherwise fall back to the most recently
+    modified ``contingency_metrics.csv`` under ``artifacts/`` so the default
+    never goes stale when a specific run directory is cleaned or renamed.
+    """
+    preferred = _ARTIFACTS_DIR / "rerun_2026-07-06_corrected" / "contingency_metrics.csv"
+    if preferred.exists():
+        return preferred
+    candidates = sorted(
+        _ARTIFACTS_DIR.glob("*/contingency_metrics.csv"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else preferred
+
+
+_DEFAULT_CSV = _resolve_default_csv()
 
 _TABLE_COLUMNS = [
     "code",
@@ -242,11 +263,17 @@ with st.sidebar:
         ),
     )
 
-csv_path = Path(csv_path_input) if csv_path_input else None
+# Fall back to the resolved default when the sidebar box is empty.  Streamlit
+# persists a widget's value across reruns, so a box that was blank in a prior
+# session stays blank and would otherwise ignore the ``value=`` default — this
+# keeps the app usable without the user having to paste the path every time.
+csv_path_resolved = csv_path_input or default_csv_str
+csv_path = Path(csv_path_resolved) if csv_path_resolved else None
 
 if csv_path is None or not csv_path.exists():
     st.warning(
-        "No valid CSV path provided. Set SKILL_EVAL_METRICS_CSV or enter a path in the sidebar."
+        "No valid CSV path provided. Set SKILL_EVAL_METRICS_CSV or enter a path in the sidebar. "
+        f"(Tried default: {default_csv_str or 'none found'}.)"
     )
     st.stop()
 

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/dashboard/app.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/dashboard/app.py
@@ -7,8 +7,10 @@ Launch command (from repo root):
 CSV path resolution order:
     1. SKILL_EVAL_METRICS_CSV environment variable
     2. Sidebar path input
-    3. Default: apps/forecast_skill_eval/artifacts/rerun_2026-06-30_phase2/contingency_metrics.csv
-       (relative to this file's location, resolved at runtime)
+    3. Default: the latest corrected run under apps/forecast_skill_eval/artifacts/
+       (prefers rerun_2026-07-06_corrected, else the most recently modified
+       contingency_metrics.csv), resolved at runtime; used when the sidebar box
+       is empty.
 
 Read-only: this dashboard never writes files or exports data.
 """
@@ -30,6 +32,7 @@ from forecast_skill_eval.dashboard.aggregates import (
     HORIZONS,
     LONG_TERM,
     get_baseline_refs,
+    lead_display,
     load_baselines,
     model_sort_key,
     prep_model_comparison_per_horizon,
@@ -216,7 +219,7 @@ def _render_fig4_bars(
         )
         layers.append(pers_rule)
 
-    lead_label = f" L{lead}" if lead is not None else ""
+    lead_label = f" {lead_display(horizon, lead)}" if lead is not None else ""
     title = f"{horizon}{lead_label} — POD (green) / FAR (red)"
     if refs.get("clim_base_rate") is not None:
         title += f"  |  Climatology: POD=0, base_rate={refs['clim_base_rate']:.2f}"
@@ -379,7 +382,15 @@ if view == "Per-station":
             st.caption("Short-term horizon — no lead dimension.")
         else:
             lead_int_choices = [int(v) for v in lead_opts]  # sorted by available_options
-            lead = st.selectbox("Lead", lead_int_choices, index=0)
+            # Quarter's lead value IS the target quarter (Q1-Q4), not a forecast
+            # lead — label and format it accordingly; month/season stay "Lead"/L.
+            lead_widget_label = "Target quarter" if horizon == "quarter" else "Lead"
+            lead = st.selectbox(
+                lead_widget_label,
+                lead_int_choices,
+                index=0,
+                format_func=lambda v: lead_display(horizon, int(v)),
+            )
         selections["lead"] = lead
 
         # 7. Model — cascaded from all upstream filters (incl. lead).
@@ -635,7 +646,7 @@ elif view == "Aggregates (pooled)":
                 tooltip=[
                     alt.Tooltip("horizon:N", title="Horizon"),
                     alt.Tooltip("model:N", title="Model"),
-                    alt.Tooltip("lead_label:N", title="Lead"),
+                    alt.Tooltip("lead_label:N", title="Lead / target quarter"),
                     alt.Tooltip("pod:Q", title="POD", format=".3f"),
                     alt.Tooltip("far:Q", title="FAR", format=".3f"),
                     alt.Tooltip("csi:Q", title="CSI", format=".3f"),
@@ -687,14 +698,21 @@ elif view == "Aggregates (pooled)":
         if selected_horizon in LONG_TERM:
             # Show one chart per approved lead
             lead_tabs = FIG4_LEADS.get(selected_horizon, [])
-            tab_labels = [f"Lead L{ll}" for ll in lead_tabs]
+            # Quarter's leads are target quarters (Q1-Q4); other horizons show
+            # a genuine forecast lead (Lead L{n}).
+            _is_quarter = selected_horizon == "quarter"
+            if _is_quarter:
+                tab_labels = [f"Q{ll}" for ll in lead_tabs]
+            else:
+                tab_labels = [f"Lead L{ll}" for ll in lead_tabs]
             if tab_labels:
                 tabs = st.tabs(tab_labels)
                 for tab, lead in zip(tabs, lead_tabs, strict=False):
                     with tab:
                         df_lead = df_melt[df_melt["lead_int"] == lead]
                         if df_lead.empty:
-                            st.info(f"No data for lead L{lead}.")
+                            _what = "target quarter" if _is_quarter else "lead"
+                            st.info(f"No data for {_what} {lead_display(selected_horizon, lead)}.")
                             continue
                         refs = get_baseline_refs(baselines_df, selected_horizon, lead=lead)
                         _render_fig4_bars(df_lead, sorted_models, refs, selected_horizon, lead)
@@ -714,7 +732,7 @@ elif view == "Aggregates (pooled)":
             "pentad",
             "decade",
             "month\nL0",
-            "quarter\nL1",
+            "quarter\nQ1",
             "season\nL0",
         ]
         series_color_map: dict[str, str] = {
@@ -758,7 +776,7 @@ elif view == "Aggregates (pooled)":
         st.altair_chart((ladder_chart + zero_line), use_container_width=True)
         st.caption(
             "Operational regime, POOLED. Long-term uses canonical lead"
-            " (month/season L0, quarter L1)."
+            " (month/season L0, quarter Q1 = target quarter)."
         )
 
     # --- Fig 6: Seasonal POD ---
@@ -817,7 +835,7 @@ elif view == "Aggregates (pooled)":
             alt.Chart(df_ovh_valid)
             .mark_bar()
             .encode(
-                x=alt.X("lead_label:N", sort=None, title="Lead"),
+                x=alt.X("lead_label:N", sort=None, title="Lead / target quarter"),
                 xOffset=alt.XOffset("regime:N", sort=regime_domain),
                 y=alt.Y("hss:Q", title="HSS"),
                 color=alt.Color(
@@ -828,7 +846,7 @@ elif view == "Aggregates (pooled)":
                 facet=alt.Facet("horizon:N", columns=3, title="Horizon"),
                 tooltip=[
                     alt.Tooltip("horizon:N", title="Horizon"),
-                    alt.Tooltip("lead_label:N", title="Lead"),
+                    alt.Tooltip("lead_label:N", title="Lead / target quarter"),
                     alt.Tooltip("regime:N", title="Regime"),
                     alt.Tooltip("hss:Q", title="HSS", format=".3f"),
                     alt.Tooltip("n_pairs:Q", title="n_pairs"),
@@ -1251,10 +1269,11 @@ elif view == "Value metrics":
             st.caption("Short-term horizon — no lead dimension.")
         else:
             vm_lead = st.selectbox(
-                "Lead (value)",
+                "Target quarter (value)" if vm_horizon == "quarter" else "Lead (value)",
                 [int(v) for v in vm_lead_opts],
                 index=0,
                 key="vm_lead",
+                format_func=lambda v: lead_display(vm_horizon, int(v)),
             )
 
     # ── Shared lead mask helpers ────────────────────────────────────────────

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/events.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/events.py
@@ -23,6 +23,11 @@ Return-period events are **opt-in** (not in the default event set) because
 they require a GEV fit over annual maxima, are expensive, and their positive
 class is rare by construction.  Enable them via ``--events rp5 rp10 ...`` or
 the ``events_filter`` config field.
+
+A norm-factor event is also available (opt-in, not in the default set):
+
+- ``below_norm_100`` — value < 1.0 × norm (plain below-norm), reclassified from
+  the ``norm`` column in the same run as the 0.80 × norm ``below_norm`` event.
 """
 
 from __future__ import annotations
@@ -48,7 +53,14 @@ ALL_EVENT_NAMES: Final[tuple[str, ...]] = (
 
 _RP_EVENT_NAMES: Final[tuple[str, ...]] = ("rp5", "rp10", "rp30", "rp100")
 
-VALID_EVENTS: Final[frozenset[str]] = frozenset((*ALL_EVENT_NAMES, *_RP_EVENT_NAMES))
+# Norm-factor events are opt-in (not in ALL_EVENT_NAMES / DEFAULT_EVENTS).  They
+# reclassify from the ``norm`` column at ``value < factor * norm`` and are only
+# computed when the caller lists them explicitly in ``--events``.
+_NORM_FACTOR_EVENT_NAMES: Final[tuple[str, ...]] = ("below_norm_100",)
+
+VALID_EVENTS: Final[frozenset[str]] = frozenset(
+    (*ALL_EVENT_NAMES, *_RP_EVENT_NAMES, *_NORM_FACTOR_EVENT_NAMES)
+)
 
 # Percentile levels required for the four percentile events.
 _REQUIRED_PERCENTILES: Final[tuple[float, ...]] = (5.0, 10.0, 90.0, 95.0)
@@ -73,12 +85,17 @@ class EventDef:
         return_period: Return period in years for EVT events, or ``None`` for
             percentile / norm-based events.  When set, the event is a
             return-period event and ``percentile`` must be ``None``.
+        factor: Norm multiplier for norm-factor events (e.g. ``1.0`` for plain
+            below-norm), or ``None`` for percentile / return-period events and
+            the global-threshold ``below_norm`` event.  When set, the event is
+            reclassified from the ``norm`` column at ``value < factor * norm``.
     """
 
     name: str
     direction: Literal["below", "above"]
     percentile: float | None
     return_period: float | None = field(default=None)
+    factor: float | None = field(default=None)
 
 
 ALL_EVENTS: Final[tuple[EventDef, ...]] = (
@@ -96,7 +113,13 @@ _RP_EVENTS: Final[tuple[EventDef, ...]] = (
     EventDef("rp100", "above", None, return_period=100.0),
 )
 
-_EVENT_BY_NAME: Final[dict[str, EventDef]] = {e.name: e for e in (*ALL_EVENTS, *_RP_EVENTS)}
+_NORM_FACTOR_EVENTS: Final[tuple[EventDef, ...]] = (
+    EventDef("below_norm_100", "below", None, factor=1.0),
+)
+
+_EVENT_BY_NAME: Final[dict[str, EventDef]] = {
+    e.name: e for e in (*ALL_EVENTS, *_RP_EVENTS, *_NORM_FACTOR_EVENTS)
+}
 
 
 # ---------------------------------------------------------------------------
@@ -288,9 +311,16 @@ def reclassify_pairs_for_event(
 ) -> pd.DataFrame:
     """Return a copy of *pairs* reclassified for the given percentile event.
 
-    For the ``below_norm`` event (``event.percentile is None``) the pairs are
-    returned unchanged — their ``fc_class``, ``obs_class``, and ``contingency``
-    columns already reflect the norm-based classification.
+    For norm-factor events (``event.factor is not None``, e.g. ``below_norm_100``
+    at ``factor=1.0``) the pairs are reclassified directly from the ``norm``
+    column: a value is "below" iff ``value < factor * norm`` (strict ``<``).
+    Rows whose ``norm`` is non-finite or ``<= 0`` are dropped (matching
+    :func:`classifier.classify` returning ``None``).
+
+    For the ``below_norm`` event (``event.percentile is None`` and
+    ``event.factor is None``) the pairs are returned unchanged — their
+    ``fc_class``, ``obs_class``, and ``contingency`` columns already reflect the
+    norm-based classification at the global ``config.threshold``.
 
     For percentile events the function recomputes ``fc_class``, ``obs_class``,
     and ``contingency`` based on the event's direction and percentile threshold.
@@ -319,6 +349,12 @@ def reclassify_pairs_for_event(
     """
     if pairs.empty:
         return pairs.copy()
+
+    if event.factor is not None:
+        # Norm-factor event (e.g. below_norm_100): reclassify from the norm
+        # column at value < factor * norm.  Mirrors classifier.classify: strict
+        # <, and rows with non-finite norm or norm <= 0 are dropped.
+        return _reclassify_pairs_from_norm(pairs, float(event.factor))
 
     if event.percentile is None and event.return_period is None:
         # below_norm: return pairs unchanged — fc_class / obs_class already set.
@@ -412,6 +448,72 @@ def reclassify_pairs_for_event(
     )
 
     df = df.copy()
+    df["fc_class"] = fc_class
+    df["obs_class"] = obs_class
+    df["contingency"] = contingency_arr
+
+    return df[orig_cols].reset_index(drop=True)
+
+
+def _reclassify_pairs_from_norm(pairs: pd.DataFrame, factor: float) -> pd.DataFrame:
+    """Reclassify *pairs* from the ``norm`` column at ``value < factor * norm``.
+
+    Mirrors :func:`classifier.classify` semantics for a norm-factor event:
+
+    - A value is "below" iff ``value < factor * norm`` (strict ``<``; equality
+      → "normal").
+    - Rows whose ``norm`` is non-finite or ``<= 0`` are dropped (the classifier
+      returns ``None`` for these).
+    - NaN ``forecast_value`` / ``observed_value`` are kept and classify as
+      "normal" (NaN comparisons return ``False``), matching the percentile
+      branch's NaN-keep behaviour.
+
+    Original column order and ``reset_index(drop=True)`` are preserved, exactly
+    like the percentile branch.
+
+    Args:
+        pairs: Pair DataFrame with ``norm``, ``forecast_value``, and
+            ``observed_value`` columns.
+        factor: Norm multiplier (e.g. ``1.0`` for plain below-norm).
+
+    Returns:
+        Reclassified DataFrame with updated ``fc_class``, ``obs_class``, and
+        ``contingency`` columns.  May be empty if no rows have a usable norm.
+    """
+    orig_cols = list(pairs.columns)
+
+    if pairs.empty:
+        return pairs.copy()
+
+    df = pairs.copy()
+
+    norm_arr = pd.to_numeric(df["norm"], errors="coerce").to_numpy(dtype=float)
+    # Drop rows with non-finite norm or norm <= 0 (classifier.classify → None).
+    keep = np.isfinite(norm_arr) & (norm_arr > 0.0)
+    if not keep.all():
+        df = df[keep].copy()
+        norm_arr = norm_arr[keep]
+    if df.empty:
+        return pd.DataFrame(columns=orig_cols)
+
+    threshold_arr = factor * norm_arr
+    fc_arr = pd.to_numeric(df["forecast_value"], errors="coerce").to_numpy(dtype=float)
+    obs_arr = pd.to_numeric(df["observed_value"], errors="coerce").to_numpy(dtype=float)
+
+    # Classify — strict < so equality at threshold → "normal".
+    # NaN comparisons return False → "normal", matching classifier.classify.
+    fc_class = np.where(fc_arr < threshold_arr, "below", "normal")
+    obs_class = np.where(obs_arr < threshold_arr, "below", "normal")
+
+    # Vectorized contingency — mirrors classifier.contingency exactly.
+    fc_b = fc_class == "below"
+    obs_b = obs_class == "below"
+    contingency_arr = np.where(
+        fc_b & obs_b,
+        "TP",
+        np.where(fc_b & ~obs_b, "FP", np.where(~fc_b & obs_b, "FN", "TN")),
+    )
+
     df["fc_class"] = fc_class
     df["obs_class"] = obs_class
     df["contingency"] = contingency_arr

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/metrics.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/metrics.py
@@ -107,9 +107,11 @@ def _add_hss(
     fn: float,
     tn: float,
 ) -> None:
-    observed_positives = tp + fn
+    # HSS is undefined ONLY when its denominator vanishes.  A slice with zero
+    # observed events (TP+FN == 0) but FP>0/TN>0 has a finite denominator and a
+    # genuine skill of 0.0 (the standard Heidke value), so it must not be NaN.
     denominator = (tp + fn) * (fn + tn) + (tp + fp) * (fp + tn)
-    undefined = observed_positives == 0 or denominator == 0
+    undefined = denominator == 0
     numerator = 2 * ((tp * tn) - (fp * fn))
     metrics["hss"] = math.nan if undefined else numerator / denominator
     metrics["hss_undefined"] = undefined

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/orchestrator.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/orchestrator.py
@@ -27,8 +27,10 @@ from forecast_skill_eval.economic_value import (
     compute_economic_value,
 )
 from forecast_skill_eval.events import (
+    _NORM_FACTOR_EVENTS,
     ALL_EVENTS,
     compute_percentile_thresholds,
+    event_by_name,
     reclassify_pairs_for_event,
 )
 from forecast_skill_eval.ledger import ExclusionLedger
@@ -162,6 +164,24 @@ def run(config: ForecastSkillEvalConfig, client: Any, run_id: str) -> ResultsBun
         ]
     )
 
+    # Additive 1.0 × norm baseline set (opt-in, tagged event="below_norm_100").
+    # Built from pairs reclassified at value < 1.0 × norm; the existing 0.80
+    # rows (tagged event="below_norm") are unchanged and ordered first.
+    if "below_norm_100" in config.events_filter:
+        event_100 = event_by_name("below_norm_100")
+        pairs_100 = reclassify_pairs_for_event(all_pairs, event_100, thresholds)
+        if not pairs_100.empty:
+            baselines = _concat_baselines(
+                [
+                    baselines,
+                    build_climatology_baseline(pairs_100, event=event_100.name),
+                    build_operational_proxy_baseline(pairs_100, event=event_100.name),
+                    build_persistence_baseline(
+                        pairs_100, threshold=float(event_100.factor), event=event_100.name
+                    ),
+                ]
+            )
+
     if os.environ.get("SAPPHIRE_SKILL_PROB", "").lower() in {"1", "true"}:
         clim_ref = precompute_climatology_crps(all_pairs)
         persist_ref = precompute_persistence_crps(all_pairs)
@@ -172,6 +192,9 @@ def run(config: ForecastSkillEvalConfig, client: Any, run_id: str) -> ResultsBun
             config.events_filter,
             threshold=float(config.threshold),
             persist_ref=persist_ref,
+            norm_factor_events=tuple(
+                event for event in _NORM_FACTOR_EVENTS if event.name in config.events_filter
+            ),
         )
         prob_reliability = build_prob_reliability(all_pairs)
         for code, _horizon in _bandless_groups(all_pairs):
@@ -190,6 +213,17 @@ def run(config: ForecastSkillEvalConfig, client: Any, run_id: str) -> ResultsBun
             all_pairs, ledger=merged_ledger
         )
         economic_value, economic_value_summary = compute_economic_value(contingency)
+        # Additive 1.0 × norm REV (opt-in).  The contingency frame already holds
+        # below_norm_100 rows (from _compute_event_contingencies), so this is a
+        # second read of the same frame filtered to that event.  0.80 rows first.
+        if "below_norm_100" in config.events_filter:
+            long_100, summary_100 = compute_economic_value(contingency, event="below_norm_100")
+            if not long_100.empty:
+                economic_value = pd.concat([economic_value, long_100], ignore_index=True)
+            if not summary_100.empty:
+                economic_value_summary = pd.concat(
+                    [economic_value_summary, summary_100], ignore_index=True
+                )
         for code in _starved_value_groups(continuous_metrics):
             merged_ledger.add(stage="value", reason="min_pairs_gate", code=code)
     else:
@@ -245,7 +279,7 @@ def _compute_event_contingencies(
     events_set = frozenset(events_filter)
     frames: list[pd.DataFrame] = []
 
-    for event in ALL_EVENTS:
+    for event in (*ALL_EVENTS, *_NORM_FACTOR_EVENTS):
         if event.name not in events_set:
             continue
         event_pairs = reclassify_pairs_for_event(pairs, event, thresholds)

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/pairs.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/pairs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import date, datetime, timedelta
 from typing import Any, Final
 
@@ -26,6 +26,13 @@ from forecast_skill_eval.periods import LONG_TERM_HORIZONS, SHORT_TERM_HORIZONS,
 from forecast_skill_eval.regimes import RegimePolicy, choose_regime_policy, derive_regime
 
 ISSUE_DAY_FILTER_HORIZONS: tuple[str, ...] = ("month",)
+
+# Long-term horizons whose stored ``horizon_value`` is NOT the forecast lead
+# (quarter = quarter-of-year, season = constant 1).  When
+# ``long_term_derive_lead`` is on, the true lead is derived from the issue and
+# target-period-start dates for these horizons.  Month is excluded because its
+# stored ``horizon_value`` already equals the lead.
+LONG_TERM_DERIVE_LEAD_HORIZONS: tuple[str, ...] = ("quarter", "season")
 
 # Months that belong to the irrigation season (April through September).
 _IRRIGATION_MONTHS: Final = frozenset({4, 5, 6, 7, 8, 9})
@@ -125,7 +132,13 @@ def build_pairs(
 
     rows: list[dict[str, object]] = []
     for forecast in forecasts.to_dict("records"):
-        instance = _forecast_instance(forecast, normalized_horizon, ledger, operational_issue_days)
+        instance = _forecast_instance(
+            forecast,
+            normalized_horizon,
+            ledger,
+            operational_issue_days,
+            derive_lead=config.long_term_derive_lead,
+        )
         if instance is None:
             continue
         regime_decision = derive_regime(
@@ -234,6 +247,16 @@ def build_pairs(
     if config.short_term_dedup_one_per_target and normalized_horizon in SHORT_TERM_HORIZONS:
         rows = _dedup_short_term_latest_issue(rows)
 
+    if config.long_term_derive_lead and normalized_horizon in LONG_TERM_DERIVE_LEAD_HORIZONS:
+        rows = _dedup_long_term(rows, normalized_horizon)
+        if normalized_horizon == "quarter":
+            # Stratify quarter output by the target quarter (period_key) so the
+            # existing per-lead contingency machinery emits one row per Q1–Q4.
+            # The derived lead has already been used for dedup selection above;
+            # the "lead" column now carries the target quarter for this horizon.
+            for row in rows:
+                row["lead"] = row.get("period_key")
+
     pairs = pd.DataFrame(rows, columns=PAIR_COLUMNS)
     _attach_regime_attrs(pairs, regime_policy)
     return pairs, ledger
@@ -260,6 +283,62 @@ def _dedup_short_term_latest_issue(rows: list[dict[str, object]]) -> list[dict[s
         key = (row.get("code"), row.get("period_key"), row.get("year"), row.get("model"))
         latest[key] = row
     return list(latest.values())
+
+
+def _dedup_long_term(
+    rows: list[dict[str, object]],
+    horizon: str,
+) -> list[dict[str, object]]:
+    """Collapse long-term re-issues, horizon-aware, keyed on the target period.
+
+    The dedup key is target-scoped ``(code, period_key, year, model)``, extended
+    with the derived ``lead`` for horizons whose ``period_key`` does NOT already
+    distinguish the lead:
+
+    * ``quarter`` — ``period_key`` is Q1–Q4, which already separates the four
+      targets; the two genuine leads {0, 1} of a single target quarter are the
+      re-issue/two-source multiplicity we want to collapse.  Key excludes the
+      lead and the SMALLEST derived lead wins (the operational-headline issuance,
+      issued closest to the target).  Ties on lead break by the LATEST
+      ``issue_date`` then original position.
+    * ``season`` — there is one Apr–Sep season per year, so ``period_key`` is the
+      constant 1 and does NOT separate leads.  The lead is added to the key so the
+      genuine leads 0–3 are all RETAINED (like month); only true re-issues within
+      the same lead are collapsed, keeping the LATEST ``issue_date`` (ties → index).
+
+    Deterministic in all cases: original position is the final tie-break.  Mirrors
+    :func:`_dedup_short_term_latest_issue` but scoped to the long-term target.
+    """
+    include_lead_in_key = horizon == "season"
+
+    def _sort_key(item: tuple[int, dict[str, object]]) -> tuple[int, bool, date, int]:
+        index, row = item
+        parsed = _date_or_none(row.get("issue_date"))
+        issue_rank = (parsed is not None, parsed or date.min, index)
+        if include_lead_in_key:
+            # Leads are separated by the key, so lead is not a selection axis;
+            # within a lead, the LATEST issue date wins.
+            return (0, *issue_rank)
+        lead = _int_or_none(row.get("lead"))
+        # Underivable-lead rows are dropped upstream; guard defensively so an
+        # unexpected missing lead sorts last (never chosen over a real lead).
+        lead_rank = lead if lead is not None else 10**9
+        # Ascending sort with last-wins dict assignment: negate the lead so the
+        # SMALLEST lead sorts last, then prefer the latest issue date, then index.
+        return (-lead_rank, *issue_rank)
+
+    winners: dict[tuple[object, ...], dict[str, object]] = {}
+    for _index, row in sorted(enumerate(rows), key=_sort_key):
+        key: tuple[object, ...] = (
+            row.get("code"),
+            row.get("period_key"),
+            row.get("year"),
+            row.get("model"),
+        )
+        if include_lead_in_key:
+            key = (*key, row.get("lead"))
+        winners[key] = row
+    return list(winners.values())
 
 
 def _read_forecasts(
@@ -370,10 +449,12 @@ def _forecast_instance(
     horizon: str,
     ledger: ExclusionLedger,
     operational_issue_days: tuple[int, ...] = (),
+    *,
+    derive_lead: bool = False,
 ) -> _ForecastInstance | None:
     if horizon in SHORT_TERM_HORIZONS:
         return _short_instance(row)
-    return _long_instance(row, ledger, horizon, operational_issue_days)
+    return _long_instance(row, ledger, horizon, operational_issue_days, derive_lead=derive_lead)
 
 
 def _short_instance(row: dict[str, object]) -> _ForecastInstance:
@@ -395,6 +476,8 @@ def _long_instance(
     ledger: ExclusionLedger,
     horizon: str = "",
     operational_issue_days: tuple[int, ...] = (),
+    *,
+    derive_lead: bool = False,
 ) -> _ForecastInstance | None:
     instance = _ForecastInstance(
         code=_string_or_none(row.get("code")),
@@ -427,7 +510,54 @@ def _long_instance(
             year=instance.year,
         )
         return None
+    if derive_lead and horizon in LONG_TERM_DERIVE_LEAD_HORIZONS:
+        derived_lead = _derive_long_lead(
+            horizon,
+            instance.period_key,
+            row.get("date"),
+            instance.year,
+        )
+        if derived_lead is None:
+            # No issue date (or otherwise underivable): drop so aggregated-only
+            # rows with no lead do not pool with genuine per-lead forecasts.
+            ledger.add(
+                stage="pair",
+                reason="long_forecast_lead_underivable",
+                code=instance.code,
+                period_key=instance.period_key,
+                year=instance.year,
+            )
+            return None
+        instance = replace(instance, lead=derived_lead)
     return instance
+
+
+def _derive_long_lead(
+    horizon: str,
+    period_key: int | None,
+    issue_date: object,
+    year: int | None,
+) -> int | None:
+    """Derive the forecast lead in months from issue date to target-period start.
+
+    ``lead = (valid_from.year - date.year) * 12 + (valid_from.month - date.month)``
+    where ``date`` is the issue date and ``valid_from`` is the target period start.
+    The target-period-start month is derived from the horizon and period key
+    (quarter Q→month {1:1, 2:4, 3:7, 4:10}; season→April) via :func:`_target_month`,
+    and ``valid_from.year`` is the scored ``year`` (year of ``valid_from``).
+
+    Returns ``None`` when the lead cannot be derived (missing issue date, year, or
+    an unmappable period key).
+    """
+    if year is None:
+        return None
+    target_month = _target_month(horizon, period_key, year) if period_key is not None else None
+    if target_month is None:
+        return None
+    issue = _date_or_none(issue_date)
+    if issue is None:
+        return None
+    return (year - issue.year) * 12 + (target_month - issue.month)
 
 
 def _pair_row(

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/pairs.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/pairs.py
@@ -115,10 +115,12 @@ def build_pairs(
         start_date=start_date,
         end_date=end_date,
         ledger=ledger,
+        repair_lr=config.short_term_lr_repair_issue_indexing,
     )
     regime_policy = choose_regime_policy(
         forecasts,
         operational_start=config.operational_start,
+        regime_source=config.regime_source,
     )
 
     rows: list[dict[str, object]] = []
@@ -149,6 +151,22 @@ def build_pairs(
                 year=instance.year,
             )
             continue
+        if config.short_term_issue_before_target and normalized_horizon in SHORT_TERM_HORIZONS:
+            # A genuine short-term forecast is issued STRICTLY BEFORE its target
+            # period starts.  Rows whose issue date lands on/after the period
+            # start observed part of their own target (leakage / mislabelled).
+            issue_date_date = _date_or_none(instance.issue_date)
+            start = _target_period_start(normalized_horizon, instance.period_key, instance.year)
+            # Unparseable issue dates are left in place (do NOT drop).
+            if issue_date_date is not None and start is not None and issue_date_date >= start:
+                ledger.add(
+                    stage="pair",
+                    reason="forecast_issue_in_target_period",
+                    code=instance.code,
+                    period_key=instance.period_key,
+                    year=instance.year,
+                )
+                continue
         if instance.forecast_value is None:
             ledger.add(
                 stage="pair",
@@ -213,9 +231,35 @@ def build_pairs(
             )
         )
 
+    if config.short_term_dedup_one_per_target and normalized_horizon in SHORT_TERM_HORIZONS:
+        rows = _dedup_short_term_latest_issue(rows)
+
     pairs = pd.DataFrame(rows, columns=PAIR_COLUMNS)
     _attach_regime_attrs(pairs, regime_policy)
     return pairs, ledger
+
+
+def _dedup_short_term_latest_issue(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Collapse re-issues to one row per ``(code, period_key, year, model)``.
+
+    Keeps the row with the LATEST ``issue_date`` for each target/model group,
+    which — combined with the issue-before-target filter — is the operational
+    decision-time forecast (the latest genuine pre-period issue).  Rows whose
+    ``issue_date`` cannot be parsed are treated as the earliest and only survive
+    when no dated re-issue exists for the same group.  Deterministic: groups are
+    resolved in ascending-issue-date order with original position as tie-break.
+    """
+
+    def _sort_key(item: tuple[int, dict[str, object]]) -> tuple[bool, date, int]:
+        index, row = item
+        parsed = _date_or_none(row.get("issue_date"))
+        return (parsed is not None, parsed or date.min, index)
+
+    latest: dict[tuple[object, object, object, object], dict[str, object]] = {}
+    for _index, row in sorted(enumerate(rows), key=_sort_key):
+        key = (row.get("code"), row.get("period_key"), row.get("year"), row.get("model"))
+        latest[key] = row
+    return list(latest.values())
 
 
 def _read_forecasts(
@@ -227,6 +271,7 @@ def _read_forecasts(
     start_date: str | None,
     end_date: str | None,
     ledger: ExclusionLedger,
+    repair_lr: bool = False,
 ) -> pd.DataFrame:
     if horizon in SHORT_TERM_HORIZONS:
         return _read_short_forecasts(
@@ -237,6 +282,7 @@ def _read_forecasts(
             start_date,
             end_date,
             ledger,
+            repair_lr=repair_lr,
         )
     if horizon in LONG_TERM_HORIZONS:
         return _read_long_forecasts(
@@ -258,6 +304,7 @@ def _read_short_forecasts(
     start_date: str | None,
     end_date: str | None,
     ledger: ExclusionLedger,
+    repair_lr: bool = False,
 ) -> pd.DataFrame:
     frames: list[pd.DataFrame] = []
     include_lr = _include_lr_forecasts(model_filters)
@@ -282,6 +329,7 @@ def _read_short_forecasts(
                 code=code,
                 start_date=start_date,
                 end_date=end_date,
+                repair_issue_indexing=repair_lr,
             )
             frames.append(_result_frame(result))
             for _index in range(result.dropped_sentinels):
@@ -596,4 +644,49 @@ def _target_month(horizon: str, period_key: int, year: int) -> int | None:
         # SAPPHIRE uses 3 decades per calendar month (36 per year).
         month = (period_key - 1) // 3 + 1
         return month if 1 <= month <= 12 else None
+    return None
+
+
+def _target_period_start(horizon: str, period_key: int, year: int) -> date | None:
+    """Return the first calendar day of a short-term target period.
+
+    Mirrors the calendar logic in :func:`_target_month`.  Long-term horizons and
+    any invalid period key return ``None`` (the issue-before-target guard is not
+    applicable to them).
+
+    Args:
+        horizon: Normalized horizon literal (day/pentad/decade for a real result).
+        period_key: The in-year period index (``horizon_in_year``).
+        year: The target calendar year.
+
+    Returns:
+        The target period's first calendar day, or ``None`` when it cannot be
+        determined (invalid period key, out-of-range date, or long-term horizon).
+    """
+    if horizon == "day":
+        # period_key is the day-of-year index (1-based).
+        try:
+            return date(year, 1, 1) + timedelta(days=period_key - 1)
+        except (ValueError, OverflowError):
+            return None
+    if horizon == "pentad":
+        # 6 pentads per calendar month (72 per year).
+        month = (period_key - 1) // 6 + 1
+        if not 1 <= month <= 12:
+            return None
+        day = [1, 6, 11, 16, 21, 26][(period_key - 1) % 6]
+        try:
+            return date(year, month, day)
+        except (ValueError, OverflowError):
+            return None
+    if horizon == "decade":
+        # 3 decades per calendar month (36 per year).
+        month = (period_key - 1) // 3 + 1
+        if not 1 <= month <= 12:
+            return None
+        day = [1, 11, 21][(period_key - 1) % 3]
+        try:
+            return date(year, month, day)
+        except (ValueError, OverflowError):
+            return None
     return None

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/prob_metrics.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/prob_metrics.py
@@ -32,6 +32,7 @@ from forecast_skill_eval.contingency import (
     ALL_SEASON,
     POOLED_CODE,
 )
+from forecast_skill_eval.events import EventDef, reclassify_pairs_for_event
 from forecast_skill_eval.metrics import _wilson_interval
 from forecast_skill_eval.periods import LONG_TERM_HORIZONS
 from forecast_skill_eval.regimes import ALL_REGIME
@@ -585,6 +586,7 @@ def compute_probabilistic_metrics(
     *,
     threshold: float = 0.80,
     persist_ref: dict | None = None,
+    norm_factor_events: tuple[EventDef, ...] = (),
 ) -> pd.DataFrame:
     """Score pairs and aggregate across the same 8-key slice structure as
     count_contingencies (POOLED + per-code; per-lead for long-term).
@@ -608,6 +610,13 @@ def compute_probabilistic_metrics(
         threshold: Below-norm threshold fraction (mirrors classifier.classify).
         persist_ref: Optional persistence reference.  Maps
             (code, horizon, period_key, year) → lag1_observed_value.
+        norm_factor_events: Optional tuple of norm-factor :class:`EventDef`
+            (e.g. ``below_norm_100`` at ``factor=1.0``).  Default ``()`` →
+            behaviour byte-identical to the pre-P1b pass.  For each event whose
+            name is in *events_filter*, the pairs are reclassified at
+            ``value < factor * norm``, re-scored at ``threshold=factor``, and an
+            additional set of Brier-only rows tagged ``event=<name>`` is emitted
+            (NO extra distribution rows — those are threshold-independent).
 
     Returns:
         DataFrame with ``PROB_METRIC_COLUMNS``.
@@ -620,23 +629,28 @@ def compute_probabilistic_metrics(
     # Attach crps_clim and crps_persist per row.
     scored = _attach_reference_crps(scored, clim_ref, persist_ref)
 
-    frames: list[pd.DataFrame] = []
     working = _ensure_group_columns(scored)
+    frames: list[pd.DataFrame] = _reduce_scopes(working, events_filter)
 
-    for basin, basin_frame in _basin_slices(working):
-        for provenance, prov_frame in _provenance_slices(basin_frame):
-            for regime, regime_frame in _regime_slices(prov_frame):
-                for season, season_frame in _season_slices(regime_frame):
-                    frames.extend(
-                        _metric_scopes(
-                            season_frame,
-                            basin,
-                            provenance,
-                            regime,
-                            season,
-                            events_filter=events_filter,
-                        )
-                    )
+    # Additive norm-factor Brier passes (opt-in, e.g. below_norm_100).  Each
+    # emits Brier-only rows scored at the event's factor and tagged with the
+    # event name; distribution rows are NOT duplicated.
+    for event in norm_factor_events:
+        if event.name not in events_filter:
+            continue
+        pairs_f = reclassify_pairs_for_event(pairs, event, thresholds)
+        if pairs_f.empty:
+            continue
+        scored_f = _score_pairs(pairs_f, threshold=float(event.factor))
+        working_f = _ensure_group_columns(scored_f)
+        frames.extend(
+            _reduce_scopes(
+                working_f,
+                events_filter,
+                brier_only=True,
+                event_label=event.name,
+            )
+        )
 
     if not frames:
         return pd.DataFrame(columns=PROB_METRIC_COLUMNS)
@@ -721,6 +735,38 @@ def _ensure_group_columns(frame: pd.DataFrame) -> pd.DataFrame:
     return out
 
 
+def _reduce_scopes(
+    working: pd.DataFrame,
+    events_filter: tuple[str, ...],
+    *,
+    brier_only: bool = False,
+    event_label: str = "below_norm",
+) -> list[pd.DataFrame]:
+    """Run the basin/provenance/regime/season slice reducer over *working*.
+
+    ``brier_only`` / ``event_label`` are threaded to :func:`_metric_scopes` so
+    a norm-factor pass can emit Brier-only rows tagged with the event name.
+    """
+    frames: list[pd.DataFrame] = []
+    for basin, basin_frame in _basin_slices(working):
+        for provenance, prov_frame in _provenance_slices(basin_frame):
+            for regime, regime_frame in _regime_slices(prov_frame):
+                for season, season_frame in _season_slices(regime_frame):
+                    frames.extend(
+                        _metric_scopes(
+                            season_frame,
+                            basin,
+                            provenance,
+                            regime,
+                            season,
+                            events_filter=events_filter,
+                            brier_only=brier_only,
+                            event_label=event_label,
+                        )
+                    )
+    return frames
+
+
 def _metric_scopes(
     frame: pd.DataFrame,
     basin: str,
@@ -728,6 +774,8 @@ def _metric_scopes(
     regime: str,
     season: str,
     events_filter: tuple[str, ...],
+    brier_only: bool = False,
+    event_label: str = "below_norm",
 ) -> list[pd.DataFrame]:
     frames: list[pd.DataFrame] = []
     for horizon, h_frame in frame.groupby("horizon", dropna=False, sort=True):
@@ -746,20 +794,22 @@ def _metric_scopes(
 
                 code_val = POOLED_CODE if pooled else str(key_dict.get("code", ""))
 
-                dist_row = _aggregate_distribution(
-                    g_frame,
-                    horizon=str(horizon),
-                    model=str(key_dict.get("model", "")),
-                    regime=regime,
-                    season=season,
-                    code=code_val,
-                    basin=basin,
-                    norm_provenance=provenance,
-                    lead=key_dict.get("lead") if is_long else None,
-                )
-                frames.append(pd.DataFrame([dist_row]))
+                if not brier_only:
+                    dist_row = _aggregate_distribution(
+                        g_frame,
+                        horizon=str(horizon),
+                        model=str(key_dict.get("model", "")),
+                        regime=regime,
+                        season=season,
+                        code=code_val,
+                        basin=basin,
+                        norm_provenance=provenance,
+                        lead=key_dict.get("lead") if is_long else None,
+                    )
+                    frames.append(pd.DataFrame([dist_row]))
 
-                if "below_norm" in events_filter:
+                emit_brier = brier_only or (event_label in events_filter)
+                if emit_brier:
                     brier_row = _aggregate_brier(
                         g_frame,
                         horizon=str(horizon),
@@ -770,6 +820,7 @@ def _metric_scopes(
                         basin=basin,
                         norm_provenance=provenance,
                         lead=key_dict.get("lead") if is_long else None,
+                        event=event_label,
                     )
                     frames.append(pd.DataFrame([brier_row]))
 
@@ -791,6 +842,50 @@ def _crpss(crps_fc: float, crps_ref: float) -> float:
     return 1.0 - crps_fc / crps_ref
 
 
+def _crpss_paired(crps: pd.Series, crps_ref: pd.Series) -> float:
+    """CRPSS over the paired finite subset of forecast and reference CRPS.
+
+    The skill-score numerator and denominator means are taken over the SAME
+    rows (``crps.notna() & crps_ref.notna()``) so a reference CRPS that is
+    missing for some pairs cannot bias the ratio (CORE-5).  Returns NaN when the
+    intersection is empty.
+    """
+    mask = crps.notna() & crps_ref.notna()
+    if not bool(mask.any()):
+        return math.nan
+    fc_mean = float(crps[mask].mean())
+    ref_mean = float(crps_ref[mask].mean())
+    return _crpss(fc_mean, ref_mean)
+
+
+def _rank_calibration_error(rank_vals: pd.Series) -> float:
+    """Cramér–von-Mises / KS-style PIT calibration divergence (CORE-4).
+
+    Returns the mean absolute deviation between the sorted empirical rank (PIT)
+    values and their expected Uniform(0, 1) quantiles ``(i - 0.5) / n``.  The
+    statistic is 0 only when the ranks are perfectly uniform (calibrated); both
+    over-dispersion (ranks clumped near 0.5) and under-dispersion (ranks piled at
+    0/1) yield a clearly positive value.
+
+    This replaces the previous ``mean|rank - 0.5|``, which equalled 0.25 for a
+    perfectly calibrated Uniform PIT and rewarded over-dispersion.
+
+    Args:
+        rank_vals: Per-pair rank/PIT values in [0, 1]; NaNs are dropped.
+
+    Returns:
+        Calibration divergence >= 0 (0 = calibrated), or NaN when no finite
+        ranks remain.
+    """
+    vals = rank_vals.dropna()
+    n_r = len(vals)
+    if n_r == 0:
+        return math.nan
+    sorted_ranks = np.sort(vals.to_numpy(dtype=float))
+    expected = (np.arange(1, n_r + 1) - 0.5) / n_r
+    return float(np.abs(sorted_ranks - expected).mean())
+
+
 def _aggregate_distribution(
     frame: pd.DataFrame,
     *,
@@ -806,9 +901,16 @@ def _aggregate_distribution(
     n = len(frame)
     grid_id = str(frame["fc_grid_id"].iloc[0]) if "fc_grid_id" in frame.columns else ""
 
+    # Reported means use every available sample (dropping only their own NaNs).
     crps_mean = _nan_mean(frame["crps"])
     crps_clim_mean = _nan_mean(frame["crps_clim"])
     crps_persist_mean = _nan_mean(frame["crps_persist"])
+
+    # Skill scores use the PAIRED finite subset so numerator and denominator are
+    # averaged over the same rows — an unbiased ratio even when the reference
+    # CRPS is missing for some pairs (CORE-5).
+    crpss = _crpss_paired(frame["crps"], frame["crps_clim"])
+    crpss_persist = _crpss_paired(frame["crps"], frame["crps_persist"])
 
     # Coverage at 50%, 80%, 90%
     cov_50 = _nan_mean(frame["hit_50"]) if "hit_50" in frame.columns else math.nan
@@ -827,11 +929,12 @@ def _aggregate_distribution(
     rel_90 = abs(cov_90 - 0.90) if math.isfinite(cov_90) else math.nan
 
     # Rank stats
-    rank_vals = frame["rank"].dropna() if "rank" in frame.columns else pd.Series(dtype=float)
+    rank_series = frame["rank"] if "rank" in frame.columns else pd.Series(dtype=float)
+    rank_vals = rank_series.dropna()
     rank_mean = float(rank_vals.mean()) if len(rank_vals) > 0 else math.nan
     rank_var = float(rank_vals.var()) if len(rank_vals) > 1 else math.nan
-    # Calibration error: mean |rank - uniform_mean| (uniform mean = 0.5)
-    rank_cal_err = float((rank_vals - 0.5).abs().mean()) if len(rank_vals) > 0 else math.nan
+    # Calibration error: Cramér–von-Mises / KS-style PIT divergence (0 = calibrated).
+    rank_cal_err = _rank_calibration_error(rank_series)
 
     return {
         "horizon": horizon,
@@ -847,9 +950,9 @@ def _aggregate_distribution(
         "n_pairs": n,
         "crps": crps_mean,
         "crps_clim": crps_clim_mean,
-        "crpss": _crpss(crps_mean, crps_clim_mean),
+        "crpss": crpss,
         "crps_persist": crps_persist_mean,
-        "crpss_persist": _crpss(crps_mean, crps_persist_mean),
+        "crpss_persist": crpss_persist,
         "coverage_50": cov_50,
         "coverage_80": cov_80,
         "coverage_90": cov_90,
@@ -892,15 +995,39 @@ def _aggregate_brier(
     basin: str,
     norm_provenance: str,
     lead: object,
+    event: str = "below_norm",
 ) -> dict:
-    """Aggregate below_norm Brier scores for a group."""
-    n = len(frame)
+    """Aggregate below-norm Brier scores for a group, tagged with *event*.
+
+    ``below_norm_prob`` and ``obs_class`` in *frame* are already threshold-
+    specific (scored at the event's factor), so this reducer is reused verbatim
+    for the 0.80 × norm (``event="below_norm"``) and 1.0 × norm
+    (``event="below_norm_100"``) passes.
+
+    The emitted ``n_pairs`` is the band-valid count — the number of pairs with a
+    finite ``below_norm_prob`` (a >=2-node band) — which is exactly the sample
+    the Brier mean and the climatology base_rate are computed over (CORE-6).  It
+    is therefore <= ``len(frame)`` and may differ from the distribution row's
+    ``n_pairs``.
+    """
     grid_id = str(frame["fc_grid_id"].iloc[0]) if "fc_grid_id" in frame.columns else ""
+
+    # Band-valid subset = pairs with a finite below_norm_prob (i.e. a >=2-node
+    # band).  This is the ACTUAL Brier sample, so n_pairs, brier_mean and the
+    # climatology base_rate are all computed over it — the Brier row is then
+    # internally consistent (CORE-6).  n_pairs here is therefore the band-valid
+    # count, NOT len(frame).
+    if "below_norm_prob" in frame.columns:
+        band_valid = pd.to_numeric(frame["below_norm_prob"], errors="coerce").notna()
+    else:
+        band_valid = pd.Series(False, index=frame.index)
+    band_frame = frame[band_valid]
+    n = int(band_valid.sum())
 
     # Compute Brier score per pair: need below_norm_prob and observed event
     brier_vals: list[float] = []
 
-    for row in frame.to_dict("records"):
+    for row in band_frame.to_dict("records"):
         fc_prob = row.get("below_norm_prob", math.nan)
         obs_class = row.get("obs_class")
         # obs_class == "below" means the event occurred
@@ -917,9 +1044,10 @@ def _aggregate_brier(
 
     brier_mean = float(np.mean(brier_vals)) if brier_vals else math.nan
 
-    # Climatology Brier reference (base rate × (1 - base_rate))
-    if "obs_class" in frame.columns:
-        obs_classes = frame["obs_class"].dropna()
+    # Climatology Brier reference (base rate × (1 - base_rate)), base_rate taken
+    # over the SAME band-valid subset used for brier_mean (CORE-6).
+    if "obs_class" in band_frame.columns:
+        obs_classes = band_frame["obs_class"].dropna()
         base_rate = float((obs_classes == "below").mean()) if len(obs_classes) > 0 else math.nan
         brier_clim = base_rate * (1.0 - base_rate) if math.isfinite(base_rate) else math.nan
     else:
@@ -941,7 +1069,7 @@ def _aggregate_brier(
         "basin": basin,
         "norm_provenance": norm_provenance,
         "lead": lead,
-        "event": "below_norm",
+        "event": event,
         "fc_grid_id": grid_id,
         "n_pairs": n,
         # NaN for distribution columns in below_norm rows

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/regimes.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/regimes.py
@@ -112,6 +112,7 @@ def choose_regime_policy(
     forecasts: pd.DataFrame,
     *,
     operational_start: str | date = DEFAULT_OPERATIONAL_START,
+    regime_source: str = "auto",
     flag_sets: RegimeFlagSets | None = None,
     operational_flags: Sequence[object] | None = None,
     hindcast_flags: Sequence[object] | None = None,
@@ -123,6 +124,10 @@ def choose_regime_policy(
     Args:
         forecasts: Forecast rows for a single horizon.
         operational_start: ISO date or date object for the operational boundary.
+        regime_source: Regime selection strategy. ``"auto"`` (default) preserves
+            the historical behaviour of auto-picking flags when flag presence is
+            meaningful and falling back to issue date otherwise. ``"flag"`` forces
+            flag-based assignment; ``"date"`` forces issue-date-based assignment.
         flag_sets: Optional pre-resolved flag taxonomy.
         operational_flags: Optional operational flag override.
         hindcast_flags: Optional hindcast/backfilled flag override.
@@ -142,6 +147,24 @@ def choose_regime_policy(
         error_flags=error_flags,
     )
     counts = flag_counts(forecasts)
+
+    if regime_source == "flag":
+        return RegimePolicy(
+            source="flag",
+            operational_start=start,
+            reason="regime source forced to flag",
+            flag_counts=counts,
+            flag_sets=resolved_flags,
+        )
+    if regime_source == "date":
+        return RegimePolicy(
+            source="date",
+            operational_start=start,
+            reason="regime source forced to issue date",
+            flag_counts=counts,
+            flag_sets=resolved_flags,
+        )
+
     informative_counts = _selected_flag_counts(
         counts,
         (*resolved_flags.hindcast_flags, *resolved_flags.nan_exclude_flags),
@@ -197,14 +220,18 @@ def derive_regime(
     flag_sets = policy.flag_sets
     if flag in flag_sets.error_flags:
         return RegimeDecision(regime=None, exclude_reason=FORECAST_ERROR_FLAG_REASON)
+    # NaN-exclude flags are mode-independent: a row whose actual value is NaN
+    # must be excluded regardless of whether the policy uses flags or issue
+    # dates. Flag sets are validated disjoint, so evaluating this ahead of the
+    # flag-mode operational/hindcast checks leaves flag-mode behaviour identical.
+    if flag in flag_sets.nan_exclude_flags:
+        return RegimeDecision(regime=None, exclude_reason=FORECAST_ACTUAL_NAN_FLAG_REASON)
 
     if policy.source == "flag":
         if flag in flag_sets.operational_flags:
             return RegimeDecision(regime=OPERATIONAL_REGIME)
         if flag in flag_sets.hindcast_flags:
             return RegimeDecision(regime=HINDCAST_REGIME)
-        if flag in flag_sets.nan_exclude_flags:
-            return RegimeDecision(regime=None, exclude_reason=FORECAST_ACTUAL_NAN_FLAG_REASON)
         return _derive_date_regime(issue_date, policy.operational_start)
 
     return _derive_date_regime(issue_date, policy.operational_start)

--- a/apps/forecast_skill_eval/tests/test_api_readers.py
+++ b/apps/forecast_skill_eval/tests/test_api_readers.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import math
+from datetime import date
 
 import pandas as pd
 import pytest
 
 from forecast_skill_eval import api_readers
 from forecast_skill_eval.api_readers import (
+    _decad_of_year,
+    _normalize_lr_forecasts,
+    _pentad_of_year,
     read_forecasts,
     read_hydrograph_norms,
     read_long_forecasts,
@@ -572,3 +576,219 @@ def test_add_quantile_band_empty_frame_adds_typed_columns(fake_client_factory) -
     assert "quantiles_note" in result.data.columns
     assert "fc_grid_id" in result.data.columns
     assert "point_value" in result.data.columns  # point path still present
+
+
+# ---------------------------------------------------------------------------
+# LR issue-indexing repair-on-read tests (optional, default off)
+# ---------------------------------------------------------------------------
+
+
+def test_period_helpers_match_tag_library_convention() -> None:
+    assert _pentad_of_year(date(2022, 1, 1)) == 1
+    assert _decad_of_year(date(2022, 1, 1)) == 1
+    assert _pentad_of_year(date(2022, 5, 15)) == 27
+    assert _decad_of_year(date(2022, 5, 15)) == 14
+    assert _pentad_of_year(date(2022, 12, 31)) == 72
+    assert _decad_of_year(date(2022, 12, 31)) == 36
+
+
+def test_lr_repair_remaps_issue_indexed_pentad_row() -> None:
+    # Issue date 2023-03-21 is pentad 17; stored horizon_in_year 17 == issue
+    # period → issue-indexed → remap to target pentad 18.
+    df = pd.DataFrame(
+        [
+            {
+                "code": "19999",
+                "date": "2023-03-21",
+                "horizon_in_year": 17,
+                "horizon_value": 5,
+                "forecasted_discharge": 10.0,
+            }
+        ]
+    )
+
+    repaired = _normalize_lr_forecasts(df, horizon="pentad", repair_issue_indexing=True)
+
+    row = repaired.iloc[0]
+    assert row["horizon_in_year"] == 18
+    assert row["horizon_value"] == ((18 - 1) % 6) + 1 == 6
+    # Non-wrap remap leaves target's year as issue-year (issue date + 1 day).
+    assert pd.to_datetime(row["target"]).year == 2023
+
+
+def test_lr_repair_leaves_already_target_indexed_row_untouched() -> None:
+    # Issue date 2023-03-21 is pentad 17; stored horizon_in_year 18 != 17 →
+    # already target-indexed → unchanged.
+    df = pd.DataFrame(
+        [
+            {
+                "code": "19999",
+                "date": "2023-03-21",
+                "horizon_in_year": 18,
+                "forecasted_discharge": 10.0,
+            }
+        ]
+    )
+
+    repaired = _normalize_lr_forecasts(df, horizon="pentad", repair_issue_indexing=True)
+
+    assert repaired.iloc[0]["horizon_in_year"] == 18
+
+
+def test_lr_repair_wraps_pentad_72_and_advances_target_year() -> None:
+    # Issue date 2023-12-27 is pentad 72; issue-indexed → wrap to pentad 1 with
+    # the target year advanced to the following year.
+    df = pd.DataFrame(
+        [
+            {
+                "code": "19999",
+                "date": "2023-12-27",
+                "horizon_in_year": 72,
+                "forecasted_discharge": 10.0,
+            }
+        ]
+    )
+
+    repaired = _normalize_lr_forecasts(df, horizon="pentad", repair_issue_indexing=True)
+
+    row = repaired.iloc[0]
+    assert row["horizon_in_year"] == 1
+    assert pd.to_datetime(row["target"]).year == 2024
+
+
+def test_lr_repair_ignores_unparseable_issue_date() -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "code": "19999",
+                "date": "not-a-date",
+                "horizon_in_year": 17,
+                "forecasted_discharge": 10.0,
+            }
+        ]
+    )
+
+    repaired = _normalize_lr_forecasts(df, horizon="pentad", repair_issue_indexing=True)
+
+    assert repaired.iloc[0]["horizon_in_year"] == 17
+
+
+def test_lr_repair_remaps_issue_indexed_decade_row() -> None:
+    # Issue date 2023-02-15 is decade 5; horizon_in_year 5 == issue → remap to 6.
+    df = pd.DataFrame(
+        [
+            {
+                "code": "19999",
+                "date": "2023-02-15",
+                "horizon_in_year": 5,
+                "horizon_value": 2,
+                "forecasted_discharge": 10.0,
+            }
+        ]
+    )
+
+    repaired = _normalize_lr_forecasts(df, horizon="decade", repair_issue_indexing=True)
+
+    row = repaired.iloc[0]
+    assert row["horizon_in_year"] == 6
+    assert row["horizon_value"] == ((6 - 1) % 3) + 1 == 3
+    assert pd.to_datetime(row["target"]).year == 2023
+
+
+def test_lr_repair_wraps_decade_36_and_advances_target_year() -> None:
+    # Issue date 2023-12-25 is decade 36; issue-indexed → wrap to decade 1 with
+    # the target year advanced to the following year.
+    df = pd.DataFrame(
+        [
+            {
+                "code": "19999",
+                "date": "2023-12-25",
+                "horizon_in_year": 36,
+                "forecasted_discharge": 10.0,
+            }
+        ]
+    )
+
+    repaired = _normalize_lr_forecasts(df, horizon="decade", repair_issue_indexing=True)
+
+    row = repaired.iloc[0]
+    assert row["horizon_in_year"] == 1
+    assert pd.to_datetime(row["target"]).year == 2024
+
+
+def test_lr_repair_off_is_byte_identical_on_target_indexed_row() -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "code": "19999",
+                "date": "2023-03-21",
+                "horizon_in_year": 18,
+                "forecasted_discharge": 10.0,
+            }
+        ]
+    )
+
+    on = _normalize_lr_forecasts(df, horizon="pentad", repair_issue_indexing=True)
+    off = _normalize_lr_forecasts(df, horizon="pentad", repair_issue_indexing=False)
+
+    assert on["horizon_in_year"].tolist() == off["horizon_in_year"].tolist()
+
+
+def test_lr_repair_off_leaves_issue_indexed_row_untouched() -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "code": "19999",
+                "date": "2023-03-21",
+                "horizon_in_year": 17,
+                "forecasted_discharge": 10.0,
+            }
+        ]
+    )
+
+    # Repair OFF, and the pre-existing default call (no horizon / no flag), both
+    # leave the stored (issue) index untouched.
+    off = _normalize_lr_forecasts(df, horizon="pentad", repair_issue_indexing=False)
+    default = _normalize_lr_forecasts(df)
+
+    assert off.iloc[0]["horizon_in_year"] == 17
+    assert default.iloc[0]["horizon_in_year"] == 17
+
+
+def test_lr_repair_excludes_day_horizon() -> None:
+    # A day-horizon call with an issue-indexed-looking row must NOT be remapped;
+    # the repair is pentad/decade only.
+    df = pd.DataFrame(
+        [
+            {
+                "code": "19999",
+                "date": "2023-03-21",
+                "horizon_in_year": 17,
+                "forecasted_discharge": 10.0,
+            }
+        ]
+    )
+
+    repaired = _normalize_lr_forecasts(df, horizon="day", repair_issue_indexing=True)
+
+    assert repaired.iloc[0]["horizon_in_year"] == 17
+
+
+def test_read_lr_forecasts_repair_on_shifts_period_via_reader(fake_client_factory) -> None:
+    client = fake_client_factory(
+        lr_forecasts_rows=[
+            _lr_row(date="2023-03-21", horizon_in_year=17, discharge=10.0),
+        ],
+    )
+
+    result = read_lr_forecasts(
+        client,
+        horizon="pentad",
+        code="19999",
+        start_date="2023-01-01",
+        end_date="2023-12-31",
+        limit=10,
+        repair_issue_indexing=True,
+    )
+
+    assert result.data.iloc[0]["horizon_in_year"] == 18

--- a/apps/forecast_skill_eval/tests/test_artifacts.py
+++ b/apps/forecast_skill_eval/tests/test_artifacts.py
@@ -729,6 +729,41 @@ def test_summary_prob_section_shows_not_computed_when_empty(tmp_path: Path) -> N
     assert "not computed" in summary
 
 
+def test_prob_section_counts_below_norm_100_brier_rows_additively() -> None:
+    """The Probabilistic Metrics section additively reports 1.0×norm Brier rows
+    only when they are present; the default frame is unaffected."""
+    from forecast_skill_eval.artifacts import _prob_metrics_section
+
+    base = _prob_metrics_frame()
+    base_lines = _prob_metrics_section(base)
+    assert not any("1.0x" in line for line in base_lines), (
+        "the 1.0×norm line must be absent when no below_norm_100 rows exist"
+    )
+
+    brier_100 = {col: math.nan for col in PROB_METRIC_COLUMNS}
+    brier_100.update(
+        {
+            "horizon": "pentad",
+            "model": "model-a",
+            "regime": "all",
+            "season": "all",
+            "code": "POOLED",
+            "basin": "all",
+            "norm_provenance": "all",
+            "lead": None,
+            "event": "below_norm_100",
+            "fc_grid_id": "short5",
+            "n_pairs": 3,
+            "brier": 0.11,
+        }
+    )
+    with_100 = pd.concat([base, pd.DataFrame([brier_100])], ignore_index=True)
+    lines_100 = _prob_metrics_section(with_100)
+    assert any("Below-norm (1.0x norm) Brier rows: 1" in line for line in lines_100)
+    # The original below_norm count line is still present and unchanged.
+    assert any(line == "Below-norm Brier rows: 0" for line in lines_100)
+
+
 # ---------------------------------------------------------------------------
 # Phase-4 value-metric artifacts (SAPPHIRE_SKILL_VALUE)
 # ---------------------------------------------------------------------------

--- a/apps/forecast_skill_eval/tests/test_baselines.py
+++ b/apps/forecast_skill_eval/tests/test_baselines.py
@@ -108,6 +108,7 @@ def _pair(
     *,
     lead: int | None = None,
     regime: str = "operational",
+    issue_date: str | None = None,
 ) -> dict[str, object]:
     return {
         "horizon": horizon,
@@ -120,6 +121,7 @@ def _pair(
         "lead": lead,
         "norm_provenance": provenance,
         "contingency": contingency,
+        "issue_date": issue_date,
     }
 
 
@@ -149,6 +151,169 @@ def _cells(row: pd.Series) -> dict[str, int]:
 # ---------------------------------------------------------------------------
 # Persistence baseline (Phase 2B)
 # ---------------------------------------------------------------------------
+
+
+def test_operational_proxy_equalizes_reissued_model_pairs() -> None:
+    """Re-issued model forecasts for a matched key must not inflate the model
+    side relative to the single-issue proxy side.
+
+    Both emitted rows must carry exactly one pair per matched key, so their
+    n_pairs are equal and equal to the number of matched keys.
+    """
+    pairs = pd.DataFrame(
+        [
+            # Two re-issues of the model forecast for the SAME matched key.
+            _pair(
+                "day",
+                "TFT",
+                STATION_CODE,
+                1,
+                2024,
+                "calculated",
+                "TP",
+                issue_date="2024-01-01",
+            ),
+            _pair(
+                "day",
+                "TFT",
+                STATION_CODE,
+                1,
+                2024,
+                "calculated",
+                "FP",
+                issue_date="2024-01-05",
+            ),
+            # A single proxy pair for the same key.
+            _pair(
+                "day",
+                "LR",
+                STATION_CODE,
+                1,
+                2024,
+                "calculated",
+                "TN",
+                issue_date="2024-01-03",
+            ),
+        ]
+    )
+
+    baseline = build_operational_proxy_baseline(pairs)
+
+    model_row = _one_row(baseline, code=STATION_CODE, model="TFT")
+    proxy_row = _one_row(baseline, code=STATION_CODE, model="LR")
+
+    # One matched key → one pair per side → equal n_pairs.
+    assert int(model_row["n_pairs"]) == 1
+    assert int(proxy_row["n_pairs"]) == 1
+    assert int(model_row["n_pairs"]) == int(proxy_row["n_pairs"])
+    # The representative kept for the model side is the LATEST issue_date
+    # (2024-01-05 → FP), not the earlier 2024-01-01 → TP.
+    assert _cells(model_row) == {"TP": 0, "FP": 1, "FN": 0, "TN": 0, "n_pairs": 1}
+    assert _cells(proxy_row) == {"TP": 0, "FP": 0, "FN": 0, "TN": 1, "n_pairs": 1}
+
+
+def test_operational_proxy_keeps_latest_issue_date_representative() -> None:
+    """The kept representative per key is the row with the latest issue_date,
+    regardless of the order rows appear in the frame."""
+    pairs = pd.DataFrame(
+        [
+            # Latest issue_date first in the frame, oldest last, to prove the
+            # choice is driven by issue_date and not by row order.
+            _pair(
+                "day",
+                "TFT",
+                STATION_CODE,
+                1,
+                2024,
+                "calculated",
+                "TN",
+                issue_date="2024-03-01",
+            ),
+            _pair(
+                "day",
+                "TFT",
+                STATION_CODE,
+                1,
+                2024,
+                "calculated",
+                "TP",
+                issue_date="2024-01-01",
+            ),
+            _pair(
+                "day",
+                "LR",
+                STATION_CODE,
+                1,
+                2024,
+                "calculated",
+                "FP",
+                issue_date="2024-02-01",
+            ),
+        ]
+    )
+
+    baseline = build_operational_proxy_baseline(pairs)
+
+    model_row = _one_row(baseline, code=STATION_CODE, model="TFT")
+    # 2024-03-01 → TN wins over 2024-01-01 → TP.
+    assert _cells(model_row) == {"TP": 0, "FP": 0, "FN": 0, "TN": 1, "n_pairs": 1}
+
+
+def test_operational_proxy_single_pair_per_key_unchanged_by_collapse() -> None:
+    """With exactly one pair per key on both sides the collapse is a no-op:
+    the contingency cells match the pre-fix result exactly."""
+    pairs = pd.DataFrame(
+        [
+            _pair(
+                "day",
+                "TFT",
+                STATION_CODE,
+                1,
+                2024,
+                "calculated",
+                "TP",
+                issue_date="2024-01-01",
+            ),
+            _pair(
+                "day",
+                "TFT",
+                STATION_CODE,
+                2,
+                2024,
+                "calculated",
+                "FN",
+                issue_date="2024-01-02",
+            ),
+            _pair(
+                "day",
+                "LR",
+                STATION_CODE,
+                1,
+                2024,
+                "calculated",
+                "TN",
+                issue_date="2024-01-01",
+            ),
+            _pair(
+                "day",
+                "LR",
+                STATION_CODE,
+                2,
+                2024,
+                "calculated",
+                "FP",
+                issue_date="2024-01-02",
+            ),
+        ]
+    )
+
+    baseline = build_operational_proxy_baseline(pairs)
+
+    model_row = _one_row(baseline, code=STATION_CODE, model="TFT")
+    proxy_row = _one_row(baseline, code=STATION_CODE, model="LR")
+
+    assert _cells(model_row) == {"TP": 1, "FP": 0, "FN": 1, "TN": 0, "n_pairs": 2}
+    assert _cells(proxy_row) == {"TP": 0, "FP": 1, "FN": 0, "TN": 1, "n_pairs": 2}
 
 
 def _pair_with_observed(
@@ -525,3 +690,104 @@ def test_persistence_baseline_wired_in_orchestrator() -> None:
     assert "persistence" in baseline_labels, (
         f"Expected 'persistence' in baselines but got: {baseline_labels}"
     )
+
+
+# ---------------------------------------------------------------------------
+# P1b: event column / below_norm_100 parity
+# ---------------------------------------------------------------------------
+
+
+def _full_pair(
+    *,
+    period_key: int,
+    year: int,
+    forecast_value: float,
+    observed_value: float,
+    norm: float = 10.0,
+    model: str = "model-a",
+    threshold: float = 0.80,
+) -> dict[str, object]:
+    """Build a complete pentad pair row classified at ``threshold × norm``."""
+    fc_class = "below" if forecast_value < threshold * norm else "normal"
+    obs_class = "below" if observed_value < threshold * norm else "normal"
+    if fc_class == "below" and obs_class == "below":
+        cont = "TP"
+    elif fc_class == "below":
+        cont = "FP"
+    elif obs_class == "below":
+        cont = "FN"
+    else:
+        cont = "TN"
+    return {
+        "horizon": "pentad",
+        "code": STATION_CODE,
+        "basin": "other",
+        "period_key": period_key,
+        "year": year,
+        "model": model,
+        "regime": "operational",
+        "season": "irrigation",
+        "lead": None,
+        "norm_provenance": "calculated",
+        "forecast_value": forecast_value,
+        "observed_value": observed_value,
+        "norm": norm,
+        "fc_class": fc_class,
+        "obs_class": obs_class,
+        "contingency": cont,
+    }
+
+
+def _flip_pairs() -> pd.DataFrame:
+    """Pairs where obs=9 (norm=10) is normal at 0.80 but below at 1.0 × norm."""
+    return pd.DataFrame(
+        [
+            _full_pair(period_key=1, year=2010, forecast_value=6.0, observed_value=9.0),
+            _full_pair(period_key=2, year=2011, forecast_value=6.0, observed_value=5.0),
+            _full_pair(period_key=3, year=2012, forecast_value=6.0, observed_value=12.0),
+            _full_pair(period_key=4, year=2013, forecast_value=6.0, observed_value=7.0),
+        ]
+    )
+
+
+def test_baseline_event_column_defaults_to_below_norm() -> None:
+    from forecast_skill_eval.baselines import BASELINE_COLUMNS
+
+    assert "event" in BASELINE_COLUMNS
+    baseline = build_climatology_baseline(_flip_pairs())
+    assert set(baseline["event"].unique()) == {"below_norm"}
+
+
+def test_climatology_below_norm_metric_values_unchanged_by_event_column() -> None:
+    """Adding the constant event column must not perturb the metric cells."""
+    baseline = build_climatology_baseline(_flip_pairs())
+    pooled = baseline[baseline["code"] == STATION_CODE].iloc[0]
+    # obs below at 0.80×10=8: obs in {9,5,12,7} -> below {5,7} -> FN=2, TN=2.
+    assert _cells(pooled) == {"TP": 0, "FP": 0, "FN": 2, "TN": 2, "n_pairs": 4}
+
+
+def test_climatology_below_norm_100_tagged_and_differs() -> None:
+    from forecast_skill_eval.events import event_by_name, reclassify_pairs_for_event
+
+    pairs = _flip_pairs()
+    pairs_100 = reclassify_pairs_for_event(pairs, event_by_name("below_norm_100"), {})
+    baseline_100 = build_climatology_baseline(pairs_100, event="below_norm_100")
+
+    assert set(baseline_100["event"].unique()) == {"below_norm_100"}
+    pooled = baseline_100[baseline_100["code"] == STATION_CODE].iloc[0]
+    # obs below at 1.0×10=10: obs in {9,5,12,7} -> below {9,5,7} -> FN=3, TN=1.
+    assert _cells(pooled) == {"TP": 0, "FP": 0, "FN": 3, "TN": 1, "n_pairs": 4}
+
+
+def test_persistence_and_operational_thread_event_label() -> None:
+    from forecast_skill_eval.events import event_by_name, reclassify_pairs_for_event
+
+    pairs = _flip_pairs()
+    pairs_100 = reclassify_pairs_for_event(pairs, event_by_name("below_norm_100"), {})
+    persistence_100 = build_persistence_baseline(pairs_100, threshold=1.0, event="below_norm_100")
+    if not persistence_100.empty:
+        assert set(persistence_100["event"].unique()) == {"below_norm_100"}
+    # Default persistence rows carry below_norm.
+    persistence = build_persistence_baseline(pairs)
+    if not persistence.empty:
+        assert set(persistence["event"].unique()) == {"below_norm"}

--- a/apps/forecast_skill_eval/tests/test_cli.py
+++ b/apps/forecast_skill_eval/tests/test_cli.py
@@ -174,6 +174,30 @@ def test_short_term_gate_flags_parse_into_config() -> None:
     assert config.short_term_dedup_one_per_target is True
 
 
+def test_long_term_derive_lead_default_off_in_cli(monkeypatch) -> None:
+    monkeypatch.delenv("SAPPHIRE_SKILL_LT_LEAD", raising=False)
+    parser = cli._parser()
+    args = parser.parse_args([])
+    config = cli._config_from_args(args)
+    assert config.long_term_derive_lead is False
+
+
+def test_long_term_derive_lead_cli_flag_parses_into_config(monkeypatch) -> None:
+    monkeypatch.delenv("SAPPHIRE_SKILL_LT_LEAD", raising=False)
+    parser = cli._parser()
+    args = parser.parse_args(["--long-term-derive-lead"])
+    config = cli._config_from_args(args)
+    assert config.long_term_derive_lead is True
+
+
+def test_long_term_derive_lead_env_enables_gate(monkeypatch) -> None:
+    monkeypatch.setenv("SAPPHIRE_SKILL_LT_LEAD", "true")
+    parser = cli._parser()
+    args = parser.parse_args([])
+    config = cli._config_from_args(args)
+    assert config.long_term_derive_lead is True
+
+
 def test_forecast_only_env_enables_both_short_term_gates(monkeypatch) -> None:
     monkeypatch.setenv("SAPPHIRE_SKILL_FORECAST_ONLY", "1")
     parser = cli._parser()

--- a/apps/forecast_skill_eval/tests/test_cli.py
+++ b/apps/forecast_skill_eval/tests/test_cli.py
@@ -138,6 +138,84 @@ def test_operational_issue_days_cli_default_is_empty() -> None:
     assert config.operational_issue_days == ()
 
 
+def test_regime_source_cli_default_is_auto() -> None:
+    parser = cli._parser()
+    args = parser.parse_args([])
+    config = cli._config_from_args(args)
+    assert config.regime_source == "auto"
+
+
+def test_regime_source_cli_arg_parses_into_config() -> None:
+    parser = cli._parser()
+    for value in ("auto", "flag", "date"):
+        args = parser.parse_args(["--regime-source", value])
+        config = cli._config_from_args(args)
+        assert config.regime_source == value
+
+
+def test_short_term_gate_flags_default_off_in_cli() -> None:
+    parser = cli._parser()
+    args = parser.parse_args([])
+    config = cli._config_from_args(args)
+    assert config.short_term_issue_before_target is False
+    assert config.short_term_dedup_one_per_target is False
+
+
+def test_short_term_gate_flags_parse_into_config() -> None:
+    parser = cli._parser()
+    args = parser.parse_args(
+        [
+            "--short-term-issue-before-target",
+            "--short-term-dedup-one-per-target",
+        ]
+    )
+    config = cli._config_from_args(args)
+    assert config.short_term_issue_before_target is True
+    assert config.short_term_dedup_one_per_target is True
+
+
+def test_forecast_only_env_enables_both_short_term_gates(monkeypatch) -> None:
+    monkeypatch.setenv("SAPPHIRE_SKILL_FORECAST_ONLY", "1")
+    parser = cli._parser()
+    args = parser.parse_args([])
+    config = cli._config_from_args(args)
+    assert config.short_term_issue_before_target is True
+    assert config.short_term_dedup_one_per_target is True
+
+
+def test_forecast_only_env_unset_leaves_gates_off(monkeypatch) -> None:
+    monkeypatch.delenv("SAPPHIRE_SKILL_FORECAST_ONLY", raising=False)
+    parser = cli._parser()
+    args = parser.parse_args([])
+    config = cli._config_from_args(args)
+    assert config.short_term_issue_before_target is False
+    assert config.short_term_dedup_one_per_target is False
+
+
+def test_lr_repair_cli_default_is_off(monkeypatch) -> None:
+    monkeypatch.delenv("SAPPHIRE_SKILL_LR_REPAIR", raising=False)
+    parser = cli._parser()
+    args = parser.parse_args([])
+    config = cli._config_from_args(args)
+    assert config.short_term_lr_repair_issue_indexing is False
+
+
+def test_lr_repair_cli_flag_enables_repair(monkeypatch) -> None:
+    monkeypatch.delenv("SAPPHIRE_SKILL_LR_REPAIR", raising=False)
+    parser = cli._parser()
+    args = parser.parse_args(["--short-term-lr-repair"])
+    config = cli._config_from_args(args)
+    assert config.short_term_lr_repair_issue_indexing is True
+
+
+def test_lr_repair_env_enables_repair(monkeypatch) -> None:
+    monkeypatch.setenv("SAPPHIRE_SKILL_LR_REPAIR", "1")
+    parser = cli._parser()
+    args = parser.parse_args([])
+    config = cli._config_from_args(args)
+    assert config.short_term_lr_repair_issue_indexing is True
+
+
 def test_apply_season_filter_passes_prob_frames_through(tmp_path: Path) -> None:
     """_apply_season_filter must slice prob_metrics / prob_reliability on 'season'
     the same way it slices contingency_metrics and baselines."""

--- a/apps/forecast_skill_eval/tests/test_config.py
+++ b/apps/forecast_skill_eval/tests/test_config.py
@@ -100,6 +100,57 @@ def test_invalid_config_inputs_are_rejected(kwargs: dict[str, object]) -> None:
         ForecastSkillEvalConfig(**kwargs)
 
 
+def test_short_term_gate_flags_default_off() -> None:
+    """Both short-term correctness gates must default to False (byte-identical)."""
+    config = ForecastSkillEvalConfig()
+
+    assert config.short_term_issue_before_target is False
+    assert config.short_term_dedup_one_per_target is False
+
+
+def test_short_term_gate_flags_can_be_enabled() -> None:
+    config = ForecastSkillEvalConfig(
+        short_term_issue_before_target=True,
+        short_term_dedup_one_per_target=True,
+    )
+
+    assert config.short_term_issue_before_target is True
+    assert config.short_term_dedup_one_per_target is True
+
+
+def test_lr_repair_flag_defaults_off() -> None:
+    """The LR repair-on-read flag must default to False (byte-identical reads)."""
+    config = ForecastSkillEvalConfig()
+
+    assert config.short_term_lr_repair_issue_indexing is False
+
+
+def test_lr_repair_flag_can_be_enabled() -> None:
+    config = ForecastSkillEvalConfig(short_term_lr_repair_issue_indexing=True)
+
+    assert config.short_term_lr_repair_issue_indexing is True
+
+
+def test_config_events_filter_accepts_below_norm_100() -> None:
+    """below_norm_100 (opt-in norm-factor event) must validate in events_filter."""
+    config = ForecastSkillEvalConfig(events_filter=("below_norm", "below_norm_100"))
+    assert set(config.events_filter) == {"below_norm", "below_norm_100"}
+
+
+def test_default_events_unchanged_by_norm_factor_event() -> None:
+    """DEFAULT_EVENTS must still be exactly the original five events."""
+    from forecast_skill_eval.config import DEFAULT_EVENTS
+
+    assert tuple(DEFAULT_EVENTS) == (
+        "below_norm",
+        "low_p10",
+        "low_p5",
+        "high_p90",
+        "high_p95",
+    )
+    assert "below_norm_100" not in DEFAULT_EVENTS
+
+
 def test_operational_issue_days_default_is_empty() -> None:
     config = ForecastSkillEvalConfig()
     assert config.operational_issue_days == ()
@@ -130,3 +181,21 @@ def test_operational_issue_days_empty_sequence_disables_filtering() -> None:
 def test_operational_issue_days_rejects_invalid(days: list[object]) -> None:
     with pytest.raises(ValueError):
         ForecastSkillEvalConfig(operational_issue_days=days)
+
+
+def test_regime_source_defaults_to_auto() -> None:
+    """A config built without regime_source keeps the byte-identical default."""
+    config = ForecastSkillEvalConfig()
+    assert config.regime_source == "auto"
+
+
+@pytest.mark.parametrize("value", ["auto", "flag", "date"])
+def test_regime_source_accepts_valid_values(value: str) -> None:
+    config = ForecastSkillEvalConfig(regime_source=value)
+    assert config.regime_source == value
+
+
+@pytest.mark.parametrize("value", ["", "issue_date", "FLAG", "dates"])
+def test_regime_source_rejects_invalid(value: str) -> None:
+    with pytest.raises(ValueError):
+        ForecastSkillEvalConfig(regime_source=value)

--- a/apps/forecast_skill_eval/tests/test_dashboard_aggregates.py
+++ b/apps/forecast_skill_eval/tests/test_dashboard_aggregates.py
@@ -26,6 +26,7 @@ from forecast_skill_eval.dashboard.aggregates import (
     _baseline_rows,
     base_horizon,
     get_baseline_refs,
+    lead_display,
     load_baselines,
     model_family,
     model_sort_key,
@@ -169,9 +170,43 @@ class TestBaseHorizon:
         assert base_horizon("quarter L1") == "quarter"
         assert base_horizon("season L0") == "season"
 
+    def test_quarter_with_q_label_returns_base(self):
+        """'quarter Q1' (target-quarter form) should still return 'quarter'."""
+        assert base_horizon("quarter Q1") == "quarter"
+        assert base_horizon("quarter Q4") == "quarter"
+
     def test_unknown_returns_input(self):
         """Unrecognised labels are passed through unchanged."""
         assert base_horizon("foobar") == "foobar"
+
+
+# ---------------------------------------------------------------------------
+# TestLeadDisplay
+# ---------------------------------------------------------------------------
+
+
+class TestLeadDisplay:
+    """Tests for the horizon-aware :func:`lead_display` helper."""
+
+    def test_quarter_uses_q_prefix(self):
+        """Quarter's lead value is the target quarter → 'Q{n}'."""
+        assert lead_display("quarter", 1) == "Q1"
+        assert lead_display("quarter", 4) == "Q4"
+
+    def test_month_uses_l_prefix(self):
+        """Month keeps genuine forecast-lead labelling → 'L{n}'."""
+        assert lead_display("month", 0) == "L0"
+        assert lead_display("month", 3) == "L3"
+
+    def test_season_uses_l_prefix(self):
+        """Season keeps genuine forecast-lead labelling → 'L{n}'."""
+        assert lead_display("season", 0) == "L0"
+        assert lead_display("season", 2) == "L2"
+
+    def test_short_term_sentinel_is_dash(self):
+        """The short-term sentinel (-1) renders as an em dash, any horizon."""
+        assert lead_display("pentad", -1) == "—"
+        assert lead_display("quarter", -1) == "—"
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +240,18 @@ class TestAddHLabel:
         df = _make_df(_base_row(horizon="month", lead=2.0))
         result = _add_h_label(df)
         assert result["h_label"].iloc[0] == "month L2"
+
+    def test_quarter_h_label_uses_q_prefix(self):
+        """Quarter rows carry the target quarter → h_label like 'quarter Q1'."""
+        df = _make_df(_base_row(horizon="quarter", lead=1.0))
+        result = _add_h_label(df)
+        assert result["h_label"].iloc[0] == "quarter Q1"
+
+    def test_season_h_label_unchanged_uses_l_prefix(self):
+        """Season rows keep the 'L{n}' lead form."""
+        df = _make_df(_base_row(horizon="season", lead=0.0))
+        result = _add_h_label(df)
+        assert result["h_label"].iloc[0] == "season L0"
 
 
 # ---------------------------------------------------------------------------
@@ -446,6 +493,23 @@ class TestPrepPerformanceDiagram:
         result = prep_performance_diagram(df)
         assert not result.empty
         assert result["lead_label"].iloc[0] == "L0"
+
+    def test_lead_label_uses_q_prefix_for_quarter(self):
+        """Quarter rows label the lead as the target quarter → 'Q1'."""
+        df = _make_df(
+            _base_row(
+                horizon="quarter",
+                norm_provenance="aggregated_from_monthly",
+                lead=1.0,
+                pod=0.70,
+                pod_undefined=False,
+                far=0.20,
+                far_undefined=False,
+            )
+        )
+        result = prep_performance_diagram(df)
+        assert not result.empty
+        assert result["lead_label"].iloc[0] == "Q1"
 
 
 # ---------------------------------------------------------------------------
@@ -880,3 +944,13 @@ class TestPrepOpVsHindcast:
         regimes = set(result["regime"].unique())
         assert "operational" in regimes
         assert "hindcast" in regimes
+
+    def test_lead_label_is_horizon_aware(self, df_lt: pd.DataFrame):
+        """Quarter rows label as 'Q{n}'; month/season keep 'L{n}'."""
+        result = prep_op_vs_hindcast(df_lt)
+        quarter_labels = set(result.loc[result["horizon"] == "quarter", "lead_label"])
+        month_labels = set(result.loc[result["horizon"] == "month", "lead_label"])
+        season_labels = set(result.loc[result["horizon"] == "season", "lead_label"])
+        assert quarter_labels == {"Q1"}
+        assert month_labels == {"L0"}
+        assert season_labels == {"L0"}

--- a/apps/forecast_skill_eval/tests/test_economic_value.py
+++ b/apps/forecast_skill_eval/tests/test_economic_value.py
@@ -178,6 +178,33 @@ def test_reducer_base_rate_undefined_all_normal_obs():
     assert row["n_pairs"] == 30
 
 
+# --------------------------------------------------------------------------- #
+# P1b: below_norm_100 event selection is independent of below_norm
+# --------------------------------------------------------------------------- #
+
+
+def test_below_norm_100_event_selection_is_independent():
+    """A contingency frame carrying BOTH events yields the 1.0 rows when asked,
+    and the below_norm selection is unaffected by the extra event rows."""
+    bn = _contingency_frame([_contingency_row(tp=8, fp=2, fn=2, tn=8)], event="below_norm")
+    bn100 = _contingency_frame([_contingency_row(tp=9, fp=1, fn=3, tn=7)], event="below_norm_100")
+    combined = pd.concat([bn, bn100], ignore_index=True)
+
+    long_bn, summary_bn = compute_economic_value(combined, event="below_norm")
+    long_100, summary_100 = compute_economic_value(combined, event="below_norm_100")
+
+    assert set(long_bn["event"].unique()) == {"below_norm"}
+    assert set(long_100["event"].unique()) == {"below_norm_100"}
+
+    # below_norm selection from the combined frame equals a below_norm-only frame.
+    long_bn_alone, summary_bn_alone = compute_economic_value(bn, event="below_norm")
+    pd.testing.assert_frame_equal(long_bn, long_bn_alone)
+    pd.testing.assert_frame_equal(summary_bn, summary_bn_alone)
+
+    # The 1.0 base rate differs (9+3)/20 = 0.6 vs 0.5 for below_norm.
+    assert summary_100.iloc[0]["base_rate_s"] == pytest.approx(0.6)
+
+
 def test_reducer_pofd_undefined_all_below_obs():
     # No non-events: FP=0, TN=0 -> pofd undefined.
     frame = _contingency_frame([_contingency_row(tp=25, fp=0, fn=5, tn=0)])

--- a/apps/forecast_skill_eval/tests/test_events.py
+++ b/apps/forecast_skill_eval/tests/test_events.py
@@ -1206,3 +1206,88 @@ def test_reclassify_equivalence_rp_event() -> None:
     # Above-level half → TP; below-level half → TN
     assert (actual.iloc[: len(above)]["contingency"] == "TP").all()
     assert (actual.iloc[len(above) :]["contingency"] == "TN").all()
+
+
+# ===========================================================================
+# Block 10 — Norm-factor event: below_norm_100 (plain below-norm at 1.0 × norm)
+# ===========================================================================
+
+
+def test_below_norm_100_registered_and_not_a_default_event() -> None:
+    """below_norm_100 must resolve with factor=1.0, be VALID, but not a default."""
+    from forecast_skill_eval.events import (
+        ALL_EVENT_NAMES,
+        VALID_EVENTS,
+        event_by_name,
+    )
+
+    event = event_by_name("below_norm_100")
+    assert event.factor == 1.0
+    assert event.direction == "below"
+    assert event.percentile is None
+    assert event.return_period is None
+    assert "below_norm_100" in VALID_EVENTS
+    assert "below_norm_100" not in ALL_EVENT_NAMES
+
+
+def test_below_norm_event_reclassify_is_byte_identical() -> None:
+    """REGRESSION: below_norm reclassification returns a frame-equal copy.
+
+    Proves the 0.80 × norm output is unchanged by the new norm-factor branch:
+    a hand-built pairs frame is returned identical (values and dtypes)."""
+    from forecast_skill_eval.events import event_by_name, reclassify_pairs_for_event
+
+    pairs = _obs_pairs(observed_values=[9.0, 5.0, 12.0], forecast_value=9.0)
+
+    event = event_by_name("below_norm")
+    result = reclassify_pairs_for_event(pairs, event, thresholds={})
+
+    pd.testing.assert_frame_equal(result, pairs)
+
+
+def test_below_norm_100_flips_rows_between_080_and_100_norm() -> None:
+    """A value in [0.80×norm, 1.0×norm) is 'normal' at below_norm but 'below' at 100.
+
+    norm=10 → below_norm threshold 8.0, below_norm_100 threshold 10.0.  A value
+    of 9.0 sits between the two.  The two events must classify the SAME rows
+    (identical row count / n_pairs), differing only in the TP/FP/FN/TN split.
+    """
+    from forecast_skill_eval.events import event_by_name, reclassify_pairs_for_event
+
+    # Row 0: fc=9, obs=9  → below_norm: TN;  below_norm_100: TP
+    # Row 1: fc=9, obs=5  → below_norm: FN;  below_norm_100: TP
+    # Row 2: fc=9, obs=12 → below_norm: TN;  below_norm_100: FP
+    pairs = _obs_pairs(observed_values=[9.0, 5.0, 12.0], forecast_value=9.0)
+
+    bn = reclassify_pairs_for_event(pairs, event_by_name("below_norm"), thresholds={})
+    bn100 = reclassify_pairs_for_event(pairs, event_by_name("below_norm_100"), thresholds={})
+
+    # Identical row set / n_pairs — norm-factor event drops no rows here.
+    assert len(bn) == len(bn100) == len(pairs)
+
+    # below_norm leaves the in-between rows classified as normal at 0.80.
+    assert list(bn["fc_class"]) == ["normal", "normal", "normal"]
+    assert list(bn["obs_class"]) == ["normal", "below", "normal"]
+
+    # below_norm_100 flips forecast to below for all three (all fc=9 < 10),
+    # and observed to below wherever obs < 10.
+    assert list(bn100["fc_class"]) == ["below", "below", "below"]
+    assert list(bn100["obs_class"]) == ["below", "below", "normal"]
+    assert list(bn100["contingency"]) == ["TP", "TP", "FP"]
+
+
+def test_below_norm_100_drops_rows_with_nonpositive_or_nonfinite_norm() -> None:
+    """Rows with norm <= 0 or non-finite norm are dropped (classifier → None)."""
+    from forecast_skill_eval.events import event_by_name, reclassify_pairs_for_event
+
+    pairs = _obs_pairs(observed_values=[9.0, 5.0, 12.0], forecast_value=9.0)
+    # Corrupt norm on two rows: one zero, one NaN.
+    pairs = pairs.copy()
+    pairs.loc[1, "norm"] = 0.0
+    pairs.loc[2, "norm"] = float("nan")
+
+    result = reclassify_pairs_for_event(pairs, event_by_name("below_norm_100"), thresholds={})
+
+    # Only the row with a finite, positive norm survives.
+    assert len(result) == 1
+    assert result.iloc[0]["contingency"] == "TP"

--- a/apps/forecast_skill_eval/tests/test_metrics.py
+++ b/apps/forecast_skill_eval/tests/test_metrics.py
@@ -36,12 +36,30 @@ def test_zero_denominators_emit_nan_and_undefined_flags() -> None:
     assert metrics["far_ci_undefined"] is True
 
 
-def test_hss_and_pss_are_undefined_when_observed_positives_are_zero() -> None:
+def test_pss_is_undefined_when_observed_positives_are_zero() -> None:
     metrics = metrics_from_counts({"TP": 0, "FP": 1, "FN": 0, "TN": 4})
 
-    assert math.isnan(metrics["hss"])
-    assert metrics["hss_undefined"] is True
     assert math.isnan(metrics["pss"])
     assert metrics["pss_undefined"] is True
     assert metrics["far"] == pytest.approx(1.0)
     assert metrics["pofd"] == pytest.approx(0.2)
+
+
+def test_hss_is_zero_when_zero_observed_events_but_denominator_finite() -> None:
+    # CORE-3: TP+FN == 0 with FP>0 and TN>0 → finite denominator, genuine HSS=0.
+    # TP=0,FP=1,FN=0,TN=16: denominator = 0*16 + 1*17 = 17, numerator = 0 → 0.0.
+    metrics = metrics_from_counts({"TP": 0, "FP": 1, "FN": 0, "TN": 16})
+
+    assert metrics["hss"] == pytest.approx(0.0)
+    assert metrics["hss_undefined"] is False
+    # PSS remains undefined — there are no observed positives.
+    assert math.isnan(metrics["pss"])
+    assert metrics["pss_undefined"] is True
+
+
+def test_hss_is_undefined_only_when_denominator_is_zero() -> None:
+    # All-zero counts → HSS denominator is 0 → genuinely undefined (NaN).
+    metrics = metrics_from_counts({"TP": 0, "FP": 0, "FN": 0, "TN": 0})
+
+    assert math.isnan(metrics["hss"])
+    assert metrics["hss_undefined"] is True

--- a/apps/forecast_skill_eval/tests/test_orchestrator.py
+++ b/apps/forecast_skill_eval/tests/test_orchestrator.py
@@ -219,6 +219,92 @@ def test_orchestrator_skips_failed_horizon_and_continues(
     assert bundle.exclusion_ledger.counts_by_stage_reason() == {("horizon", "horizon_error"): 1}
 
 
+# ---------------------------------------------------------------------------
+# Norm-factor event: below_norm_100 in the contingency pipeline
+# ---------------------------------------------------------------------------
+
+
+def _below_norm_pairs() -> pd.DataFrame:
+    """Build a small pentad pairs frame classified at 0.80 × norm (norm=10)."""
+    rows = []
+    specs = [(9.0, 9.0), (9.0, 5.0), (5.0, 5.0), (9.0, 12.0)]
+    for i, (fc, obs) in enumerate(specs):
+        fc_class = "below" if fc < 8.0 else "normal"
+        obs_class = "below" if obs < 8.0 else "normal"
+        if fc_class == "below" and obs_class == "below":
+            cont = "TP"
+        elif fc_class == "below":
+            cont = "FP"
+        elif obs_class == "below":
+            cont = "FN"
+        else:
+            cont = "TN"
+        rows.append(
+            {
+                "horizon": "pentad",
+                "code": STATION_CODE,
+                "basin": "other",
+                "period_key": 1,
+                "year": 2010 + i,
+                "model": "model-a",
+                "regime": "hindcast",
+                "season": "irrigation",
+                "lead": None,
+                "issue_date": None,
+                "forecast_value": fc,
+                "observed_value": obs,
+                "norm": 10.0,
+                "norm_provenance": "calculated",
+                "fc_class": fc_class,
+                "obs_class": obs_class,
+                "contingency": cont,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def test_compute_event_contingencies_includes_below_norm_100_when_requested() -> None:
+    """With both events requested, both appear and share identical n_pairs per group,
+    while below_norm rows are unchanged vs a below_norm-only run."""
+    from forecast_skill_eval.orchestrator import _compute_event_contingencies
+
+    pairs = _below_norm_pairs()
+
+    both = _compute_event_contingencies(pairs, {}, ("below_norm", "below_norm_100"))
+    bn_only = _compute_event_contingencies(pairs, {}, ("below_norm",))
+
+    # Both events present in the combined output.
+    assert set(both["event"].unique()) == {"below_norm", "below_norm_100"}
+
+    group_keys = [
+        "horizon",
+        "model",
+        "regime",
+        "season",
+        "code",
+        "basin",
+        "norm_provenance",
+        "lead",
+    ]
+
+    bn_rows = both[both["event"] == "below_norm"].reset_index(drop=True)
+    bn100_rows = both[both["event"] == "below_norm_100"].reset_index(drop=True)
+
+    # Identical n_pairs per matching group (same row set, differing only in split).
+    merged = bn_rows.merge(
+        bn100_rows,
+        on=group_keys,
+        suffixes=("_bn", "_bn100"),
+        how="inner",
+    )
+    assert len(merged) == len(bn_rows)
+    assert (merged["n_pairs_bn"] == merged["n_pairs_bn100"]).all()
+
+    # below_norm rows are byte-identical whether or not below_norm_100 is requested.
+    bn_only_rows = bn_only[bn_only["event"] == "below_norm"].reset_index(drop=True)
+    pd.testing.assert_frame_equal(bn_rows, bn_only_rows)
+
+
 def _daily_rows(*, year: int, month: int, value: float) -> list[dict[str, object]]:
     rows = []
     day = date(year, month, 1)
@@ -550,3 +636,90 @@ def test_value_flag_truthiness_accepts_true_string(
     assert not bundle.continuous_metrics.empty, (
         "SAPPHIRE_SKILL_VALUE='true' must enable value metrics"
     )
+
+
+# ---------------------------------------------------------------------------
+# P1b: below_norm_100 full-parity (economic value / baselines / prob) invariant
+# ---------------------------------------------------------------------------
+
+
+def _band_client(fake_client_factory):
+    return fake_client_factory(
+        forecasts_rows=[_FORECAST_WITH_BAND],
+        runoff_rows=[_RUNOFF_PENTAD],
+        hydrograph_rows=[_HYDROGRAPH_PENTAD],
+    )
+
+
+def test_economic_value_includes_below_norm_100_when_requested(
+    fake_client_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SAPPHIRE_SKILL_VALUE", "1")
+    config = ForecastSkillEvalConfig(
+        horizons=["pentad"],
+        station_filter=[STATION_CODE],
+        events_filter=("below_norm", "below_norm_100"),
+    )
+    bundle = run(config, _band_client(fake_client_factory), run_id="ev-100")
+
+    assert {"below_norm", "below_norm_100"} <= set(bundle.economic_value["event"].unique())
+    assert {"below_norm", "below_norm_100"} <= set(bundle.economic_value_summary["event"].unique())
+    # 0.80 rows are ordered first (deterministic).
+    events_in_order = bundle.economic_value["event"].tolist()
+    first_100 = events_in_order.index("below_norm_100")
+    assert all(e == "below_norm" for e in events_in_order[:first_100])
+
+
+def test_below_norm_100_is_purely_additive_across_all_frames(
+    fake_client_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ABSOLUTE INVARIANT: adding below_norm_100 leaves the below_norm slice
+    of every output frame (contingency, prob, economic value + summary,
+    baselines) byte-identical to a below_norm-only run."""
+    monkeypatch.setenv("SAPPHIRE_SKILL_PROB", "1")
+    monkeypatch.setenv("SAPPHIRE_SKILL_VALUE", "1")
+
+    only = run(
+        ForecastSkillEvalConfig(
+            horizons=["pentad"],
+            station_filter=[STATION_CODE],
+            events_filter=("below_norm",),
+        ),
+        _band_client(fake_client_factory),
+        run_id="only",
+    )
+    both = run(
+        ForecastSkillEvalConfig(
+            horizons=["pentad"],
+            station_filter=[STATION_CODE],
+            events_filter=("below_norm", "below_norm_100"),
+        ),
+        _band_client(fake_client_factory),
+        run_id="both",
+    )
+
+    def _bn(df: pd.DataFrame) -> pd.DataFrame:
+        return df[df["event"] == "below_norm"].reset_index(drop=True)
+
+    def _nonfactor_prob(df: pd.DataFrame) -> pd.DataFrame:
+        return df[df["event"].isin(["distribution", "below_norm"])].reset_index(drop=True)
+
+    # Byte-identical below_norm slice across all four frame families.
+    pd.testing.assert_frame_equal(_bn(only.contingency_metrics), _bn(both.contingency_metrics))
+    pd.testing.assert_frame_equal(_bn(only.baselines), _bn(both.baselines))
+    pd.testing.assert_frame_equal(_bn(only.economic_value), _bn(both.economic_value))
+    pd.testing.assert_frame_equal(
+        _bn(only.economic_value_summary), _bn(both.economic_value_summary)
+    )
+    pd.testing.assert_frame_equal(
+        _nonfactor_prob(only.prob_metrics), _nonfactor_prob(both.prob_metrics)
+    )
+
+    # And the both-run actually carries the new below_norm_100 rows everywhere.
+    assert "below_norm_100" in set(both.contingency_metrics["event"])
+    assert "below_norm_100" in set(both.baselines["event"])
+    assert "below_norm_100" in set(both.economic_value["event"])
+    assert "below_norm_100" in set(both.economic_value_summary["event"])
+    assert "below_norm_100" in set(both.prob_metrics["event"])

--- a/apps/forecast_skill_eval/tests/test_pairs.py
+++ b/apps/forecast_skill_eval/tests/test_pairs.py
@@ -9,7 +9,12 @@ import pytest
 from forecast_skill_eval.baselines import build_operational_proxy_baseline
 from forecast_skill_eval.config import ForecastSkillEvalConfig
 from forecast_skill_eval.ledger import ExclusionLedger
-from forecast_skill_eval.pairs import _read_short_forecasts, basin_for_code, build_pairs
+from forecast_skill_eval.pairs import (
+    _read_short_forecasts,
+    _target_period_start,
+    basin_for_code,
+    build_pairs,
+)
 from forecast_skill_eval.regimes import RegimePolicy, choose_regime_policy, derive_regime
 
 STATION_CODE = "19999"
@@ -227,6 +232,82 @@ def test_flag_regime_derivation_uses_taxonomy_and_date_fallback(
 
     assert decision.regime == expected_regime
     assert decision.exclude_reason == expected_reason
+
+
+def test_regime_source_auto_matches_default_on_flag_rich_frame() -> None:
+    """regime_source='auto' reproduces the no-arg policy on a flag-rich frame."""
+    frame = _flag_frame(([4] * 1100) + ([0] * 10))
+    default_policy = choose_regime_policy(frame)
+    auto_policy = choose_regime_policy(frame, regime_source="auto")
+
+    assert default_policy.source == "flag"
+    assert auto_policy.source == default_policy.source
+    assert auto_policy.reason == default_policy.reason
+    assert auto_policy.flag_counts == default_policy.flag_counts
+
+
+def test_regime_source_auto_matches_default_on_flag_sparse_frame() -> None:
+    """regime_source='auto' reproduces the no-arg policy on a flag-sparse frame."""
+    frame = _flag_frame([0] * 20)
+    default_policy = choose_regime_policy(frame)
+    auto_policy = choose_regime_policy(frame, regime_source="auto")
+
+    assert default_policy.source == "date"
+    assert auto_policy.source == default_policy.source
+    assert auto_policy.reason == default_policy.reason
+    assert auto_policy.flag_counts == default_policy.flag_counts
+
+
+def test_regime_source_flag_forces_flag_on_sparse_frame() -> None:
+    """regime_source='flag' forces flag mode even when auto would pick date."""
+    frame = _flag_frame([0] * 20)
+
+    assert choose_regime_policy(frame).source == "date"
+    forced = choose_regime_policy(frame, regime_source="flag")
+    assert forced.source == "flag"
+    assert forced.reason == "regime source forced to flag"
+
+
+def test_regime_source_date_forces_date_on_flag_rich_frame() -> None:
+    """regime_source='date' forces date mode even when auto would pick flag."""
+    frame = _flag_frame(([4] * 1100) + ([0] * 10))
+
+    assert choose_regime_policy(frame).source == "flag"
+    forced = choose_regime_policy(frame, regime_source="date")
+    assert forced.source == "date"
+    assert forced.reason == "regime source forced to issue date"
+
+
+@pytest.mark.parametrize("source", ["flag", "date"])
+def test_nan_flag_excluded_in_both_modes(source: str) -> None:
+    """REG-5: a flag-3 (nan) row is excluded regardless of regime source."""
+    policy = RegimePolicy(
+        source=source,
+        operational_start=date(2024, 1, 1),
+        reason="test",
+        flag_counts={},
+    )
+
+    decision = derive_regime({"flag": 3}, issue_date="2025-01-01", policy=policy)
+
+    assert decision.regime is None
+    assert decision.exclude_reason == "forecast_actual_nan_flag"
+
+
+@pytest.mark.parametrize("source", ["flag", "date"])
+def test_error_flag_excluded_in_both_modes(source: str) -> None:
+    """A flag-2 (error) row is excluded regardless of regime source."""
+    policy = RegimePolicy(
+        source=source,
+        operational_start=date(2024, 1, 1),
+        reason="test",
+        flag_counts={},
+    )
+
+    decision = derive_regime({"flag": 2}, issue_date="2025-01-01", policy=policy)
+
+    assert decision.regime is None
+    assert decision.exclude_reason == "forecast_error_flag"
 
 
 def test_flagless_lr_rows_date_fallback_match_flagged_operational_ml(
@@ -940,3 +1021,219 @@ def test_pairs_quantile_columns_do_not_alter_existing_columns(fake_client_factor
     assert row["obs_class"] == "below"  # 7.0 < threshold → below
     assert row["contingency"] == "FN"
     assert ledger.entries == ()
+
+
+# ---------------------------------------------------------------------------
+# Short-term issue-before-target filter + one-per-target dedup (default off)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("horizon", "period_key", "year", "expected"),
+    [
+        ("decade", 16, 2025, date(2025, 6, 1)),  # 6th decade → month 6, day 1
+        ("decade", 1, 2025, date(2025, 1, 1)),
+        ("decade", 3, 2025, date(2025, 1, 21)),
+        ("pentad", 1, 2025, date(2025, 1, 1)),
+        ("pentad", 7, 2025, date(2025, 2, 1)),  # first pentad of month 2
+        ("pentad", 6, 2025, date(2025, 1, 26)),
+        ("day", 1, 2025, date(2025, 1, 1)),
+        ("day", 60, 2024, date(2024, 2, 29)),  # leap-year day-of-year
+    ],
+)
+def test_target_period_start_maps_short_term_periods(
+    horizon: str,
+    period_key: int,
+    year: int,
+    expected: date,
+) -> None:
+    assert _target_period_start(horizon, period_key, year) == expected
+
+
+@pytest.mark.parametrize(
+    ("horizon", "period_key", "year"),
+    [
+        ("decade", 0, 2025),  # month 0 → invalid
+        ("decade", 37, 2025),  # month 13 → invalid
+        ("pentad", 0, 2025),
+        ("pentad", 73, 2025),
+        ("month", 4, 2025),  # long-term → filter N/A
+        ("quarter", 2, 2025),
+        ("season", 1, 2025),
+    ],
+)
+def test_target_period_start_returns_none_for_invalid_or_long_term(
+    horizon: str,
+    period_key: int,
+    year: int,
+) -> None:
+    assert _target_period_start(horizon, period_key, year) is None
+
+
+def _issue_filter_client(fake_client_factory):
+    # day period_key 5 → target start 2024-01-05; period_key 6 → 2024-01-06.
+    return fake_client_factory(
+        forecasts_rows=[
+            _short_forecast(5, 7.0, issue_date="2024-01-01"),  # before start → keep
+            _short_forecast(6, 7.0, issue_date="2024-01-10"),  # after start → drop
+        ],
+        runoff_rows=[
+            _short_observed(5, 2024, 7.0),
+            _short_observed(6, 2024, 7.0),
+        ],
+        hydrograph_rows=[_day_norm(5), _day_norm(6)],
+    )
+
+
+def test_issue_before_target_filter_drops_leaking_short_term_forecast(
+    fake_client_factory,
+) -> None:
+    client = _issue_filter_client(fake_client_factory)
+    config = ForecastSkillEvalConfig(
+        station_filter=[STATION_CODE],
+        short_term_issue_before_target=True,
+    )
+
+    pairs, ledger = build_pairs(config, client, "day")
+
+    assert pairs["period_key"].tolist() == [5]
+    assert ledger.counts_by_stage_reason() == {("pair", "forecast_issue_in_target_period"): 1}
+
+
+def test_issue_before_target_filter_off_by_default_keeps_all(
+    fake_client_factory,
+) -> None:
+    client = _issue_filter_client(fake_client_factory)
+    config = ForecastSkillEvalConfig(station_filter=[STATION_CODE])
+
+    pairs, ledger = build_pairs(config, client, "day")
+
+    assert sorted(pairs["period_key"].tolist()) == [5, 6]
+    assert ("pair", "forecast_issue_in_target_period") not in ledger.counts_by_stage_reason()
+
+
+def test_unparseable_issue_date_is_not_dropped_by_filter(
+    fake_client_factory,
+) -> None:
+    # An unparseable issue date makes the issue-before-target guard a no-op, so
+    # turning the filter on must produce the exact same outcome as leaving it off
+    # (whatever downstream regime handling does is identical in both runs).
+    def _client():
+        return fake_client_factory(
+            forecasts_rows=[_short_forecast(6, 7.0, issue_date="not-a-date")],
+            runoff_rows=[_short_observed(6, 2024, 7.0)],
+            hydrograph_rows=[_day_norm(6)],
+        )
+
+    off_pairs, off_ledger = build_pairs(
+        ForecastSkillEvalConfig(station_filter=[STATION_CODE]),
+        _client(),
+        "day",
+    )
+    on_pairs, on_ledger = build_pairs(
+        ForecastSkillEvalConfig(
+            station_filter=[STATION_CODE],
+            short_term_issue_before_target=True,
+        ),
+        _client(),
+        "day",
+    )
+
+    pd.testing.assert_frame_equal(on_pairs, off_pairs)
+    assert on_ledger.counts_by_stage_reason() == off_ledger.counts_by_stage_reason()
+    assert ("pair", "forecast_issue_in_target_period") not in on_ledger.counts_by_stage_reason()
+
+
+def _reissue_client(fake_client_factory):
+    # Three genuine pre-period re-issues for the same (code, pk, year, model).
+    return fake_client_factory(
+        forecasts_rows=[
+            _short_forecast(10, 7.0, model_type="TFT", issue_date="2024-01-01"),
+            _short_forecast(10, 7.0, model_type="TFT", issue_date="2024-01-02"),
+            _short_forecast(10, 7.0, model_type="TFT", issue_date="2024-01-03"),
+        ],
+        runoff_rows=[_short_observed(10, 2024, 7.0)],
+        hydrograph_rows=[_day_norm(10)],
+    )
+
+
+def test_dedup_one_per_target_keeps_latest_issue(fake_client_factory) -> None:
+    client = _reissue_client(fake_client_factory)
+    config = ForecastSkillEvalConfig(
+        station_filter=[STATION_CODE],
+        short_term_dedup_one_per_target=True,
+    )
+
+    pairs, _ledger = build_pairs(config, client, "day")
+
+    assert len(pairs) == 1
+    assert pairs.iloc[0]["issue_date"] == "2024-01-03"
+    assert pairs.iloc[0]["period_key"] == 10
+
+
+def test_dedup_off_by_default_keeps_all_reissues(fake_client_factory) -> None:
+    client = _reissue_client(fake_client_factory)
+    config = ForecastSkillEvalConfig(station_filter=[STATION_CODE])
+
+    pairs, _ledger = build_pairs(config, client, "day")
+
+    assert len(pairs) == 3
+    assert sorted(pairs["issue_date"].tolist()) == [
+        "2024-01-01",
+        "2024-01-02",
+        "2024-01-03",
+    ]
+
+
+def test_long_term_horizons_unaffected_by_short_term_gates(
+    fake_client_factory,
+) -> None:
+    # Two month re-issues for the same target period; one issued INSIDE April.
+    # Neither short-term gate may touch long-term pairs.
+    client = fake_client_factory(
+        long_forecasts_rows=[
+            _long_forecast(issue_date="2024-01-25"),
+            _long_forecast(issue_date="2024-04-15"),  # inside target month
+        ],
+        runoff_rows=_daily_rows(year=2024, month=4, value=7.0),
+        hydrograph_rows=[_april_hydrograph_norm()],
+    )
+    config = ForecastSkillEvalConfig(
+        station_filter=[STATION_CODE],
+        short_term_issue_before_target=True,
+        short_term_dedup_one_per_target=True,
+    )
+
+    pairs, ledger = build_pairs(config, client, "month")
+
+    assert len(pairs) == 2
+    assert ("pair", "forecast_issue_in_target_period") not in ledger.counts_by_stage_reason()
+
+
+def test_default_config_run_is_byte_identical_with_leakage_and_reissues(
+    fake_client_factory,
+) -> None:
+    # Fixture mixes a leaking issue (pk 6 issued after start) with three re-issues
+    # (pk 10).  With both gates off (default) every row must survive unchanged.
+    client = fake_client_factory(
+        forecasts_rows=[
+            _short_forecast(5, 7.0, issue_date="2024-01-01"),
+            _short_forecast(6, 7.0, issue_date="2024-01-10"),
+            _short_forecast(10, 7.0, model_type="TFT", issue_date="2024-01-01"),
+            _short_forecast(10, 7.0, model_type="TFT", issue_date="2024-01-02"),
+            _short_forecast(10, 7.0, model_type="TFT", issue_date="2024-01-03"),
+        ],
+        runoff_rows=[
+            _short_observed(5, 2024, 7.0),
+            _short_observed(6, 2024, 7.0),
+            _short_observed(10, 2024, 7.0),
+        ],
+        hydrograph_rows=[_day_norm(5), _day_norm(6), _day_norm(10)],
+    )
+    config = ForecastSkillEvalConfig(station_filter=[STATION_CODE])
+
+    pairs, ledger = build_pairs(config, client, "day")
+
+    assert len(pairs) == 5
+    assert sorted(pairs["period_key"].tolist()) == [5, 6, 10, 10, 10]
+    assert ("pair", "forecast_issue_in_target_period") not in ledger.counts_by_stage_reason()

--- a/apps/forecast_skill_eval/tests/test_pairs.py
+++ b/apps/forecast_skill_eval/tests/test_pairs.py
@@ -8,8 +8,10 @@ import pytest
 
 from forecast_skill_eval.baselines import build_operational_proxy_baseline
 from forecast_skill_eval.config import ForecastSkillEvalConfig
+from forecast_skill_eval.contingency import count_contingencies
 from forecast_skill_eval.ledger import ExclusionLedger
 from forecast_skill_eval.pairs import (
+    _derive_long_lead,
     _read_short_forecasts,
     _target_period_start,
     basin_for_code,
@@ -1237,3 +1239,343 @@ def test_default_config_run_is_byte_identical_with_leakage_and_reissues(
     assert len(pairs) == 5
     assert sorted(pairs["period_key"].tolist()) == [5, 6, 10, 10, 10]
     assert ("pair", "forecast_issue_in_target_period") not in ledger.counts_by_stage_reason()
+
+
+# ---------------------------------------------------------------------------
+# Long-term derive-lead correctness gate (default off)
+# ---------------------------------------------------------------------------
+
+
+def _quarter_norm(quarter: int, norm: float = 10.0) -> dict[str, object]:
+    return {
+        "horizon": "quarter",
+        "code": STATION_CODE,
+        "horizon_in_year": quarter,
+        "norm": norm,
+    }
+
+
+def _season_norm(norm: float = 10.0) -> dict[str, object]:
+    return {
+        "horizon": "season",
+        "code": STATION_CODE,
+        "horizon_in_year": 1,
+        "norm": norm,
+    }
+
+
+# Aligned validity windows for the four calendar quarters.
+_QUARTER_WINDOW = {
+    1: ("01-01", "03-31", (1, 2, 3)),
+    2: ("04-01", "06-30", (4, 5, 6)),
+    3: ("07-01", "09-30", (7, 8, 9)),
+    4: ("10-01", "12-31", (10, 11, 12)),
+}
+
+
+def _quarter_runoff(year: int, quarter: int, value: float = 7.0) -> list[dict[str, object]]:
+    _start, _end, months = _QUARTER_WINDOW[quarter]
+    rows: list[dict[str, object]] = []
+    for month in months:
+        rows.extend(_daily_rows(year=year, month=month, value=value))
+    return rows
+
+
+def _season_runoff(year: int, value: float = 7.0) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for month in range(4, 10):  # Apr–Sep
+        rows.extend(_daily_rows(year=year, month=month, value=value))
+    return rows
+
+
+def test_derive_long_lead_quarter_season_and_underivable() -> None:
+    # Quarter Q2 (target month 4): lead = 4 - issue_month within the same year.
+    assert _derive_long_lead("quarter", 2, "2024-03-25", 2024) == 1
+    assert _derive_long_lead("quarter", 2, "2024-04-10", 2024) == 0
+    # Quarter Q4 (target month 10): {0, 1} for late-summer / in-quarter issuances.
+    assert _derive_long_lead("quarter", 4, "2024-09-25", 2024) == 1
+    assert _derive_long_lead("quarter", 4, "2024-10-05", 2024) == 0
+    # Season (target month 4 = April): spans leads 0..3 across the issue months.
+    assert _derive_long_lead("season", 1, "2024-01-15", 2024) == 3
+    assert _derive_long_lead("season", 1, "2024-02-10", 2024) == 2
+    assert _derive_long_lead("season", 1, "2024-03-01", 2024) == 1
+    assert _derive_long_lead("season", 1, "2024-04-01", 2024) == 0
+    # Cross-year issuance (Q1 target month 1, issued the prior December).
+    assert _derive_long_lead("quarter", 1, "2023-12-25", 2024) == 1
+    # Underivable: no issue date, missing year, or unmappable period key.
+    assert _derive_long_lead("quarter", 2, None, 2024) is None
+    assert _derive_long_lead("quarter", 2, "2024-03-25", None) is None
+    assert _derive_long_lead("quarter", 9, "2024-03-25", 2024) is None
+
+
+def test_quarter_flag_off_is_byte_identical_to_legacy(fake_client_factory) -> None:
+    # Two re-issues of the same Q2/2024 target.  With the flag OFF the legacy
+    # behaviour keeps BOTH rows and the "lead" column carries the stored
+    # horizon_value (here a deliberately distinct sentinel 9, not the quarter).
+    def _client():
+        return fake_client_factory(
+            long_forecasts_rows=[
+                _long_forecast(
+                    horizon="quarter",
+                    issue_date="2024-03-25",
+                    valid_from="2024-04-01",
+                    valid_to="2024-06-30",
+                    horizon_value=9,
+                    value=7.0,
+                ),
+                _long_forecast(
+                    horizon="quarter",
+                    issue_date="2024-04-10",
+                    valid_from="2024-04-01",
+                    valid_to="2024-06-30",
+                    horizon_value=9,
+                    value=7.0,
+                ),
+            ],
+            runoff_rows=_quarter_runoff(2024, 2),
+            hydrograph_rows=[_quarter_norm(2)],
+        )
+
+    off_pairs, off_ledger = build_pairs(
+        ForecastSkillEvalConfig(station_filter=[STATION_CODE]),
+        _client(),
+        "quarter",
+    )
+
+    assert len(off_pairs) == 2
+    assert off_pairs["lead"].tolist() == [9, 9]
+    assert ("pair", "long_forecast_lead_underivable") not in off_ledger.counts_by_stage_reason()
+
+    # Flipping the flag ON must change the outcome (dedup to one, lead = quarter).
+    on_pairs, _on_ledger = build_pairs(
+        ForecastSkillEvalConfig(station_filter=[STATION_CODE], long_term_derive_lead=True),
+        _client(),
+        "quarter",
+    )
+    assert len(on_pairs) == 1
+    assert on_pairs.iloc[0]["lead"] == 2
+
+
+def test_quarter_flag_on_dedups_two_sources_to_smallest_lead(fake_client_factory) -> None:
+    # Two sources for the SAME Q2/2024 target: one issued in March (lead 1) and
+    # one issued in April (lead 0).  Under the flag they collapse to one deduped
+    # pair keeping the smallest-lead (April) issuance.
+    client = fake_client_factory(
+        long_forecasts_rows=[
+            _long_forecast(
+                horizon="quarter",
+                issue_date="2024-03-25",  # lead 1
+                valid_from="2024-04-01",
+                valid_to="2024-06-30",
+                horizon_value=2,
+                value=7.0,
+            ),
+            _long_forecast(
+                horizon="quarter",
+                issue_date="2024-04-10",  # lead 0 (smallest → wins)
+                valid_from="2024-04-01",
+                valid_to="2024-06-30",
+                horizon_value=2,
+                value=7.0,
+            ),
+        ],
+        runoff_rows=_quarter_runoff(2024, 2),
+        hydrograph_rows=[_quarter_norm(2)],
+    )
+    config = ForecastSkillEvalConfig(station_filter=[STATION_CODE], long_term_derive_lead=True)
+
+    pairs, _ledger = build_pairs(config, client, "quarter")
+
+    assert len(pairs) == 1
+    row = pairs.iloc[0]
+    assert row["issue_date"] == "2024-04-10"  # smallest derived lead retained
+    assert row["period_key"] == 2
+    assert row["lead"] == 2  # stratified by target quarter
+
+
+def test_quarter_flag_on_stratifies_contingency_per_target_quarter(
+    fake_client_factory,
+) -> None:
+    # One aligned forecast per calendar quarter of 2024.  Under the flag the
+    # quarter contingency must break out one per-target-quarter row (Q1–Q4),
+    # carrying the target quarter in the "lead" column.
+    long_rows = [
+        _long_forecast(
+            horizon="quarter",
+            issue_date="2023-12-25" if q == 1 else f"2024-{_QUARTER_WINDOW[q][0]}",
+            valid_from=f"2024-{_QUARTER_WINDOW[q][0]}",
+            valid_to=f"2024-{_QUARTER_WINDOW[q][1]}",
+            horizon_value=q,
+            value=7.0,
+        )
+        for q in (1, 2, 3, 4)
+    ]
+    runoff_rows: list[dict[str, object]] = []
+    for q in (1, 2, 3, 4):
+        runoff_rows.extend(_quarter_runoff(2024, q))
+    client = fake_client_factory(
+        long_forecasts_rows=long_rows,
+        runoff_rows=runoff_rows,
+        hydrograph_rows=[_quarter_norm(q) for q in (1, 2, 3, 4)],
+    )
+    config = ForecastSkillEvalConfig(station_filter=[STATION_CODE], long_term_derive_lead=True)
+
+    pairs, _ledger = build_pairs(config, client, "quarter")
+
+    assert len(pairs) == 4
+    assert sorted(pairs["lead"].tolist()) == [1, 2, 3, 4]
+
+    contingency = count_contingencies(pairs)
+    pooled = contingency[
+        (contingency["code"] == "POOLED")
+        & (contingency["basin"] == "all")
+        & (contingency["norm_provenance"] == "all")
+        & (contingency["regime"] == "all")
+        & (contingency["season"] == "all")
+    ]
+    assert sorted(pooled["lead"].tolist()) == [1, 2, 3, 4]
+    assert (pooled["n_pairs"] == 1).all()
+
+
+def test_season_flag_on_keeps_all_leads_and_dedups_reissues(fake_client_factory) -> None:
+    # A single Apr–Sep season (2024) issued at all four leads 0–3.  Unlike quarter,
+    # season's period_key is the constant 1, so the derived lead MUST enter the
+    # dedup key: all four genuine leads are retained (like month), and only a true
+    # re-issue WITHIN a lead is collapsed (here lead 1 has two issuances → keep the
+    # latest).  Season keeps the derived lead as the stratifier (never period_key).
+    client = fake_client_factory(
+        long_forecasts_rows=[
+            _long_forecast(
+                horizon="season",
+                issue_date="2024-01-15",  # lead 3
+                valid_from="2024-04-01",
+                valid_to="2024-09-30",
+                horizon_value=1,
+                value=7.0,
+            ),
+            _long_forecast(
+                horizon="season",
+                issue_date="2024-02-10",  # lead 2
+                valid_from="2024-04-01",
+                valid_to="2024-09-30",
+                horizon_value=1,
+                value=7.0,
+            ),
+            _long_forecast(
+                horizon="season",
+                issue_date="2024-03-01",  # lead 1
+                valid_from="2024-04-01",
+                valid_to="2024-09-30",
+                horizon_value=1,
+                value=7.0,
+            ),
+            _long_forecast(
+                horizon="season",
+                issue_date="2024-03-20",  # lead 1 re-issue (latest → wins)
+                valid_from="2024-04-01",
+                valid_to="2024-09-30",
+                horizon_value=1,
+                value=7.0,
+            ),
+            _long_forecast(
+                horizon="season",
+                issue_date="2024-04-01",  # lead 0
+                valid_from="2024-04-01",
+                valid_to="2024-09-30",
+                horizon_value=1,
+                value=7.0,
+            ),
+        ],
+        runoff_rows=_season_runoff(2024),
+        hydrograph_rows=[_season_norm()],
+    )
+    config = ForecastSkillEvalConfig(station_filter=[STATION_CODE], long_term_derive_lead=True)
+
+    pairs, _ledger = build_pairs(config, client, "season")
+
+    # All four genuine leads retained; the lead-1 re-issue collapsed to one.
+    assert sorted(pairs["lead"].tolist()) == [0, 1, 2, 3]
+    assert (pairs["period_key"] == 1).all()  # lead NOT overwritten by period_key
+    issue_by_lead = dict(zip(pairs["lead"], pairs["issue_date"], strict=True))
+    assert issue_by_lead[1] == "2024-03-20"  # latest issue within lead 1
+
+    # Season contingency stratifies per genuine lead 0–3.
+    contingency = count_contingencies(pairs)
+    pooled = contingency[
+        (contingency["code"] == "POOLED")
+        & (contingency["basin"] == "all")
+        & (contingency["norm_provenance"] == "all")
+        & (contingency["regime"] == "all")
+        & (contingency["season"] == "all")
+    ]
+    assert sorted(pooled["lead"].tolist()) == [0, 1, 2, 3]
+
+
+def test_month_unchanged_under_long_term_derive_lead(fake_client_factory) -> None:
+    # Month's stored horizon_value already IS the lead; the flag must not touch it,
+    # dedup it, or drop it as underivable.
+    def _client():
+        return fake_client_factory(
+            long_forecasts_rows=[
+                _long_forecast(issue_date="2024-01-25", horizon_value=3),
+                _long_forecast(issue_date="2024-02-25", horizon_value=2),
+            ],
+            runoff_rows=_daily_rows(year=2024, month=4, value=7.0),
+            hydrograph_rows=[_april_hydrograph_norm()],
+        )
+
+    off_pairs, _ = build_pairs(
+        ForecastSkillEvalConfig(station_filter=[STATION_CODE]),
+        _client(),
+        "month",
+    )
+    on_pairs, on_ledger = build_pairs(
+        ForecastSkillEvalConfig(station_filter=[STATION_CODE], long_term_derive_lead=True),
+        _client(),
+        "month",
+    )
+
+    pd.testing.assert_frame_equal(on_pairs, off_pairs)
+    assert sorted(on_pairs["lead"].tolist()) == [2, 3]
+    assert ("pair", "long_forecast_lead_underivable") not in on_ledger.counts_by_stage_reason()
+
+
+def test_quarter_underivable_lead_dropped_under_flag(fake_client_factory) -> None:
+    # A calendar-aligned quarter forecast with NO issue date: under the flag it
+    # cannot yield a lead, so it is dropped with the dedicated ledger reason
+    # instead of pooling as an aggregated (lead-less) row.
+    dateless_row = {
+        "horizon": "quarter",
+        "code": STATION_CODE,
+        "valid_from": "2024-04-01",
+        "valid_to": "2024-06-30",
+        "horizon_value": 2,
+        "model_type": "model-a",
+        "q": 7.0,
+    }
+
+    def _client():
+        return fake_client_factory(
+            long_forecasts_rows=[dateless_row],
+            runoff_rows=_quarter_runoff(2024, 2),
+            hydrograph_rows=[_quarter_norm(2)],
+        )
+
+    # OFF: legacy behaviour never reaches the underivable guard.  (A date-less row
+    # cannot form a pair anyway — the regime step drops it — but crucially NOT with
+    # the derive-lead reason.)
+    _off_pairs, off_ledger = build_pairs(
+        ForecastSkillEvalConfig(station_filter=[STATION_CODE]),
+        _client(),
+        "quarter",
+    )
+    assert ("pair", "long_forecast_lead_underivable") not in off_ledger.counts_by_stage_reason()
+
+    # ON: dropped early as underivable, before the regime step even runs.
+    on_pairs, on_ledger = build_pairs(
+        ForecastSkillEvalConfig(station_filter=[STATION_CODE], long_term_derive_lead=True),
+        _client(),
+        "quarter",
+    )
+    assert on_pairs.empty
+    assert on_ledger.counts_by_stage_reason() == {("pair", "long_forecast_lead_underivable"): 1}

--- a/apps/forecast_skill_eval/tests/test_prob_metrics.py
+++ b/apps/forecast_skill_eval/tests/test_prob_metrics.py
@@ -14,6 +14,9 @@ import pytest
 from forecast_skill_eval.prob_metrics import (
     PROB_METRIC_COLUMNS,
     PROB_RELIABILITY_COLUMNS,
+    _aggregate_brier,
+    _crpss_paired,
+    _rank_calibration_error,
     _score_pairs,
     brier_score,
     build_prob_reliability,
@@ -821,3 +824,236 @@ class TestBuildProbReliability:
         pooled = result[result["code"] == "POOLED"]
         if len(pooled) > 0:
             assert pooled["n"].max() == n
+
+
+# ===========================================================================
+# P1b: norm-factor Brier parity (below_norm_100)
+# ===========================================================================
+
+
+_NF_KEYS = [
+    "horizon",
+    "model",
+    "regime",
+    "season",
+    "code",
+    "basin",
+    "norm_provenance",
+]
+
+
+class TestNormFactorBrier:
+    def test_default_empty_norm_factor_events_is_frame_equal(self):
+        """Default ``norm_factor_events=()`` must be byte-identical to today."""
+        pairs = _make_scored_pairs()
+        base = compute_probabilistic_metrics(pairs, {}, {}, ("below_norm",))
+        same = compute_probabilistic_metrics(pairs, {}, {}, ("below_norm",), norm_factor_events=())
+        pd.testing.assert_frame_equal(base, same)
+
+    def test_norm_factor_events_not_passed_has_no_effect(self):
+        """Even with below_norm_100 in events_filter, no rows appear unless the
+        EventDef is passed via ``norm_factor_events``."""
+        pairs = _make_scored_pairs()
+        result = compute_probabilistic_metrics(pairs, {}, {}, ("below_norm", "below_norm_100"))
+        assert "below_norm_100" not in set(result["event"].unique())
+
+    def test_below_norm_100_adds_brier_only_rows_no_extra_distribution(self):
+        from forecast_skill_eval.events import event_by_name
+
+        pairs = _make_scored_pairs()
+        ev = event_by_name("below_norm_100")
+
+        without = compute_probabilistic_metrics(pairs, {}, {}, ("below_norm", "below_norm_100"))
+        result = compute_probabilistic_metrics(
+            pairs,
+            {},
+            {},
+            ("below_norm", "below_norm_100"),
+            norm_factor_events=(ev,),
+        )
+
+        events = set(result["event"].unique())
+        assert "below_norm_100" in events
+        assert "distribution" in events
+        assert "below_norm" in events
+
+        # No extra distribution rows are introduced by the norm-factor pass.
+        n_dist_without = int((without["event"] == "distribution").sum())
+        n_dist_result = int((result["event"] == "distribution").sum())
+        assert n_dist_result == n_dist_without
+
+        # below_norm_100 rows are Brier-only (NaN CRPS / coverage).
+        bn100 = result[result["event"] == "below_norm_100"]
+        assert bn100["crps"].isna().all()
+        assert bn100["coverage_90"].isna().all()
+
+    def test_below_norm_100_matches_below_norm_group_keys_and_n_pairs(self):
+        from forecast_skill_eval.events import event_by_name
+
+        pairs = _make_scored_pairs()
+        ev = event_by_name("below_norm_100")
+        result = compute_probabilistic_metrics(
+            pairs,
+            {},
+            {},
+            ("below_norm", "below_norm_100"),
+            norm_factor_events=(ev,),
+        )
+        bn = result[result["event"] == "below_norm"].reset_index(drop=True)
+        bn100 = result[result["event"] == "below_norm_100"].reset_index(drop=True)
+
+        # The norm-factor pass reuses the exact same slice/group reducer over a
+        # frame with identical group-key columns, so the Brier rows are emitted
+        # in the same order with the same group keys and the same n_pairs.
+        key_cols = [*_NF_KEYS, "lead", "n_pairs"]
+        pd.testing.assert_frame_equal(
+            bn[key_cols].reset_index(drop=True),
+            bn100[key_cols].reset_index(drop=True),
+        )
+
+    def test_below_norm_only_rows_unchanged_by_norm_factor_pass(self):
+        """distribution + below_norm rows must be byte-identical whether or not
+        the below_norm_100 Brier pass runs."""
+        from forecast_skill_eval.events import event_by_name
+
+        pairs = _make_scored_pairs()
+        ev = event_by_name("below_norm_100")
+
+        base = compute_probabilistic_metrics(pairs, {}, {}, ("below_norm", "below_norm_100"))
+        result = compute_probabilistic_metrics(
+            pairs,
+            {},
+            {},
+            ("below_norm", "below_norm_100"),
+            norm_factor_events=(ev,),
+        )
+
+        def _nonfactor(df: pd.DataFrame) -> pd.DataFrame:
+            return df[df["event"].isin(["distribution", "below_norm"])].reset_index(drop=True)
+
+        pd.testing.assert_frame_equal(_nonfactor(base), _nonfactor(result))
+
+
+# ===========================================================================
+# CORE-4: rank_calibration_error — proper PIT divergence (0 = calibrated)
+# ===========================================================================
+
+
+class TestRankCalibrationError:
+    def test_perfectly_uniform_ranks_gives_zero(self):
+        # Exact Uniform PIT: ranks at the expected (i-0.5)/n quantiles → 0.
+        n = 20
+        ranks = pd.Series([(i - 0.5) / n for i in range(1, n + 1)])
+        assert _rank_calibration_error(ranks) == pytest.approx(0.0, abs=1e-12)
+
+    def test_old_definition_would_have_been_nonzero_for_calibrated(self):
+        # Guard against regressing to mean|rank-0.5|, which was 0.25 here.
+        n = 20
+        ranks = pd.Series([(i - 0.5) / n for i in range(1, n + 1)])
+        assert _rank_calibration_error(ranks) < 0.01
+
+    def test_overdispersed_ranks_clumped_near_half_gives_positive(self):
+        # Over-dispersion: all PIT mass at 0.5 must be penalised, not rewarded.
+        ranks = pd.Series([0.5] * 20)
+        assert _rank_calibration_error(ranks) > 0.1
+
+    def test_underdispersed_ranks_at_extremes_gives_positive(self):
+        ranks = pd.Series([0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+        assert _rank_calibration_error(ranks) > 0.1
+
+    def test_empty_returns_nan(self):
+        assert math.isnan(_rank_calibration_error(pd.Series(dtype=float)))
+
+    def test_nans_are_dropped(self):
+        n = 10
+        clean = pd.Series([(i - 0.5) / n for i in range(1, n + 1)])
+        with_nan = pd.concat([clean, pd.Series([float("nan"), float("nan")])], ignore_index=True)
+        assert _rank_calibration_error(with_nan) == pytest.approx(_rank_calibration_error(clean))
+
+
+# ===========================================================================
+# CORE-5: CRPSS uses the paired finite subset
+# ===========================================================================
+
+
+class TestCrpssPaired:
+    def test_uses_intersection_of_finite_pairs(self):
+        crps = pd.Series([1.0, 2.0, 3.0, 4.0])
+        crps_ref = pd.Series([2.0, 4.0, float("nan"), 8.0])
+        # Paired rows: 0, 1, 3 → fc_mean = 7/3, ref_mean = 14/3 → 1 - 0.5 = 0.5.
+        assert _crpss_paired(crps, crps_ref) == pytest.approx(0.5)
+
+    def test_all_reference_nan_returns_nan(self):
+        crps = pd.Series([1.0, 2.0])
+        crps_ref = pd.Series([float("nan"), float("nan")])
+        assert math.isnan(_crpss_paired(crps, crps_ref))
+
+    def test_paired_subset_differs_from_independent_means(self):
+        # Independent means would give 1 - 5.5/2.0 = -1.75 (biased); the paired
+        # subset (row 0 only) gives the correct 1 - 1.0/2.0 = 0.5.
+        crps = pd.Series([1.0, 10.0])
+        crps_ref = pd.Series([2.0, float("nan")])
+        assert _crpss_paired(crps, crps_ref) == pytest.approx(0.5)
+
+    def test_zero_reference_returns_nan(self):
+        crps = pd.Series([1.0, 2.0])
+        crps_ref = pd.Series([0.0, 0.0])
+        assert math.isnan(_crpss_paired(crps, crps_ref))
+
+
+# ===========================================================================
+# CORE-6: Brier row n_pairs / base_rate match the band-valid Brier sample
+# ===========================================================================
+
+
+class TestAggregateBrierBandValid:
+    @staticmethod
+    def _brier_kwargs() -> dict:
+        return {
+            "horizon": "pentad",
+            "model": "TFT",
+            "regime": "all",
+            "season": "all",
+            "code": "POOLED",
+            "basin": "all",
+            "norm_provenance": "official",
+            "lead": None,
+        }
+
+    @staticmethod
+    def _frame() -> pd.DataFrame:
+        # 2 band-valid pairs (finite below_norm_prob) + 2 band-less pairs (NaN).
+        # All-obs base_rate = 3/4 = 0.75; band-valid base_rate = 1/2 = 0.50.
+        return pd.DataFrame(
+            [
+                {"below_norm_prob": 0.2, "obs_class": "below", "fc_grid_id": "g"},
+                {"below_norm_prob": 0.6, "obs_class": "normal", "fc_grid_id": "g"},
+                {"below_norm_prob": float("nan"), "obs_class": "below", "fc_grid_id": "g"},
+                {"below_norm_prob": float("nan"), "obs_class": "below", "fc_grid_id": "g"},
+            ]
+        )
+
+    def test_n_pairs_is_band_valid_count(self):
+        row = _aggregate_brier(self._frame(), **self._brier_kwargs())
+        assert row["n_pairs"] == 2
+
+    def test_brier_ss_uses_band_valid_base_rate(self):
+        row = _aggregate_brier(self._frame(), **self._brier_kwargs())
+        # brier_mean = mean[(0.2-1)^2, (0.6-0)^2] = mean[0.64, 0.36] = 0.5.
+        assert row["brier"] == pytest.approx(0.5)
+        # base_rate over the band-valid subset = 0.5 → brier_clim = 0.25 →
+        # brier_ss = 1 - 0.5/0.25 = -1.0.  (All-obs base_rate 0.75 would give
+        # brier_clim 0.1875 → brier_ss ≈ -1.667, which this asserts against.)
+        assert row["brier_ss"] == pytest.approx(-1.0)
+
+    def test_all_band_invalid_gives_zero_pairs_and_nan(self):
+        frame = pd.DataFrame(
+            [
+                {"below_norm_prob": float("nan"), "obs_class": "below", "fc_grid_id": "g"},
+                {"below_norm_prob": float("nan"), "obs_class": "normal", "fc_grid_id": "g"},
+            ]
+        )
+        row = _aggregate_brier(frame, **self._brier_kwargs())
+        assert row["n_pairs"] == 0
+        assert math.isnan(row["brier"])
+        assert math.isnan(row["brier_ss"])

--- a/doc/plans/working/forecast_skill_eval_report_draft.md
+++ b/doc/plans/working/forecast_skill_eval_report_draft.md
@@ -1,12 +1,38 @@
 # Forecast Skill Evaluation — Irrigation Limit-Plan Decision (Report Draft)
 
-**Status:** results complete — phase-2 re-run 2026-06-30.
+**Status:** results complete — both-threshold re-run 2026-07-02.
 
-Re-run date: 2026-06-30. Artifacts:
-`apps/forecast_skill_eval/artifacts/rerun_2026-06-30_phase2/`
-(phase 2 adds `season` column {all, irrigation, non_irrigation} to
-`contingency_metrics.csv` and a `persistence` baseline to `baselines.csv`;
-phase-1 path `rerun_2026-06-30/` superseded).
+Re-run date: 2026-07-02. Artifacts:
+`apps/forecast_skill_eval/artifacts/rerun_2026-07-02_both_thresholds/`
+(this run evaluates **two below-norm thresholds side by side** — the operational
+`below_norm` = value < 0.80 × norm limit-plan trigger and a new
+`below_norm_100` = value < 1.0 × norm plain-below-average event — and keeps the
+phase-2 `season` column {all, irrigation, non_irrigation} in
+`contingency_metrics.csv` plus the `persistence` baseline in `baselines.csv`;
+earlier paths `rerun_2026-06-30/` and `rerun_2026-06-30_phase2/` superseded).
+
+---
+
+## What this report now covers — two thresholds
+
+This report carries **two below-norm events reported side by side** and they
+must **not** be compared cell-for-cell:
+
+- **`below_norm` (value < 0.80 × norm)** — the operational **irrigation
+  limit-plan / restriction** trigger. This is the primary story of the report:
+  it is the boundary the river-basin organization actually uses to decide
+  whether to impose a limit plan. It is the **rarer** event (lower base rate).
+- **`below_norm_100` (value < 1.0 × norm)** — **plain below-average flow**: any
+  period whose runoff falls short of the climatological norm. This is a
+  **common** event (base rate typically ~0.4–0.8) and describes general
+  below-average water availability rather than a restriction decision.
+
+**Non-comparability caveat (applies everywhere both appear):** the two events
+have **different base rates**, so their POD / FAR / HSS are **not comparable
+directly**. HSS in particular is base-rate sensitive — a lower HSS on the
+common 1.0 × norm event does *not* mean worse detection than on the rarer
+0.80 × norm event. Read the 0.80 numbers as the operational-restriction result
+and the 1.0 numbers as a separate description of below-average-flow detection.
 
 ---
 
@@ -73,23 +99,28 @@ All metrics come from the 2×2 contingency table for the binary event
 
 ## Coverage and data quality
 
-| Horizon | n_pairs (all regimes) | Regimes | Station codes |
-|---------|----------------------|---------|---------------|
-| day     | 45 605               | all, hindcast, operational | 83 (65 Kyrgyz, 17 Tajik, 1 other) |
-| pentad  | 158 369              | all, hindcast, operational | 83 |
-| decade  | 78 655               | all, hindcast, operational | 83 |
-| month   | 544 498 (summed over leads 0–12) | all, hindcast (L0–L3 only), operational | 83 |
-| quarter | 44 804               | all, hindcast (L1 only), operational | 83 |
-| season  | 21 832               | all, hindcast, operational | 83 |
+| Horizon | n_pairs (all regimes) | Regimes | Stations (this horizon) |
+|---------|----------------------|---------|-------------------------|
+| day     | 47 529               | all, hindcast, operational | 66 |
+| pentad  | 158 461              | all, hindcast, operational | 81 |
+| decade  | 78 755               | all, hindcast, operational | 81 |
+| month   | 566 569 (summed over leads 0–12) | all, hindcast (L0–L3 only), operational | 53 |
+| quarter | 45 412               | all, hindcast (L1 only), operational | 53 |
+| season  | 21 915               | all, hindcast, operational | 51 |
 
-**Org balance:** 65 Kyrgyz station codes (prefixes 15, 16) vs 17 Tajik (prefix
-17). Long-term (month/quarter/season) n_pairs are dominated by Kyrgyz stations;
+The **pooled station set is 83 distinct codes (65 Kyrgyz, 17 Tajik, 1 other)**;
+not every station has data at every horizon, so per-horizon coverage ranges from
+51 (season) to 81 (pentad/decade). n_pairs (all regimes) sums the paired counts
+over all models and both norm-provenance views for that horizon.
+
+**Org balance:** 65 Kyrgyz stations vs 17 Tajik (plus 1 other). Long-term
+(month/quarter/season) n_pairs are dominated by Kyrgyz stations;
 Tajik operational-month pairs are thin at leads ≥ 2. Metrics at those leads
 carry wide Wilson CIs and should be treated as low-confidence.
 
-**DAY horizon is exploratory:** n_pairs 215–809 across models. Results are
-consistent in direction but CIs are wide; do not over-interpret absolute
-numbers.
+**DAY horizon is exploratory:** n_pairs 632–1 090 across models (operational,
+POOLED). Results are consistent in direction but CIs are wide; do not
+over-interpret absolute numbers.
 
 ---
 
@@ -141,47 +172,96 @@ all stations, no per-station codes). Wilson 95 % CIs are shown for POD.
 
 | Model | TP | FP | FN | TN | n_pairs | base_rate | POD | FAR | HSS | PSS | POD CI 95 % |
 |-------|-----|-----|-----|-----|---------|-----------|-----|-----|-----|-----|-------------|
-| EM    | 4646 | 359 | 360 | 5970 | 11 335 | 0.44 | **0.928** | 0.072 | **0.871** | 0.871 | [0.921, 0.935] |
-| NE    | 4429 | 389 | 424 | 6276 | 11 518 | 0.42 | 0.913 | 0.081 | 0.855 | 0.854 | [0.904, 0.920] |
-| TiDE  | 2715 | 256 | 305 | 4097 | 7 373  | 0.41 | 0.899 | 0.086 | 0.842 | 0.840 | [0.888, 0.909] |
-| TSMixer | 2510 | 279 | 274 | 3623 | 6 686 | 0.42 | 0.902 | 0.100 | 0.830 | 0.830 | [0.890, 0.912] |
-| TFT   | 2669 | 315 | 325 | 4258 | 7 567  | 0.40 | 0.891 | 0.106 | 0.823 | 0.823 | [0.880, 0.902] |
-| LR    | 3449 | 398 | 809 | 8226 | 12 882 | 0.33 | 0.810 | 0.103 | 0.783 | 0.764 | [0.798, 0.822] |
+| EM    | 4651 | 359 | 361 | 5971 | 11 342 | 0.44 | **0.928** | 0.072 | **0.871** | 0.871 | [0.920, 0.935] |
+| NE    | 4433 | 389 | 424 | 6279 | 11 525 | 0.42 | 0.913 | 0.081 | 0.855 | 0.854 | [0.904, 0.920] |
+| TiDE  | 2716 | 256 | 306 | 4099 | 7 377  | 0.41 | 0.899 | 0.086 | 0.842 | 0.840 | [0.887, 0.909] |
+| TSMixer | 2512 | 279 | 274 | 3629 | 6 694 | 0.42 | 0.902 | 0.100 | 0.830 | 0.830 | [0.890, 0.912] |
+| TFT   | 2671 | 314 | 326 | 4262 | 7 573  | 0.40 | 0.891 | 0.105 | 0.823 | 0.823 | [0.880, 0.902] |
+| LR    | 3466 | 400 | 810 | 8260 | 12 936 | 0.33 | 0.811 | 0.103 | 0.783 | 0.764 | [0.799, 0.822] |
 
 Key observations:
-- **FP/FN balance:** EM achieves near-equal FP and FN counts (359 vs 360,
-  ratio ≈ 1.00). NE is slightly FP-heavy (FN 17 % > FP); LR is strongly
-  FN-heavy (FN 809 vs FP 398, ratio 0.49) — more missed limit-plan events.
+- **FP/FN balance:** EM achieves near-equal FP and FN counts (359 vs 361,
+  ratio ≈ 1.00). NE is slightly FP-heavy (FN 424 > FP 389); LR is strongly
+  FN-heavy (FN 810 vs FP 400, ratio 0.49) — more missed limit-plan events.
 - All ML models substantially outperform LR on HSS and PSS.
 - **FN rate is low** for top models: EM misses only 7.2 % of true limit-plan
   events (POD 0.928). FAR 7.2 % is operationally acceptable.
+
+#### Below-norm (1.0 × norm) — plain below-average flow (pentad)
+
+Reported side by side with the 0.80 table above. **Do not compare cell-for-cell:**
+the 1.0 × norm event is far more common (pentad base rate ≈ 0.60–0.70 vs ≈ 0.33–0.44
+for 0.80 × norm), so its POD/FAR/HSS describe general below-average-flow
+detection, not the limit-plan decision. HSS is compressed by the higher base
+rate and is *not* directly comparable to the 0.80 HSS.
+
+| Model | TP | FP | FN | TN | n_pairs | base_rate | POD | FAR | HSS | PSS | POD CI 95 % |
+|-------|-----|-----|-----|-----|---------|-----------|-----|-----|-----|-----|-------------|
+| EM    | 7565 | 357 | 339 | 3081 | 11 342 | 0.70 | **0.957** | 0.045 | **0.855** | 0.853 | [0.952, 0.961] |
+| NE    | 7412 | 400 | 401 | 3312 | 11 525 | 0.68 | 0.949 | 0.051 | 0.841 | 0.841 | [0.944, 0.953] |
+| TFT   | 4631 | 273 | 355 | 2314 | 7 573  | 0.66 | 0.929 | 0.056 | 0.817 | 0.823 | [0.921, 0.936] |
+| TiDE  | 4650 | 311 | 288 | 2128 | 7 377  | 0.67 | 0.942 | 0.063 | 0.816 | 0.814 | [0.935, 0.948] |
+| TSMixer | 4260 | 284 | 312 | 1838 | 6 694 | 0.68 | 0.932 | 0.062 | 0.795 | 0.798 | [0.924, 0.939] |
+| LR    | 7121 | 709 | 687 | 4419 | 12 936 | 0.60 | 0.912 | 0.091 | 0.774 | 0.774 | [0.906, 0.918] |
+
+At the plain below-average threshold, POD rises across the board (EM 0.957) —
+most periods that fall short of the norm are detected — and FAR falls (EM 0.045)
+because the event is common. This is a description of below-average-flow
+detection only; the limit-plan decision remains the 0.80 table above.
 
 ### Decade (10-day)
 
 | Model | TP | FP | FN | TN | n_pairs | base_rate | POD | FAR | HSS | PSS | POD CI 95 % |
 |-------|-----|-----|-----|-----|---------|-----------|-----|-----|-----|-----|-------------|
-| EM    | 2258 | 167 | 238 | 2396 | 5 059 | 0.49 | **0.905** | 0.069 | **0.840** | 0.839 | [0.892, 0.916] |
-| NE    | 2622 | 266 | 320 | 3178 | 6 386 | 0.46 | 0.891 | 0.092 | 0.815 | 0.814 | [0.879, 0.902] |
-| TFT   | 1435 | 217 | 219 | 2204 | 4 075 | 0.41 | 0.868 | 0.131 | 0.778 | 0.778 | [0.850, 0.883] |
-| TiDE  | 1303 | 177 | 202 | 1868 | 3 550 | 0.42 | 0.866 | 0.120 | 0.781 | 0.779 | [0.848, 0.882] |
-| TSMixer | 1222 | 188 | 157 | 1536 | 3 103 | 0.44 | 0.886 | 0.133 | 0.775 | 0.777 | [0.868, 0.902] |
-| LR    | 1457 | 221 | 625 | 4070 | 6 373 | 0.33 | 0.700 | 0.132 | 0.682 | 0.648 | [0.680, 0.719] |
+| EM    | 2267 | 168 | 239 | 2412 | 5 086 | 0.49 | **0.905** | 0.069 | **0.840** | 0.840 | [0.893, 0.916] |
+| NE    | 2623 | 266 | 319 | 3183 | 6 391 | 0.46 | 0.892 | 0.092 | 0.816 | 0.814 | [0.880, 0.902] |
+| TFT   | 1435 | 218 | 219 | 2205 | 4 077 | 0.41 | 0.868 | 0.132 | 0.778 | 0.778 | [0.850, 0.883] |
+| TiDE  | 1304 | 176 | 201 | 1871 | 3 552 | 0.42 | 0.866 | 0.119 | 0.782 | 0.780 | [0.848, 0.883] |
+| TSMixer | 1223 | 188 | 156 | 1539 | 3 106 | 0.44 | 0.887 | 0.133 | 0.776 | 0.778 | [0.869, 0.903] |
+| LR    | 1469 | 222 | 629 | 4107 | 6 427 | 0.33 | 0.700 | 0.131 | 0.683 | 0.649 | [0.680, 0.719] |
 
-Key observations: same pattern as pentad — EM leads, LR is FN-heavy (FN 625,
-ratio FP/FN = 0.35). TSMixer is slightly FP-heavy at decade scale (FN 157 < FP 188).
+Key observations: same pattern as pentad — EM leads, LR is FN-heavy (FN 629,
+ratio FP/FN = 0.35). TSMixer is slightly FP-heavy at decade scale (FN 156 < FP 188).
 
-### Day (exploratory, n_pairs 215–809)
+#### Below-norm (1.0 × norm) — plain below-average flow (decade)
+
+Side by side with the 0.80 table above. **Not comparable cell-for-cell:** the
+1.0 × norm event is more common (decade base rate ≈ 0.60–0.72 vs ≈ 0.33–0.49 for
+0.80 × norm); base-rate-sensitive HSS is compressed relative to the 0.80 story.
+
+| Model | TP | FP | FN | TN | n_pairs | base_rate | POD | FAR | HSS | PSS | POD CI 95 % |
+|-------|-----|-----|-----|-----|---------|-----------|-----|-----|-----|-----|-------------|
+| EM    | 3483 | 178 | 181 | 1244 | 5 086 | 0.72 | **0.951** | 0.049 | **0.825** | 0.825 | [0.943, 0.957] |
+| NE    | 4187 | 291 | 289 | 1624 | 6 391 | 0.70 | 0.935 | 0.065 | 0.784 | 0.783 | [0.928, 0.942] |
+| TFT   | 2448 | 209 | 230 | 1190 | 4 077 | 0.66 | 0.914 | 0.079 | 0.762 | 0.765 | [0.903, 0.924] |
+| TiDE  | 2189 | 201 | 200 | 962  | 3 552 | 0.67 | 0.916 | 0.084 | 0.744 | 0.743 | [0.904, 0.927] |
+| TSMixer | 2004 | 189 | 184 | 729 | 3 106 | 0.70 | 0.916 | 0.086 | 0.711 | 0.710 | [0.904, 0.927] |
+| LR    | 3305 | 499 | 556 | 2067 | 6 427 | 0.60 | 0.856 | 0.131 | 0.659 | 0.662 | [0.845, 0.867] |
+
+### Day (exploratory, n_pairs 632–1 090)
 
 | Model | n_pairs | POD | FAR | HSS | PSS |
 |-------|---------|-----|-----|-----|-----|
-| TSMixer | 809 | 0.540 | 0.162 | 0.498 | 0.469 |
-| TiDE    | 552 | 0.536 | 0.177 | 0.452 | 0.439 |
-| TFT     | 215 | 0.510 | 0.131 | 0.443 | 0.438 |
+| TSMixer | 1 055 | 0.455 | 0.139 | 0.441 | 0.406 |
+| TiDE    | 1 090 | 0.578 | 0.246 | 0.451 | 0.438 |
+| TFT     | 632   | 0.623 | 0.232 | 0.538 | 0.516 |
 
-Day-horizon skill is substantially lower than pentad/decade. POD ~0.51–0.54
-with HSS ~0.44–0.50. With only 215–809 pairs the CIs are wide; interpret with
+Day-horizon skill is substantially lower than pentad/decade. POD ~0.46–0.62
+with HSS ~0.44–0.54. With only 632–1 090 pairs the CIs are wide; interpret with
 caution. The small sample reflects that day-resolution ML archive is limited to
 approximately the last 1–2 years (vs 15+ years for pentad/decade).
+
+#### Below-norm (1.0 × norm) — plain below-average flow (day)
+
+Side by side with the 0.80 day table above. **Not comparable cell-for-cell:**
+the day 1.0 × norm base rate (≈ 0.70–0.74) is far higher than the 0.80 × norm
+base rate (≈ 0.36–0.43), so HSS is not comparable across the two events.
+
+| Model | n_pairs | POD | FAR | HSS | PSS |
+|-------|---------|-----|-----|-----|-----|
+| TFT     | 632   | 0.728 | 0.103 | 0.476 | 0.534 |
+| TiDE    | 1 090 | 0.869 | 0.138 | 0.469 | 0.466 |
+| TSMixer | 1 055 | 0.704 | 0.128 | 0.360 | 0.420 |
 
 ---
 
@@ -195,63 +275,105 @@ the nearest forecast (i.e., smallest forecast offset).
 
 | Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS | POD CI 95 % |
 |------|-----|-----|-----|------|---------|-----|-----|-----|-----|-------------|
-| L0   | 1337 | 117 | 214 | 4100 | 5 768 | **0.862** | 0.080 | **0.851** | 0.834 | [0.844, 0.878] |
-| L1   | 338  | 33  | 65  | 1206 | 1 642 | 0.839 | 0.089 | 0.834 | 0.812 | [0.800, 0.871] |
-| L2   | 107  | 7   | 35  | 427  | 576   | 0.754 | 0.061 | 0.790 | 0.737 | [0.677, 0.817] |
-| L3   | 35   | 6   | 24  | 369  | 434   | 0.593 | 0.146 | 0.662 | 0.577 | [0.466, 0.709] |
+| L0   | 1567 | 120 | 271 | 7459 | 9 417 | **0.853** | 0.071 | **0.864** | 0.837 | [0.836, 0.868] |
+| L1   | 354  | 40  | 79  | 2126 | 2 599 | 0.818 | 0.102 | 0.829 | 0.799 | [0.778, 0.851] |
+| L2   | 89   | 4   | 29  | 552  | 674   | 0.754 | 0.043 | 0.815 | 0.747 | [0.669, 0.823] |
+| L3   | 32   | 6   | 18  | 492  | 548   | 0.640 | 0.158 | 0.704 | 0.628 | [0.501, 0.759] |
 | L4+  | — | — | — | — | thin | — | — | — | — | — |
 
-HSS degrades markedly from L0 (0.851) to L3 (0.662). Leads L4–L12 have very
-few pairs (67–436 for EM), concentrated on a small set of Kyrgyz stations;
-metrics should be treated as low-confidence.
+The month archive grew substantially since the previous run (L0 n_pairs
+5 768 → 9 417). HSS degrades from L0 (0.864) to L3 (0.704). Leads L4–L12 have
+very few pairs, concentrated on a small set of Kyrgyz stations; metrics should
+be treated as low-confidence.
 
 **Naive Mean** (unweighted average of all model forecasts, no skill weighting)
-is available at all leads (L0 n_pairs 9 579):
-- L0: POD 0.803, FAR 0.107, HSS 0.810 — EM substantially outperforms.
-- L3: POD 0.327, FAR 0.240, HSS 0.394 — EM at L3 still outperforms (HSS 0.662).
+is available at all leads (L0 n_pairs 12 442):
+- L0: POD 0.788, FAR 0.102, HSS 0.804 — EM substantially outperforms.
+- L3: POD 0.334, FAR 0.245, HSS 0.396 — EM at L3 still outperforms (HSS 0.704).
 
 **Skilled Mean** (ensemble of trained long-term models) at L0:
-- POD 0.883, FAR 0.079, HSS 0.873 — best among all month L0 models.
-- n_pairs 8 471 (broad coverage). Strongly positive skill over climatology.
+- POD 0.852, FAR 0.097, HSS 0.844 — n_pairs 6 765 (broad coverage).
+- Strongly positive skill over climatology; at this run EM edges it at L0
+  (HSS 0.864 vs 0.844).
+
+#### Below-norm (1.0 × norm) — plain below-average flow (month, EM per-lead)
+
+Side by side with the 0.80 month table above. **Not comparable cell-for-cell:**
+the 1.0 × norm month event is much more common (base rate ≈ 0.23–0.43 vs
+≈ 0.09–0.20 for 0.80 × norm), and base-rate-sensitive HSS shifts accordingly.
+
+| Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS | POD CI 95 % |
+|------|-----|-----|-----|------|---------|-----|-----|-----|-----|-------------|
+| L0   | 3672 | 194 | 334 | 5217 | 9 417 | **0.917** | 0.050 | **0.885** | 0.881 | [0.908, 0.925] |
+| L1   | 921  | 74  | 98  | 1506 | 2 599 | 0.904 | 0.074 | 0.861 | 0.857 | [0.884, 0.920] |
+| L2   | 213  | 8   | 36  | 417  | 674   | 0.855 | 0.036 | 0.857 | 0.837 | [0.806, 0.894] |
+| L3   | 99   | 9   | 26  | 414  | 548   | 0.792 | 0.083 | 0.810 | 0.771 | [0.713, 0.854] |
 
 ### Quarter (EM, operational, POOLED, aggregated_from_monthly)
 
 | Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS |
 |------|-----|-----|-----|------|---------|-----|-----|-----|-----|
-| L1   | 75  | 29  | 119 | 1664 | 1 887 | 0.387 | 0.279 | 0.465 | 0.369 |
-| L2   | 24  | 20  | 0   | 35  | 79    | **1.000** | 0.455 | 0.515 | 0.636 |
-| L3   | 40  | 9   | 17  | 83  | 149   | 0.702 | 0.184 | 0.620 | 0.604 |
-| L4   | 51  | 25  | 12  | 342 | 430   | 0.810 | 0.329 | 0.683 | 0.741 |
+| L1   | 86  | 35  | 164 | 2276 | 2 561 | 0.344 | 0.289 | 0.427 | 0.329 |
+| L2   | 24  | 20  | 0   | 39   | 83    | **1.000** | 0.455 | 0.530 | 0.661 |
+| L3   | 42  | 9   | 18  | 98   | 167   | 0.700 | 0.176 | 0.637 | 0.616 |
+| L4   | 53  | 28  | 14  | 357  | 452   | 0.791 | 0.346 | 0.661 | 0.718 |
 
-Quarter L2 has only 79 pairs (small n, POD of 1.0 is artefact). L1 is the
-best-sampled lead (1 887 pairs) and shows modest skill (HSS 0.465). L4 shows
-better POD (0.810) but n_pairs remains limited.
+Quarter L2 has only 83 pairs (small n, POD of 1.0 is artefact). L1 is the
+best-sampled lead (2 561 pairs) and shows modest skill (HSS 0.427). L4 shows
+better POD (0.791) but n_pairs remains limited.
 
-**LR_Base** at L1: POD 0.337, FAR 0.343, HSS 0.401 — positive but weaker
+**LR_Base** at L1: POD 0.316, FAR 0.371, HSS 0.380 — positive but weaker
 than EM.
 
-**GBT** at L1: POD 0.462, FAR 0.141, HSS 0.561 — better than EM at L1 in HSS
-with lower FAR; n_pairs 1 127.
+**GBT** at L1: POD 0.415, FAR 0.182, HSS 0.512 — better than EM at L1 in HSS
+with lower FAR; n_pairs 1 096.
+
+#### Below-norm (1.0 × norm) — plain below-average flow (quarter, EM per-lead)
+
+Side by side with the 0.80 quarter table above. **Not comparable cell-for-cell:**
+the 1.0 × norm quarter event is far more common (base rate ≈ 0.31–0.64 vs
+≈ 0.10–0.36 for 0.80 × norm); HSS shifts with the base rate.
+
+| Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS |
+|------|-----|-----|-----|------|---------|-----|-----|-----|-----|
+| L1   | 483 | 137 | 300 | 1641 | 2 561 | 0.617 | 0.221 | 0.573 | 0.540 |
+| L2   | 41  | 16  | 6   | 20   | 83    | **0.872** | 0.281 | 0.442 | 0.428 |
+| L3   | 85  | 10  | 21  | 51   | 167   | 0.802 | 0.105 | 0.614 | 0.638 |
+| L4   | 163 | 52  | 13  | 224  | 452   | 0.926 | 0.242 | 0.709 | 0.738 |
 
 ### Season (EM, operational, POOLED, aggregated_from_monthly)
 
 | Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS |
 |------|-----|-----|-----|-----|---------|-----|-----|-----|-----|
-| L0   | 123 | 57  | 174 | 977  | 1 331 | 0.414 | 0.317 | 0.418 | 0.359 |
+| L0   | 130 | 59  | 186 | 1064 | 1 439 | 0.411 | 0.312 | 0.419 | 0.359 |
 | L1   | 155 | 102 | 274 | 1402 | 1 933 | 0.361 | 0.397 | 0.343 | 0.293 |
 | L2   | 66  | 41  | 124 | 670  | 901   | 0.347 | 0.383 | 0.345 | 0.290 |
 | L3   | 67  | 51  | 132 | 662  | 912   | 0.337 | 0.432 | 0.311 | 0.265 |
 
 Seasonal forecasts have moderate positive skill (HSS 0.31–0.42) across all
-leads, but POD is only 0.34–0.41. That means **roughly 58–66 % of true
+leads, but POD is only 0.34–0.41. That means **roughly 59–66 % of true
 limit-plan seasons are missed** at the seasonal horizon — consistent with the
-fundamental difficulty of seasonal prediction. FAR is also elevated (0.32–0.43),
+fundamental difficulty of seasonal prediction. FAR is also elevated (0.31–0.43),
 meaning around 1 in 3 season-ahead limit-plan signals is a false alarm.
 Nevertheless, HSS > 0 confirms skill over climatology at all leads.
 
-**LR_Base** at all season leads: HSS 0.34–0.35, POD 0.34–0.36, FAR 0.32–0.41
+**LR_Base** at all season leads: HSS 0.33–0.36, POD 0.34–0.36, FAR 0.31–0.42
 — nearly identical to EM. No clear advantage of ML over LR at the seasonal
 scale.
+
+#### Below-norm (1.0 × norm) — plain below-average flow (season, EM per-lead)
+
+Side by side with the 0.80 season table above. **Not comparable cell-for-cell:**
+the 1.0 × norm season event is much more common (base rate ≈ 0.49–0.51 vs
+≈ 0.21–0.22 for 0.80 × norm), so its higher POD/HSS reflect the higher base
+rate — not stronger limit-plan detection.
+
+| Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS |
+|------|-----|-----|-----|-----|---------|-----|-----|-----|-----|
+| L0   | 478 | 131 | 228 | 602 | 1 439 | 0.677 | 0.215 | 0.500 | 0.498 |
+| L1   | 646 | 189 | 338 | 760 | 1 933 | 0.657 | 0.226 | 0.456 | 0.457 |
+| L2   | 298 | 86  | 152 | 365 | 901   | 0.662 | 0.224 | 0.472 | 0.472 |
+| L3   | 294 | 92  | 165 | 361 | 912   | 0.641 | 0.238 | 0.437 | 0.437 |
 
 ---
 
@@ -272,12 +394,14 @@ skill over the trivially no-skill climatology baseline.
 Pooled-operational base rates (fraction of all periods that are genuinely
 below-norm) and the events climatology misses entirely:
 
+(Base rates are for the operational **0.80 × norm** limit-plan event.)
+
 | Horizon | Base rate | Events missed by climatology |
 |---------|-----------|------------------------------|
-| day     | 0.48      | 48 % of all day-periods |
+| day     | ≈ 0.40    | ~40 % of all day-periods (varies 0.36–0.43 by model) |
 | pentad  | 0.44      | 44 % of all pentad-periods |
 | decade  | 0.49      | 49 % of all decade-periods |
-| month (L0) | 0.27  | 27 % of all month-periods |
+| month (L0) | 0.20  | 20 % of all month-periods |
 | quarter (L1) | 0.10 | 10 % of all quarter-periods |
 | season (L0) | 0.22  | 22 % of all season-periods |
 
@@ -290,14 +414,14 @@ Yes — decisively for short-term, positive but weaker for long-term.
   entirely.  At a pentad base rate of 0.44, climatology flags zero events; EM
   flags 93 % of the genuine ones.
 - **Decade EM** (POD 0.905, HSS 0.840): EM catches 90.5 % of events
-  climatology misses.  Stronger than LR (POD 0.700, HSS 0.682).
-- **Month L0 Skilled Mean / EM** (POD 0.862–0.883, HSS 0.851–0.873): strong
-  skill; climatology misses all 27 % of below-norm months.  Monthly forecasts
+  climatology misses.  Stronger than LR (POD 0.700, HSS 0.683).
+- **Month L0 EM / Skilled Mean** (POD 0.853–0.852, HSS 0.864–0.844): strong
+  skill; climatology misses all 20 % of below-norm months.  Monthly forecasts
   are reliable enough to inform seasonal irrigation planning one month ahead.
-- **Quarter L1 EM** (POD 0.387, HSS 0.465): positive but modest.  Climatology
-  misses all 10 % of below-norm quarters; EM catches 38.7 % of them.
-- **Season L0 EM** (POD 0.414, HSS 0.418): weak but positive.  Climatology
-  misses all 22 % of below-norm seasons; EM catches 41.4 % of them.
+- **Quarter L1 EM** (POD 0.344, HSS 0.427): positive but modest.  Climatology
+  misses all 10 % of below-norm quarters; EM catches 34.4 % of them.
+- **Season L0 EM** (POD 0.411, HSS 0.419): weak but positive.  Climatology
+  misses all 22 % of below-norm seasons; EM catches 41.1 % of them.
 
 In every fig4 panel, a labelled annotation shows the climatology reference
 (POD = 0, HSS = 0, base rate) so the gain from any real model is immediately
@@ -328,9 +452,9 @@ named model.  For long-term horizons, LR_Base is the proxy.
 
 Summary of best model vs. climatology vs. LR:
 - **Pentad EM**: HSS 0.871 — far above climatology (0.00). Beats LR (0.783).
-- **Decade EM**: HSS 0.840 — far above climatology. Beats LR (0.682).
-- **Month L0 Skilled Mean**: HSS 0.873 — strong skill. Naive Mean HSS 0.810.
-- **Season L0 EM**: HSS 0.418 — positive but modest; LR_Base similar (0.353).
+- **Decade EM**: HSS 0.840 — far above climatology. Beats LR (0.683).
+- **Month L0 EM**: HSS 0.864 — strong skill. Naive Mean HSS 0.804.
+- **Season L0 EM**: HSS 0.419 — positive but modest; LR_Base similar (0.361).
 
 For pentad/decade, ML ensemble models (EM, NE) substantially exceed the LR
 baseline. For season, the gap narrows and LR_Base is competitive with EM.
@@ -348,23 +472,23 @@ canonical provenance; comparison model = EM except day = TFT):
 
 | Horizon | Persistence POD | Persistence FAR | Persistence HSS | n_matched |
 |---------|----------------|----------------|----------------|-----------|
-| day     | 0.981 | 0.140 | **0.866** | 588 |
-| pentad  | 0.852 | 0.141 | 0.743 | 11 322 |
-| decade  | 0.785 | 0.144 | 0.658 | 5 036 |
-| month L0 | 0.504 | 0.382 | 0.459 | 6 369 |
-| quarter L1 | 0.220 | 0.679 | 0.193 | 1 851 |
-| season L0 | 0.387 | 0.607 | 0.218 | 1 282 |
+| day     | 0.987 | 0.154 | **0.854** | 632 |
+| pentad  | 0.851 | 0.141 | 0.742 | 11 329 |
+| decade  | 0.785 | 0.144 | 0.659 | 5 063 |
+| month L0 | 0.528 | 0.403 | 0.461 | 9 391 |
+| quarter L1 | 0.229 | 0.678 | 0.203 | 2 507 |
+| season L0 | 0.376 | 0.624 | 0.202 | 1 390 |
 
 **Three-way skill ladder — climatology / persistence / best model:**
 
 | Horizon | Climatology HSS | Persistence HSS | Best model HSS | Winner |
 |---------|:--------------:|:--------------:|:-------------:|--------|
-| day     | 0 | 0.866 | 0.508 (TiDE) | **Persistence** |
-| pentad  | 0 | 0.743 | 0.871 (EM)   | EM |
-| decade  | 0 | 0.658 | 0.840 (EM)   | EM |
-| month L0 | 0 | 0.459 | 0.855 (EM)  | EM |
-| quarter L1 | 0 | 0.193 | 0.465 (EM) | EM |
-| season L0 | 0 | 0.218 | 0.418 (EM)  | EM |
+| day     | 0 | 0.854 | 0.538 (TFT) | **Persistence** |
+| pentad  | 0 | 0.742 | 0.871 (EM)   | EM |
+| decade  | 0 | 0.659 | 0.840 (EM)   | EM |
+| month L0 | 0 | 0.461 | 0.864 (EM)  | EM |
+| quarter L1 | 0 | 0.203 | 0.427 (EM) | EM |
+| season L0 | 0 | 0.202 | 0.419 (EM)  | EM |
 
 Key findings:
 
@@ -378,9 +502,9 @@ Key findings:
   well-trained models — as persistence degrades with longer forecast lead,
   the models' learned climatological signal takes over.
 - **At the day scale, persistence beats our thin ML models.**  Day-horizon
-  persistence achieves HSS 0.87 against only 0.44–0.51 for TFT/TSMixer/TiDE.
+  persistence achieves HSS 0.85 against only 0.44–0.54 for TFT/TSMixer/TiDE.
   This is largely a sample-size effect: day-horizon ML forecasts are drawn
-  from a very small operational archive (n = 588–809 vs ~12 000+ at pentad).
+  from a very small operational archive (n = 632–1 090 vs ~12 000+ at pentad).
   With more operational data the gap would likely close, but day-ahead
   persistence (last observed flow) is a very strong competitor at this scale.
 
@@ -394,12 +518,12 @@ persistence as reference annotations in the lower-right corner.
 
 | Horizon | Best lead | HSS (best) | HSS (worst shown) | Degradation |
 |---------|-----------|-----------|-------------------|-------------|
-| day     | n/a (no lead) | 0.50 (TSMixer) | — | — |
+| day     | n/a (no lead) | 0.538 (TFT) | — | — |
 | pentad  | n/a       | 0.871 (EM) | — | — |
 | decade  | n/a       | 0.840 (EM) | — | — |
-| month   | L0        | 0.851 (EM) | 0.662 (L3) | −0.19 over 3 leads |
-| quarter | L4        | 0.683 (EM) | 0.465 (L1) | varies non-monotonically |
-| season  | L0        | 0.418 (EM) | 0.311 (L3) | −0.11 over 3 leads |
+| month   | L0        | 0.864 (EM) | 0.704 (L3) | −0.16 over 3 leads |
+| quarter | L4        | 0.661 (EM) | 0.427 (L1) | varies non-monotonically |
+| season  | L0        | 0.419 (EM) | 0.311 (L3) | −0.11 over 3 leads |
 
 Month shows the clearest monotonic degradation with lead. Season degrades more
 slowly but is moderate at all leads.
@@ -419,19 +543,32 @@ canonical provenance**.
 
 ### Seasonal POD / FAR / HSS table (EM, POOLED)
 
-| Horizon | Season | n | POD | FAR | HSS | POD CI 95 % |
-|---------|--------|---|-----|-----|-----|-------------|
-| pentad | all | 11 335 | 0.928 | 0.072 | 0.871 | [0.921, 0.935] |
-| pentad | irrigation (Apr–Sep) | 6 813 | **0.933** | 0.072 | 0.856 | [0.925, 0.941] |
-| pentad | non-irrigation (Oct–Mar) | 4 522 | 0.916 | 0.071 | **0.885** | [0.900, 0.929] |
-| decade | all | 5 059 | 0.905 | 0.069 | 0.840 | [0.892, 0.916] |
-| decade | irrigation (Apr–Sep) | 2 794 | **0.905** | 0.066 | 0.798 | [0.890, 0.918] |
-| decade | non-irrigation (Oct–Mar) | 2 265 | 0.904 | 0.075 | **0.869** | [0.882, 0.923] |
-| month L0 | all | 6 387 | 0.863 | 0.096 | 0.855 | [0.843, 0.881] |
-| month L0 | irrigation (Apr–Sep) | 2 505 | **0.880** | 0.119 | 0.828 | [0.855, 0.901] |
-| month L0 | non-irrigation (Oct–Mar) | 3 882 | 0.835 | 0.057 | **0.870** | [0.800, 0.866] |
-| season L0 | all / irrigation | 1 331 | 0.414 | 0.317 | 0.418 | [0.360, 0.471] |
-| season L0 | non-irrigation | — | — | — | — | — |
+Both events are shown. **The two events are not comparable cell-for-cell**
+(different base rates); the 0.80 × norm rows are the limit-plan story, the
+1.0 × norm rows describe plain below-average flow.
+
+| Horizon | Event | Season | n | POD | FAR | HSS | POD CI 95 % |
+|---------|-------|--------|---|-----|-----|-----|-------------|
+| pentad | 0.80 | all | 11 342 | 0.928 | 0.072 | 0.871 | [0.920, 0.935] |
+| pentad | 0.80 | irrigation (Apr–Sep) | 6 820 | **0.933** | 0.072 | 0.856 | [0.924, 0.941] |
+| pentad | 0.80 | non-irrigation (Oct–Mar) | 4 522 | 0.916 | 0.071 | **0.885** | [0.900, 0.929] |
+| pentad | 1.0  | all | 11 342 | 0.957 | 0.045 | 0.855 | [0.952, 0.961] |
+| pentad | 1.0  | irrigation (Apr–Sep) | 6 820 | 0.958 | 0.040 | 0.839 | [0.952, 0.963] |
+| pentad | 1.0  | non-irrigation (Oct–Mar) | 4 522 | 0.955 | 0.054 | 0.868 | [0.947, 0.962] |
+| decade | 0.80 | all | 5 086 | 0.905 | 0.069 | 0.840 | [0.893, 0.916] |
+| decade | 0.80 | irrigation (Apr–Sep) | 2 821 | **0.905** | 0.066 | 0.799 | [0.890, 0.918] |
+| decade | 0.80 | non-irrigation (Oct–Mar) | 2 265 | 0.904 | 0.075 | **0.869** | [0.882, 0.923] |
+| decade | 1.0  | all | 5 086 | 0.951 | 0.049 | 0.825 | [0.943, 0.957] |
+| decade | 1.0  | irrigation (Apr–Sep) | 2 821 | 0.949 | 0.047 | 0.756 | [0.939, 0.957] |
+| decade | 1.0  | non-irrigation (Oct–Mar) | 2 265 | 0.953 | 0.052 | 0.870 | [0.941, 0.963] |
+| month L0 | 0.80 | all | 9 417 | 0.853 | 0.071 | 0.864 | [0.836, 0.868] |
+| month L0 | 0.80 | irrigation (Apr–Sep) | 3 664 | **0.864** | 0.081 | 0.844 | [0.843, 0.883] |
+| month L0 | 0.80 | non-irrigation (Oct–Mar) | 5 753 | 0.834 | 0.054 | **0.871** | [0.804, 0.859] |
+| month L0 | 1.0  | all | 9 417 | 0.917 | 0.050 | 0.885 | [0.908, 0.925] |
+| month L0 | 1.0  | irrigation (Apr–Sep) | 3 664 | 0.922 | 0.052 | 0.858 | [0.909, 0.933] |
+| month L0 | 1.0  | non-irrigation (Oct–Mar) | 5 753 | 0.911 | 0.048 | 0.896 | [0.898, 0.923] |
+| season L0 | 0.80 | all / irrigation | 1 439 | 0.411 | 0.312 | 0.419 | [0.359, 0.466] |
+| season L0 | 1.0  | all / irrigation | 1 439 | 0.677 | 0.215 | 0.500 | [0.642, 0.711] |
 
 **Note on season horizon:** All season-ahead forecasts (Apr–Sep seasonal
 runoff) target the irrigation season by definition.  There is no
@@ -440,10 +577,11 @@ non-irrigation split for the season horizon.
 ### Interpretation
 
 **POD is slightly higher in the irrigation season than out-of-season:**
-at the pentad scale, EM detects 93.3 % of below-norm events during Apr–Sep
-vs 91.6 % during Oct–Mar (difference 1.7 pp, within CI overlap but
-consistent across models).  At month L0, the irrigation-season advantage is
-4.5 pp (88.0 % vs 83.5 %).
+at the pentad scale (0.80 × norm), EM detects 93.3 % of below-norm events
+during Apr–Sep vs 91.6 % during Oct–Mar (difference 1.7 pp, within CI overlap
+but consistent across models).  At month L0, the irrigation-season advantage is
+3.0 pp (86.4 % vs 83.4 %). The same in-season / out-of-season ordering holds for
+the 1.0 × norm event.
 
 **HSS is slightly lower in-season** despite higher POD.  This is a
 base-rate effect: below-norm events are more frequent in the irrigation
@@ -474,17 +612,17 @@ events are missed** (FN rate = 1 − POD)?
   shortage events.
 - **Pentad/decade (LR):** FN rate 19–30 %. LR is FN-heavy — much more likely
   to miss a genuine shortage. ML models offer a clear advantage.
-- **Month L0 (Skilled Mean / EM):** FN rate 12–14 %. Strong skill, comparable
+- **Month L0 (EM / Skilled Mean):** FN rate ≈ 15 %. Strong skill, comparable
   to short-term ML. Monthly forecasts are reliable enough to inform seasonal
   irrigation planning one month ahead.
-- **Month L3 (EM):** FN rate 41 %. Skill degrades substantially at 3-month
+- **Month L3 (EM):** FN rate 36 %. Skill degrades substantially at 3-month
   lead. Three-month-ahead seasonal signals should be treated as directional
   guidance only.
 - **Quarter / Season:** FN rate 59–66 % at all leads (EM). More than half of
   true limit-plan events are missed. These horizons provide only weak, positive
   skill — useful for ensemble signal but not for firm operational decisions. FAR
   is also elevated (31–43 %).
-- **Day (exploratory):** FN rate 46–49 %. Low coverage and inherent day-scale
+- **Day (exploratory):** FN rate 38–55 %. Low coverage and inherent day-scale
   variability mean day-ahead limit-plan decisions carry substantial uncertainty.
 
 **Recommendation:** rely on pentad/decade ML ensemble (EM or NE) for the core
@@ -809,7 +947,7 @@ matters directly for allocation and hydropower.
 
 ## Caveats and limitations
 
-1. **DAY horizon is thin and exploratory.** n_pairs 215–809 across models;
+1. **DAY horizon is thin and exploratory.** n_pairs 632–1 090 across models;
    CIs span ±10–15 pp. Use for direction only.
 2. **Long-term coverage is Kyrgyz-dominated.** 65 of 83 stations are Kyrgyz;
    Tajik operational-month pairs at leads ≥ 2 are scarce. Tajik seasonal skill
@@ -821,9 +959,12 @@ matters directly for allocation and hydropower.
    and season L0–L3 and is systematically higher than operational (typical
    optimism of hindcast-trained models). Report operational figures for real-world
    assessment.
-5. **Threshold fixed at 0.80 × norm.** Results may change for different
-   threshold values; the tool supports re-running with any threshold.
-6. **Quarter L2 artefact:** 79 pairs, POD = 1.00 — artefact of small n. Treat
+5. **Two thresholds reported side by side, not comparable.** The operational
+   story is the **0.80 × norm** limit-plan event; the **1.0 × norm** plain
+   below-average event is reported alongside it for reference only. The two have
+   different base rates, so their POD/FAR/HSS must not be compared cell-for-cell
+   (HSS is base-rate sensitive). The tool supports re-running with any threshold.
+6. **Quarter L2 artefact:** 83 pairs, POD = 1.00 — artefact of small n. Treat
    that cell as unreliable.
 7. **`min_years = 10`** filter applied: stations with fewer than 10 years of
    paired data were excluded from long-term norm computation.
@@ -907,8 +1048,9 @@ All figures are in `doc/plans/working/forecast_skill_eval_figures/`:
 ## Related documents
 
 - Planner prompt / locked requirements: `forecast_skill_eval_planner_prompt.md`
-- Run configuration: `apps/forecast_skill_eval/artifacts/rerun_2026-06-30/run_config.json`
-- Phase-2 artifacts: `apps/forecast_skill_eval/artifacts/rerun_2026-06-30_phase2/`
-  (canonical source; includes season column + persistence baseline)
+- Run configuration: `apps/forecast_skill_eval/artifacts/rerun_2026-07-02_both_thresholds/run_config.json`
+- Phase-2 artifacts: `apps/forecast_skill_eval/artifacts/rerun_2026-07-02_both_thresholds/`
+  (canonical source; both thresholds `below_norm` 0.80 × norm and `below_norm_100`
+  1.0 × norm, season column, persistence baseline)
 - Lead-aware figure script: `doc/plans/working/forecast_skill_eval_figures/make_figures.py`
-- Summary (auto-generated): `apps/forecast_skill_eval/artifacts/rerun_2026-06-30/summary.md`
+- Summary (auto-generated): `apps/forecast_skill_eval/artifacts/rerun_2026-07-02_both_thresholds/summary.md`

--- a/doc/plans/working/forecast_skill_eval_report_draft.md
+++ b/doc/plans/working/forecast_skill_eval_report_draft.md
@@ -1,15 +1,56 @@
 # Forecast Skill Evaluation — Irrigation Limit-Plan Decision (Report Draft)
 
-**Status:** results complete — both-threshold re-run 2026-07-02.
+**Status:** results complete — corrected module-correctness re-run 2026-07-03.
 
-Re-run date: 2026-07-02. Artifacts:
-`apps/forecast_skill_eval/artifacts/rerun_2026-07-02_both_thresholds/`
+Re-run date: 2026-07-03. Artifacts:
+`apps/forecast_skill_eval/artifacts/rerun_2026-07-03_corrected/`
 (this run evaluates **two below-norm thresholds side by side** — the operational
 `below_norm` = value < 0.80 × norm limit-plan trigger and a new
 `below_norm_100` = value < 1.0 × norm plain-below-average event — and keeps the
 phase-2 `season` column {all, irrigation, non_irrigation} in
-`contingency_metrics.csv` plus the `persistence` baseline in `baselines.csv`;
-earlier paths `rerun_2026-06-30/` and `rerun_2026-06-30_phase2/` superseded).
+`contingency_metrics.csv` plus the `persistence` baseline in `baselines.csv`.
+It **supersedes** `rerun_2026-07-02_both_thresholds/` (and the earlier
+`rerun_2026-06-30*` paths): the numbers changed because of four module-correctness
+bug fixes — short-term de-leaking, a date-based long-term regime split, a
+historical LR issue→target repair, and a quarter mis-stratification fix (see
+**Corrections in this revision** below).
+
+---
+
+## Corrections in this revision
+
+The previous draft's numbers were inflated or mislabelled by four bugs that are
+now fixed. Every number in this revision reflects the corrected run. The four
+corrections are:
+
+1. **Short-term de-leaking (issue-before-target + one-forecast-per-target).**
+   Short-term forecasts were previously scored on *every* intraday re-issue,
+   including in-period nowcasts that had already observed part of their own
+   target period — an information leak that inflated skill. The corrected run
+   keeps only genuine forecasts (issued strictly before the target period) and
+   exactly one forecast per target. Effect: pentad EM POD 0.928 → **0.899**,
+   HSS 0.871 → **0.847** (n 11 342 → 3 384); decade EM POD 0.905 → **0.845**,
+   HSS 0.840 → **0.791**. Still strong — now honest.
+2. **Long-term regime split (date-based, genuine-2026).** The old "operational"
+   long-term regime was flag-based and was dominated by *pre-2026 backfills that
+   had been mislabelled operational*. The corrected run defines "operational" as
+   **genuinely post-2026 real-time** forecasts only (very thin: month L0 n = 40,
+   quarter Q1 n = 40, season L0 n = 49) and moves the full pre-2026 archive into
+   **hindcast**, where it belongs. The old "operational" long-term numbers were
+   really hindcast (e.g. old month L0 HSS 0.864 ≈ new **hindcast** HSS 0.875).
+   Consequently the long-term sections below now **lead with the hindcast tables**
+   (robust, full-archive skill) and present the genuine-2026 operational numbers
+   only as a thin, preliminary footnote.
+3. **Historical LR issue→target repair.** Pre-2024 short-term LR forecasts were
+   mis-aligned by one period (issue vs target). This is now corrected, so the LR
+   hindcast archive is valid and the LR short-term numbers can be trusted.
+4. **Quarter mis-stratification (overloaded `horizon_value`).** The quarter
+   horizon previously showed four bogus "leads" L1–L4 that were in fact the
+   *target quarter* leaking through an overloaded `horizon_value`, with two
+   forecast sources pooled and intra-quarter re-issues double-counted. Quarter is
+   now **deduped** (one forecast per station / target quarter / year / model) and
+   shown **per target quarter Q1–Q4**, each effectively a single-lead forecast;
+   season is shown per **genuine lead 0–3** (re-issues deduped within each lead).
 
 ---
 
@@ -99,28 +140,42 @@ All metrics come from the 2×2 contingency table for the binary event
 
 ## Coverage and data quality
 
-| Horizon | n_pairs (all regimes) | Regimes | Stations (this horizon) |
-|---------|----------------------|---------|-------------------------|
-| day     | 47 529               | all, hindcast, operational | 66 |
-| pentad  | 158 461              | all, hindcast, operational | 81 |
-| decade  | 78 755               | all, hindcast, operational | 81 |
-| month   | 566 569 (summed over leads 0–12) | all, hindcast (L0–L3 only), operational | 53 |
-| quarter | 45 412               | all, hindcast (L1 only), operational | 53 |
-| season  | 21 915               | all, hindcast, operational | 51 |
+n_pairs below are the `below_norm` event, pooled provenance, summed over all
+models and leads. The **operational** column is the corrected genuine-forecast
+count (short-term de-leaked; long-term genuine-2026 only); the **hindcast**
+column is the robust full-archive count that the long-term sections now lead with.
+
+| Horizon | n_pairs (all regimes) | n_pairs operational | n_pairs hindcast | Stations |
+|---------|----------------------:|--------------------:|-----------------:|:--------:|
+| day     | 6 789   | 260    | 6 529   | 66 |
+| pentad  | 126 380 | 25 947 | 100 433 | 81 |
+| decade  | 63 590  | 13 603 | 49 987  | 81 |
+| month   | 548 790 | 8 836  | 539 954 | 53 |
+| quarter | 30 709  | 826    | 29 883  | 53 |
+| season  | 16 494  | 723    | 15 771  | 51 |
 
 The **pooled station set is 83 distinct codes (65 Kyrgyz, 17 Tajik, 1 other)**;
 not every station has data at every horizon, so per-horizon coverage ranges from
-51 (season) to 81 (pentad/decade). n_pairs (all regimes) sums the paired counts
-over all models and both norm-provenance views for that horizon.
+51 (season) to 81 (pentad/decade).
+
+**Short-term operational counts fell sharply after de-leaking** (correction 1):
+the per-target dedup and issue-before-target filter drop the intraday re-issues
+and in-period nowcasts, so e.g. pentad EM operational n falls from 11 342 to
+3 384. The remaining pairs are genuine forecasts.
+
+**Long-term operational is now genuinely thin** (correction 2): only post-2026
+real-time forecasts qualify as operational (month L0 n = 40, quarter Q1 n = 40,
+season L0 n = 49). The robust long-term skill lives in the hindcast column
+(month 539 954 pairs, quarter 29 883, season 15 771), which is why the long-term
+sections lead with hindcast.
 
 **Org balance:** 65 Kyrgyz stations vs 17 Tajik (plus 1 other). Long-term
-(month/quarter/season) n_pairs are dominated by Kyrgyz stations;
-Tajik operational-month pairs are thin at leads ≥ 2. Metrics at those leads
-carry wide Wilson CIs and should be treated as low-confidence.
+n_pairs are dominated by Kyrgyz stations; Tajik pairs are thin at longer leads
+and carry wide Wilson CIs.
 
-**DAY horizon is exploratory:** n_pairs 632–1 090 across models (operational,
-POOLED). Results are consistent in direction but CIs are wide; do not
-over-interpret absolute numbers.
+**DAY horizon is exploratory:** operational n_pairs 56–108 across models after
+de-leaking (POOLED). Results are consistent in direction but CIs are very wide;
+do not over-interpret absolute numbers.
 
 ---
 
@@ -172,40 +227,43 @@ all stations, no per-station codes). Wilson 95 % CIs are shown for POD.
 
 | Model | TP | FP | FN | TN | n_pairs | base_rate | POD | FAR | HSS | PSS | POD CI 95 % |
 |-------|-----|-----|-----|-----|---------|-----------|-----|-----|-----|-----|-------------|
-| EM    | 4651 | 359 | 361 | 5971 | 11 342 | 0.44 | **0.928** | 0.072 | **0.871** | 0.871 | [0.920, 0.935] |
-| NE    | 4433 | 389 | 424 | 6279 | 11 525 | 0.42 | 0.913 | 0.081 | 0.855 | 0.854 | [0.904, 0.920] |
-| TiDE  | 2716 | 256 | 306 | 4099 | 7 377  | 0.41 | 0.899 | 0.086 | 0.842 | 0.840 | [0.887, 0.909] |
-| TSMixer | 2512 | 279 | 274 | 3629 | 6 694 | 0.42 | 0.902 | 0.100 | 0.830 | 0.830 | [0.890, 0.912] |
-| TFT   | 2671 | 314 | 326 | 4262 | 7 573  | 0.40 | 0.891 | 0.105 | 0.823 | 0.823 | [0.880, 0.902] |
-| LR    | 3466 | 400 | 810 | 8260 | 12 936 | 0.33 | 0.811 | 0.103 | 0.783 | 0.764 | [0.799, 0.822] |
+| EM    | 1261 | 109 | 141 | 1873 | 3 384 | 0.41 | **0.899** | 0.080 | **0.847** | 0.844 | [0.883, 0.914] |
+| TiDE  | 943  | 88  | 130 | 1371 | 2 532 | 0.42 | 0.879 | 0.085 | 0.823 | 0.819 | [0.858, 0.897] |
+| TFT   | 815  | 84  | 112 | 1229 | 2 240 | 0.41 | 0.879 | 0.093 | 0.819 | 0.815 | [0.857, 0.899] |
+| NE    | 897  | 88  | 121 | 1231 | 2 337 | 0.44 | 0.881 | 0.089 | 0.817 | 0.814 | [0.860, 0.900] |
+| TSMixer | 843 | 93  | 128 | 1452 | 2 516 | 0.39 | 0.868 | 0.099 | 0.813 | 0.808 | [0.845, 0.888] |
+| LR    | 3483 | 428 | 816 | 8211 | 12 938 | 0.33 | 0.810 | 0.109 | 0.778 | 0.761 | [0.798, 0.822] |
+
+(De-leaked, corrected run: only genuine forecasts issued before the target
+pentad, one per target. EM operational n falls from 11 342 to 3 384; HSS
+0.871 → 0.847. LR keeps a larger n because it is archived at one issue per target.)
 
 Key observations:
-- **FP/FN balance:** EM achieves near-equal FP and FN counts (359 vs 361,
-  ratio ≈ 1.00). NE is slightly FP-heavy (FN 424 > FP 389); LR is strongly
-  FN-heavy (FN 810 vs FP 400, ratio 0.49) — more missed limit-plan events.
-- All ML models substantially outperform LR on HSS and PSS.
-- **FN rate is low** for top models: EM misses only 7.2 % of true limit-plan
-  events (POD 0.928). FAR 7.2 % is operationally acceptable.
+- **FP/FN balance:** EM is close to balanced (FP 109 vs FN 141); LR is strongly
+  FN-heavy (FN 816 vs FP 428, ratio 0.52) — more missed limit-plan events.
+- All ML models still outperform LR on HSS and PSS after de-leaking.
+- **FN rate stays low** for top models: EM misses only ~10 % of true limit-plan
+  events (POD 0.899). FAR 8.0 % is operationally acceptable.
 
 #### Below-norm (1.0 × norm) — plain below-average flow (pentad)
 
 Reported side by side with the 0.80 table above. **Do not compare cell-for-cell:**
-the 1.0 × norm event is far more common (pentad base rate ≈ 0.60–0.70 vs ≈ 0.33–0.44
+the 1.0 × norm event is far more common (pentad base rate ≈ 0.64–0.68 vs ≈ 0.39–0.44
 for 0.80 × norm), so its POD/FAR/HSS describe general below-average-flow
 detection, not the limit-plan decision. HSS is compressed by the higher base
 rate and is *not* directly comparable to the 0.80 HSS.
 
 | Model | TP | FP | FN | TN | n_pairs | base_rate | POD | FAR | HSS | PSS | POD CI 95 % |
 |-------|-----|-----|-----|-----|---------|-----------|-----|-----|-----|-----|-------------|
-| EM    | 7565 | 357 | 339 | 3081 | 11 342 | 0.70 | **0.957** | 0.045 | **0.855** | 0.853 | [0.952, 0.961] |
-| NE    | 7412 | 400 | 401 | 3312 | 11 525 | 0.68 | 0.949 | 0.051 | 0.841 | 0.841 | [0.944, 0.953] |
-| TFT   | 4631 | 273 | 355 | 2314 | 7 573  | 0.66 | 0.929 | 0.056 | 0.817 | 0.823 | [0.921, 0.936] |
-| TiDE  | 4650 | 311 | 288 | 2128 | 7 377  | 0.67 | 0.942 | 0.063 | 0.816 | 0.814 | [0.935, 0.948] |
-| TSMixer | 4260 | 284 | 312 | 1838 | 6 694 | 0.68 | 0.932 | 0.062 | 0.795 | 0.798 | [0.924, 0.939] |
-| LR    | 7121 | 709 | 687 | 4419 | 12 936 | 0.60 | 0.912 | 0.091 | 0.774 | 0.774 | [0.906, 0.918] |
+| EM    | 2115 | 126 | 129 | 1014 | 3 384 | 0.66 | **0.943** | 0.056 | **0.831** | 0.832 | [0.932, 0.951] |
+| TFT   | 1373 | 85  | 102 | 680  | 2 240 | 0.66 | 0.931 | 0.058 | 0.815 | 0.820 | [0.917, 0.943] |
+| NE    | 1482 | 98  | 103 | 654  | 2 337 | 0.68 | 0.935 | 0.062 | 0.803 | 0.805 | [0.922, 0.946] |
+| TiDE  | 1581 | 109 | 122 | 720  | 2 532 | 0.67 | 0.928 | 0.064 | 0.794 | 0.797 | [0.915, 0.940] |
+| TSMixer | 1467 | 110 | 135 | 804 | 2 516 | 0.64 | 0.916 | 0.070 | 0.791 | 0.795 | [0.901, 0.928] |
+| LR    | 7151 | 723 | 678 | 4386 | 12 938 | 0.61 | 0.913 | 0.092 | 0.773 | 0.772 | [0.907, 0.919] |
 
-At the plain below-average threshold, POD rises across the board (EM 0.957) —
-most periods that fall short of the norm are detected — and FAR falls (EM 0.045)
+At the plain below-average threshold, POD rises across the board (EM 0.943) —
+most periods that fall short of the norm are detected — and FAR falls (EM 0.056)
 because the event is common. This is a description of below-average-flow
 detection only; the limit-plan decision remains the 0.80 table above.
 
@@ -213,55 +271,64 @@ detection only; the limit-plan decision remains the 0.80 table above.
 
 | Model | TP | FP | FN | TN | n_pairs | base_rate | POD | FAR | HSS | PSS | POD CI 95 % |
 |-------|-----|-----|-----|-----|---------|-----------|-----|-----|-----|-----|-------------|
-| EM    | 2267 | 168 | 239 | 2412 | 5 086 | 0.49 | **0.905** | 0.069 | **0.840** | 0.840 | [0.893, 0.916] |
-| NE    | 2623 | 266 | 319 | 3183 | 6 391 | 0.46 | 0.892 | 0.092 | 0.816 | 0.814 | [0.880, 0.902] |
-| TFT   | 1435 | 218 | 219 | 2205 | 4 077 | 0.41 | 0.868 | 0.132 | 0.778 | 0.778 | [0.850, 0.883] |
-| TiDE  | 1304 | 176 | 201 | 1871 | 3 552 | 0.42 | 0.866 | 0.119 | 0.782 | 0.780 | [0.848, 0.883] |
-| TSMixer | 1223 | 188 | 156 | 1539 | 3 106 | 0.44 | 0.887 | 0.133 | 0.776 | 0.778 | [0.869, 0.903] |
-| LR    | 1469 | 222 | 629 | 4107 | 6 427 | 0.33 | 0.700 | 0.131 | 0.683 | 0.649 | [0.680, 0.719] |
+| EM    | 639 | 71 | 117 | 1067 | 1 894 | 0.40 | **0.845** | 0.100 | **0.791** | 0.783 | [0.818, 0.869] |
+| NE    | 514 | 78 | 91  | 705  | 1 388 | 0.44 | 0.850 | 0.132 | 0.752 | 0.750 | [0.819, 0.876] |
+| TSMixer | 450 | 74 | 75 | 609 | 1 208 | 0.43 | 0.857 | 0.141 | 0.749 | 0.749 | [0.825, 0.884] |
+| TiDE  | 464 | 75 | 87  | 709  | 1 335 | 0.41 | 0.842 | 0.139 | 0.749 | 0.746 | [0.809, 0.870] |
+| TFT   | 458 | 79 | 90  | 722  | 1 349 | 0.41 | 0.836 | 0.147 | 0.739 | 0.737 | [0.802, 0.864] |
+| LR    | 1488 | 235 | 618 | 4088 | 6 429 | 0.33 | 0.707 | 0.136 | 0.684 | 0.652 | [0.687, 0.726] |
 
-Key observations: same pattern as pentad — EM leads, LR is FN-heavy (FN 629,
-ratio FP/FN = 0.35). TSMixer is slightly FP-heavy at decade scale (FN 156 < FP 188).
+(De-leaked, corrected run: only genuine forecasts issued before the target
+decade, one per target. EM operational n falls from 5 086 to 1 894; POD
+0.905 → 0.845, HSS 0.840 → 0.791. LR keeps a larger n because it is archived
+at one issue per target.)
+
+Key observations: same pattern as pentad — EM leads (POD 0.845, HSS 0.791),
+LR is strongly FN-heavy (FN 618 vs FP 235, ratio 0.38) — more missed
+limit-plan events. All ML models still clear LR on HSS after de-leaking.
 
 #### Below-norm (1.0 × norm) — plain below-average flow (decade)
 
 Side by side with the 0.80 table above. **Not comparable cell-for-cell:** the
-1.0 × norm event is more common (decade base rate ≈ 0.60–0.72 vs ≈ 0.33–0.49 for
+1.0 × norm event is more common (decade base rate ≈ 0.60–0.69 vs ≈ 0.33–0.44 for
 0.80 × norm); base-rate-sensitive HSS is compressed relative to the 0.80 story.
 
 | Model | TP | FP | FN | TN | n_pairs | base_rate | POD | FAR | HSS | PSS | POD CI 95 % |
 |-------|-----|-----|-----|-----|---------|-----------|-----|-----|-----|-----|-------------|
-| EM    | 3483 | 178 | 181 | 1244 | 5 086 | 0.72 | **0.951** | 0.049 | **0.825** | 0.825 | [0.943, 0.957] |
-| NE    | 4187 | 291 | 289 | 1624 | 6 391 | 0.70 | 0.935 | 0.065 | 0.784 | 0.783 | [0.928, 0.942] |
-| TFT   | 2448 | 209 | 230 | 1190 | 4 077 | 0.66 | 0.914 | 0.079 | 0.762 | 0.765 | [0.903, 0.924] |
-| TiDE  | 2189 | 201 | 200 | 962  | 3 552 | 0.67 | 0.916 | 0.084 | 0.744 | 0.743 | [0.904, 0.927] |
-| TSMixer | 2004 | 189 | 184 | 729 | 3 106 | 0.70 | 0.916 | 0.086 | 0.711 | 0.710 | [0.904, 0.927] |
-| LR    | 3305 | 499 | 556 | 2067 | 6 427 | 0.60 | 0.856 | 0.131 | 0.659 | 0.662 | [0.845, 0.867] |
+| EM    | 1167 | 98 | 85 | 544 | 1 894 | 0.66 | **0.932** | 0.077 | **0.783** | 0.779 | [0.917, 0.945] |
+| TFT   | 816  | 78 | 79 | 376 | 1 349 | 0.66 | 0.912 | 0.087 | 0.740 | 0.740 | [0.891, 0.929] |
+| TiDE  | 829  | 89 | 73 | 344 | 1 335 | 0.68 | 0.919 | 0.097 | 0.720 | 0.714 | [0.899, 0.935] |
+| NE    | 886  | 95 | 75 | 332 | 1 388 | 0.69 | 0.922 | 0.097 | 0.709 | 0.699 | [0.903, 0.937] |
+| TSMixer | 770 | 86 | 69 | 283 | 1 208 | 0.69 | 0.918 | 0.100 | 0.694 | 0.685 | [0.897, 0.935] |
+| LR    | 3355 | 505 | 519 | 2050 | 6 429 | 0.60 | 0.866 | 0.131 | 0.668 | 0.668 | [0.855, 0.876] |
 
-### Day (exploratory, n_pairs 632–1 090)
+### Day (exploratory, n_pairs 56–108)
 
 | Model | n_pairs | POD | FAR | HSS | PSS |
 |-------|---------|-----|-----|-----|-----|
-| TSMixer | 1 055 | 0.455 | 0.139 | 0.441 | 0.406 |
-| TiDE    | 1 090 | 0.578 | 0.246 | 0.451 | 0.438 |
-| TFT     | 632   | 0.623 | 0.232 | 0.538 | 0.516 |
+| TFT     | 56  | 0.571 | 0.059 | 0.536 | 0.536 |
+| TiDE    | 108 | 0.514 | 0.182 | 0.509 | 0.459 |
+| TSMixer | 96  | 0.517 | 0.375 | 0.403 | 0.383 |
 
-Day-horizon skill is substantially lower than pentad/decade. POD ~0.46–0.62
-with HSS ~0.44–0.54. With only 632–1 090 pairs the CIs are wide; interpret with
-caution. The small sample reflects that day-resolution ML archive is limited to
-approximately the last 1–2 years (vs 15+ years for pentad/decade).
+Day-horizon skill is substantially lower than pentad/decade. POD ~0.51–0.57
+with HSS ~0.40–0.54. After de-leaking, the day operational archive collapses to
+only 56–108 genuine pairs per model, so the CIs are very wide (±0.15–0.17 on
+POD); interpret direction only, not absolute numbers. The tiny sample reflects
+that the day-resolution ML archive is limited to approximately the last 1–2
+years (vs 15+ years for pentad/decade) and that de-leaking keeps only one
+genuine forecast per target.
 
 #### Below-norm (1.0 × norm) — plain below-average flow (day)
 
 Side by side with the 0.80 day table above. **Not comparable cell-for-cell:**
-the day 1.0 × norm base rate (≈ 0.70–0.74) is far higher than the 0.80 × norm
-base rate (≈ 0.36–0.43), so HSS is not comparable across the two events.
+the day 1.0 × norm base rate (≈ 0.61–0.84) is far higher than the 0.80 × norm
+base rate (≈ 0.30–0.50), so HSS is not comparable across the two events.
 
 | Model | n_pairs | POD | FAR | HSS | PSS |
 |-------|---------|-----|-----|-----|-----|
-| TFT     | 632   | 0.728 | 0.103 | 0.476 | 0.534 |
-| TiDE    | 1 090 | 0.869 | 0.138 | 0.469 | 0.466 |
-| TSMixer | 1 055 | 0.704 | 0.128 | 0.360 | 0.420 |
+| TFT     | 56  | 0.723 | 0.029 | 0.398 | 0.612 |
+| TiDE    | 108 | 0.682 | 0.224 | 0.360 | 0.372 |
+| TSMixer | 96  | 0.705 | 0.127 | 0.197 | 0.261 |
 
 ---
 
@@ -271,109 +338,138 @@ Long-term horizons emit **no lead-aggregated POOLED row**. Every metric is
 per-lead. Figures label these `month L0`, `month L1`, etc. where lead 0 is
 the nearest forecast (i.e., smallest forecast offset).
 
-### Month (EM, operational, POOLED, official provenance)
+**Regime note (correction 2).** Real-time long-term forecasting at these sites
+only began around 2026, so the genuine-operational archive is very thin (month
+L0 n = 40, quarter Q1 n = 40, season L0 n = 49) and cannot carry a reliable
+skill estimate. The **robust** long-term skill lives in the full pre-2026
+**hindcast** archive. Each section below therefore **leads with the hindcast
+tables** and reports the genuine-2026 operational numbers only as a short
+*preliminary — too thin to score* footnote. The operational-vs-hindcast contrast
+is the subject of **fig3**.
+
+### Month — HINDCAST (EM, POOLED, official provenance) — robust
 
 | Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS | POD CI 95 % |
 |------|-----|-----|-----|------|---------|-----|-----|-----|-----|-------------|
-| L0   | 1567 | 120 | 271 | 7459 | 9 417 | **0.853** | 0.071 | **0.864** | 0.837 | [0.836, 0.868] |
-| L1   | 354  | 40  | 79  | 2126 | 2 599 | 0.818 | 0.102 | 0.829 | 0.799 | [0.778, 0.851] |
-| L2   | 89   | 4   | 29  | 552  | 674   | 0.754 | 0.043 | 0.815 | 0.747 | [0.669, 0.823] |
-| L3   | 32   | 6   | 18  | 492  | 548   | 0.640 | 0.158 | 0.704 | 0.628 | [0.501, 0.759] |
-| L4+  | — | — | — | — | thin | — | — | — | — | — |
+| L0   | 1402 | 96 | 207 | 5376 | 7 081 | **0.871** | 0.064 | **0.875** | 0.854 | [0.854, 0.887] |
+| L1   | 375  | 32 | 83  | 1675 | 2 165 | 0.819 | 0.079 | 0.834 | 0.800 | [0.781, 0.851] |
+| L2   | 96   | 2  | 30  | 585  | 713   | 0.762 | 0.020 | 0.831 | 0.758 | [0.680, 0.828] |
+| L3   | 52   | 7  | 28  | 557  | 644   | 0.650 | 0.119 | 0.719 | 0.638 | [0.541, 0.745] |
 
-The month archive grew substantially since the previous run (L0 n_pairs
-5 768 → 9 417). HSS degrades from L0 (0.864) to L3 (0.704). Leads L4–L12 have
-very few pairs, concentrated on a small set of Kyrgyz stations; metrics should
-be treated as low-confidence.
+HSS degrades gently from L0 (0.875) to L3 (0.719). The hindcast archive is
+robust (L0 n_pairs 7 081). Leads L4–L12 exist but are sparse and concentrated on
+a small set of Kyrgyz stations; the figures cap month at L0–L3.
 
-**Naive Mean** (unweighted average of all model forecasts, no skill weighting)
-is available at all leads (L0 n_pairs 12 442):
-- L0: POD 0.788, FAR 0.102, HSS 0.804 — EM substantially outperforms.
-- L3: POD 0.334, FAR 0.245, HSS 0.396 — EM at L3 still outperforms (HSS 0.704).
+Among all long-term models, EM leads the month L0 hindcast (HSS 0.875), just
+ahead of **Skilled Mean** (POD 0.877, FAR 0.095, HSS 0.862) and well above the
+**Naive Mean** (POD 0.778, HSS 0.794), MC_ALD (0.819), GBT (0.789) and LR_Base
+(0.776). The skill-weighted ensemble genuinely beats the straight average.
 
-**Skilled Mean** (ensemble of trained long-term models) at L0:
-- POD 0.852, FAR 0.097, HSS 0.844 — n_pairs 6 765 (broad coverage).
-- Strongly positive skill over climatology; at this run EM edges it at L0
-  (HSS 0.864 vs 0.844).
+**Preliminary — genuine-2026 operational (too thin to score).** Month
+operational EM: L0 n = 40 (POD 0.571, HSS 0.688), L1 n = 21 (POD/HSS = 1.000, a
+20-event artefact), L2 n = 14, L3 n = 5. These carry Wilson CIs so wide they
+convey no reliable signal; use the hindcast table above. (Across all models the
+best-sampled operational L0 cell is MC_ALD at n = 134, HSS 0.820 — still an
+order of magnitude below the hindcast sample.)
 
-#### Below-norm (1.0 × norm) — plain below-average flow (month, EM per-lead)
+#### Below-norm (1.0 × norm) — plain below-average flow (month hindcast, EM per-lead)
 
-Side by side with the 0.80 month table above. **Not comparable cell-for-cell:**
-the 1.0 × norm month event is much more common (base rate ≈ 0.23–0.43 vs
-≈ 0.09–0.20 for 0.80 × norm), and base-rate-sensitive HSS shifts accordingly.
+Side by side with the 0.80 hindcast table above. **Not comparable cell-for-cell:**
+the 1.0 × norm month event is much more common (base rate ≈ 0.32–0.48 vs
+≈ 0.12–0.23 for 0.80 × norm), and base-rate-sensitive HSS shifts accordingly.
 
 | Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS | POD CI 95 % |
 |------|-----|-----|-----|------|---------|-----|-----|-----|-----|-------------|
-| L0   | 3672 | 194 | 334 | 5217 | 9 417 | **0.917** | 0.050 | **0.885** | 0.881 | [0.908, 0.925] |
-| L1   | 921  | 74  | 98  | 1506 | 2 599 | 0.904 | 0.074 | 0.861 | 0.857 | [0.884, 0.920] |
-| L2   | 213  | 8   | 36  | 417  | 674   | 0.855 | 0.036 | 0.857 | 0.837 | [0.806, 0.894] |
-| L3   | 99   | 9   | 26  | 414  | 548   | 0.792 | 0.083 | 0.810 | 0.771 | [0.713, 0.854] |
+| L0   | 3172 | 154 | 247 | 3508 | 7 081 | **0.928** | 0.046 | **0.887** | 0.886 | [0.919, 0.936] |
+| L1   | 906  | 72  | 111 | 1076 | 2 165 | 0.891 | 0.074 | 0.830 | 0.828 | [0.870, 0.909] |
+| L2   | 250  | 10  | 32  | 421  | 713   | 0.887 | 0.038 | 0.875 | 0.863 | [0.844, 0.918] |
+| L3   | 172  | 17  | 34  | 421  | 644   | 0.835 | 0.090 | 0.814 | 0.796 | [0.778, 0.879] |
 
-### Quarter (EM, operational, POOLED, aggregated_from_monthly)
+### Quarter — HINDCAST (EM, POOLED, aggregated_from_monthly) — robust, by target quarter
 
-| Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS |
-|------|-----|-----|-----|------|---------|-----|-----|-----|-----|
-| L1   | 86  | 35  | 164 | 2276 | 2 561 | 0.344 | 0.289 | 0.427 | 0.329 |
-| L2   | 24  | 20  | 0   | 39   | 83    | **1.000** | 0.455 | 0.530 | 0.661 |
-| L3   | 42  | 9   | 18  | 98   | 167   | 0.700 | 0.176 | 0.637 | 0.616 |
-| L4   | 53  | 28  | 14  | 357  | 452   | 0.791 | 0.346 | 0.661 | 0.718 |
+Quarter is now **deduped** (one forecast per station / target quarter / year /
+model) and stratified by **target quarter Q1–Q4**, each effectively a
+single-lead forecast. (The earlier draft's L1–L4 "leads" were an artefact of an
+overloaded `horizon_value` — see **Corrections in this revision**.)
 
-Quarter L2 has only 83 pairs (small n, POD of 1.0 is artefact). L1 is the
-best-sampled lead (2 561 pairs) and shows modest skill (HSS 0.427). L4 shows
-better POD (0.791) but n_pairs remains limited.
+| Target quarter | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS | POD CI 95 % |
+|------|-----|-----|-----|------|---------|-----|-----|-----|-----|-------------|
+| Q1 (Jan–Mar) | 35 | 7  | 34 | 789 | 865 | 0.507 | 0.167 | **0.607** | 0.498 | [0.392, 0.622] |
+| Q2 (Apr–Jun) | 25 | 18 | 0  | 39  | 82  | **1.000** | 0.419 | 0.569 | 0.684 | [0.867, 1.000] |
+| Q3 (Jul–Sep) | 36 | 9  | 17 | 82  | 144 | 0.679 | 0.200 | 0.599 | 0.580 | [0.545, 0.789] |
+| Q4 (Oct–Dec) | 27 | 16 | 79 | 767 | 889 | 0.255 | 0.372 | **0.315** | 0.234 | [0.181, 0.345] |
 
-**LR_Base** at L1: POD 0.316, FAR 0.371, HSS 0.380 — positive but weaker
-than EM.
+**Q4 (Oct–Dec) is markedly harder than Q1 (Jan–Mar).** The two well-sampled
+quarters carry the operational story: EM hindcast HSS falls from **0.607 at Q1**
+(POD 0.507, base rate 0.08) to **0.315 at Q4** (POD 0.255, base rate 0.12) —
+autumn/early-winter below-norm quarters are missed far more often (Q4: 79 misses
+vs only 27 hits). **Q2 and Q3 are thin for EM** (n = 82 and 144), so their high
+POD/HSS should be read with caution (Q2 POD 1.000 is a zero-miss, small-n
+artefact); the robust EM signal is Q1 and Q4. At the quarter horizon the
+below-norm event is rare in the well-sampled quarters (base rate ≈ 0.08–0.12)
+and hard to catch.
 
-**GBT** at L1: POD 0.415, FAR 0.182, HSS 0.512 — better than EM at L1 in HSS
-with lower FAR; n_pairs 1 096.
+**Preliminary — genuine-2026 operational (too thin to score).** Real-time 2026
+so far covers only the year's first quarters: quarter operational EM Q1 n = 40
+(POD 0.667, FAR 0.250, HSS 0.627), Q2 n = 2 (undefined). Rely on the hindcast
+table.
 
-#### Below-norm (1.0 × norm) — plain below-average flow (quarter, EM per-lead)
+#### Below-norm (1.0 × norm) — plain below-average flow (quarter hindcast, EM by target quarter)
 
-Side by side with the 0.80 quarter table above. **Not comparable cell-for-cell:**
-the 1.0 × norm quarter event is far more common (base rate ≈ 0.31–0.64 vs
-≈ 0.10–0.36 for 0.80 × norm); HSS shifts with the base rate.
+Side by side with the 0.80 hindcast table above. **Not comparable cell-for-cell:**
+the 1.0 × norm quarter event is far more common (base rate ≈ 0.31–0.62 vs
+≈ 0.08–0.37 for 0.80 × norm); HSS shifts with the base rate.
 
-| Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS |
-|------|-----|-----|-----|------|---------|-----|-----|-----|-----|
-| L1   | 483 | 137 | 300 | 1641 | 2 561 | 0.617 | 0.221 | 0.573 | 0.540 |
-| L2   | 41  | 16  | 6   | 20   | 83    | **0.872** | 0.281 | 0.442 | 0.428 |
-| L3   | 85  | 10  | 21  | 51   | 167   | 0.802 | 0.105 | 0.614 | 0.638 |
-| L4   | 163 | 52  | 13  | 224  | 452   | 0.926 | 0.242 | 0.709 | 0.738 |
+| Target quarter | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS | POD CI 95 % |
+|------|-----|-----|-----|------|---------|-----|-----|-----|-----|-------------|
+| Q1 (Jan–Mar) | 177 | 31 | 87  | 570 | 865 | 0.670 | 0.149 | 0.658 | 0.619 | [0.612, 0.724] |
+| Q2 (Apr–Jun) | 39  | 16 | 5   | 22  | 82  | 0.886 | 0.291 | 0.475 | 0.465 | [0.760, 0.950] |
+| Q3 (Jul–Sep) | 70  | 10 | 19  | 45  | 144 | 0.787 | 0.125 | 0.586 | 0.605 | [0.690, 0.859] |
+| Q4 (Oct–Dec) | 176 | 62 | 128 | 523 | 889 | 0.579 | 0.261 | 0.499 | 0.473 | [0.523, 0.633] |
 
-### Season (EM, operational, POOLED, aggregated_from_monthly)
+The per-quarter figures **fig1_quarter** and **fig4_quarter** now show the Q1–Q4
+target-quarter stratification (they previously showed the bogus L1–L4 leads).
 
-| Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS |
-|------|-----|-----|-----|-----|---------|-----|-----|-----|-----|
-| L0   | 130 | 59  | 186 | 1064 | 1 439 | 0.411 | 0.312 | 0.419 | 0.359 |
-| L1   | 155 | 102 | 274 | 1402 | 1 933 | 0.361 | 0.397 | 0.343 | 0.293 |
-| L2   | 66  | 41  | 124 | 670  | 901   | 0.347 | 0.383 | 0.345 | 0.290 |
-| L3   | 67  | 51  | 132 | 662  | 912   | 0.337 | 0.432 | 0.311 | 0.265 |
+### Season — HINDCAST (EM, POOLED, aggregated_from_monthly) — robust, by genuine lead
 
-Seasonal forecasts have moderate positive skill (HSS 0.31–0.42) across all
-leads, but POD is only 0.34–0.41. That means **roughly 59–66 % of true
-limit-plan seasons are missed** at the seasonal horizon — consistent with the
-fundamental difficulty of seasonal prediction. FAR is also elevated (0.31–0.43),
-meaning around 1 in 3 season-ahead limit-plan signals is a false alarm.
-Nevertheless, HSS > 0 confirms skill over climatology at all leads.
+Season is shown by its **genuine forecast leads 0–3** (re-issues deduped within
+each lead, ~870 pairs per lead). Lead 0 is the nearest forecast.
 
-**LR_Base** at all season leads: HSS 0.33–0.36, POD 0.34–0.36, FAR 0.31–0.42
-— nearly identical to EM. No clear advantage of ML over LR at the seasonal
+| Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS | POD CI 95 % |
+|------|-----|-----|-----|-----|---------|-----|-----|-----|-----|-------------|
+| L0   | 91 | 36 | 97  | 659 | 883 | 0.484 | 0.283 | **0.490** | 0.432 | [0.414, 0.555] |
+| L1   | 69 | 36 | 116 | 655 | 876 | 0.373 | 0.343 | 0.381 | 0.321 | [0.307, 0.445] |
+| L2   | 63 | 40 | 119 | 649 | 871 | 0.346 | 0.388 | 0.343 | 0.288 | [0.281, 0.418] |
+| L3   | 58 | 42 | 125 | 639 | 864 | 0.317 | 0.420 | 0.306 | 0.255 | [0.254, 0.388] |
+
+Seasonal forecasts carry only **modest** positive skill (HSS 0.31–0.49) and low
+POD (0.32–0.48) across all leads: **roughly 52–68 % of true limit-plan seasons
+are missed**, consistent with the fundamental difficulty of seasonal prediction.
+FAR is elevated (0.28–0.42) — around 1 in 3 season-ahead limit-plan signals is a
+false alarm. Nevertheless HSS > 0 confirms skill over climatology at every lead,
+and HSS degrades gently from L0 (0.490) to L3 (0.306). At season, EM and Naive
+Mean coincide (the ensemble reduces to the straight average), and **LR_Base** is
+competitive (L0 HSS 0.419, L1 0.362) — no clear ML advantage at the seasonal
 scale.
 
-#### Below-norm (1.0 × norm) — plain below-average flow (season, EM per-lead)
+**Preliminary — genuine-2026 operational (too thin to score).** Season
+operational EM: L0 n = 49 (POD 0.375, FAR 0.500, HSS 0.206), L1 n = 49 (POD
+0.375, HSS 0.171). Directionally consistent with the hindcast (weak positive
+skill) but far too few pairs for a firm estimate.
 
-Side by side with the 0.80 season table above. **Not comparable cell-for-cell:**
-the 1.0 × norm season event is much more common (base rate ≈ 0.49–0.51 vs
-≈ 0.21–0.22 for 0.80 × norm), so its higher POD/HSS reflect the higher base
-rate — not stronger limit-plan detection.
+#### Below-norm (1.0 × norm) — plain below-average flow (season hindcast, EM per-lead)
 
-| Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS |
-|------|-----|-----|-----|-----|---------|-----|-----|-----|-----|
-| L0   | 478 | 131 | 228 | 602 | 1 439 | 0.677 | 0.215 | 0.500 | 0.498 |
-| L1   | 646 | 189 | 338 | 760 | 1 933 | 0.657 | 0.226 | 0.456 | 0.457 |
-| L2   | 298 | 86  | 152 | 365 | 901   | 0.662 | 0.224 | 0.472 | 0.472 |
-| L3   | 294 | 92  | 165 | 361 | 912   | 0.641 | 0.238 | 0.437 | 0.437 |
+Side by side with the 0.80 hindcast table above. **Not comparable cell-for-cell:**
+the 1.0 × norm season event is much more common (base rate ≈ 0.50 vs ≈ 0.21 for
+0.80 × norm), so its higher POD/HSS reflect the higher base rate — not stronger
+limit-plan detection.
+
+| Lead | TP | FP | FN | TN | n_pairs | POD | FAR | HSS | PSS | POD CI 95 % |
+|------|-----|-----|-----|-----|---------|-----|-----|-----|-----|-------------|
+| L0   | 315 | 81 | 124 | 363 | 883 | 0.718 | 0.205 | 0.535 | 0.535 | [0.674, 0.758] |
+| L1   | 295 | 79 | 139 | 363 | 876 | 0.680 | 0.211 | 0.502 | 0.501 | [0.634, 0.722] |
+| L2   | 285 | 82 | 146 | 358 | 871 | 0.661 | 0.223 | 0.476 | 0.475 | [0.615, 0.704] |
+| L3   | 272 | 82 | 157 | 353 | 864 | 0.634 | 0.232 | 0.446 | 0.446 | [0.587, 0.678] |
 
 ---
 
@@ -396,32 +492,38 @@ below-norm) and the events climatology misses entirely:
 
 (Base rates are for the operational **0.80 × norm** limit-plan event.)
 
+Short-term rows are operational (de-leaked); long-term rows are hindcast (the
+robust regime these sections lead with).
+
 | Horizon | Base rate | Events missed by climatology |
 |---------|-----------|------------------------------|
-| day     | ≈ 0.40    | ~40 % of all day-periods (varies 0.36–0.43 by model) |
-| pentad  | 0.44      | 44 % of all pentad-periods |
-| decade  | 0.49      | 49 % of all decade-periods |
-| month (L0) | 0.20  | 20 % of all month-periods |
-| quarter (L1) | 0.10 | 10 % of all quarter-periods |
-| season (L0) | 0.22  | 22 % of all season-periods |
+| day     | ≈ 0.30–0.50 | 30–50 % of all day-periods (varies by model) |
+| pentad  | 0.41      | 41 % of all pentad-periods |
+| decade  | 0.40      | 40 % of all decade-periods |
+| month (L0, hindcast) | 0.23  | 23 % of all month-periods |
+| quarter (Q1, hindcast) | 0.08 | 8 % of all quarter-periods (Q1) |
+| season (L0, hindcast) | 0.21  | 21 % of all season-periods |
 
 **Are our forecasts better than climatology?**
 
 Yes — decisively for short-term, positive but weaker for long-term.
 
-- **Pentad EM** (POD 0.928, HSS 0.871 vs climatology POD 0, HSS 0): EM
-  catches 92.8 % of the below-norm shortage events that climatology misses
-  entirely.  At a pentad base rate of 0.44, climatology flags zero events; EM
-  flags 93 % of the genuine ones.
-- **Decade EM** (POD 0.905, HSS 0.840): EM catches 90.5 % of events
-  climatology misses.  Stronger than LR (POD 0.700, HSS 0.683).
-- **Month L0 EM / Skilled Mean** (POD 0.853–0.852, HSS 0.864–0.844): strong
-  skill; climatology misses all 20 % of below-norm months.  Monthly forecasts
-  are reliable enough to inform seasonal irrigation planning one month ahead.
-- **Quarter L1 EM** (POD 0.344, HSS 0.427): positive but modest.  Climatology
-  misses all 10 % of below-norm quarters; EM catches 34.4 % of them.
-- **Season L0 EM** (POD 0.411, HSS 0.419): weak but positive.  Climatology
-  misses all 22 % of below-norm seasons; EM catches 41.1 % of them.
+- **Pentad EM** (POD 0.899, HSS 0.847 vs climatology POD 0, HSS 0): EM
+  catches 89.9 % of the below-norm shortage events that climatology misses
+  entirely.  At a pentad base rate of 0.41, climatology flags zero events; EM
+  flags 90 % of the genuine ones.
+- **Decade EM** (POD 0.845, HSS 0.791): EM catches 84.5 % of events
+  climatology misses.  Stronger than LR (POD 0.707, HSS 0.684).
+- **Month L0 EM / Skilled Mean** (hindcast POD 0.871–0.877, HSS 0.875–0.862):
+  strong skill; climatology misses all 23 % of below-norm months.  Monthly
+  forecasts are reliable enough to inform seasonal irrigation planning one month
+  ahead.
+- **Quarter Q1 EM** (hindcast POD 0.507, HSS 0.607): positive and moderate.
+  Climatology misses all 8 % of below-norm Q1 quarters; EM catches 50.7 % of them
+  (other models do better — Skilled Mean HSS 0.736). Q4 is much harder (HSS
+  0.315) — see the per-target-quarter Quarter section.
+- **Season L0 EM** (hindcast POD 0.484, HSS 0.490): weak but positive.
+  Climatology misses all 21 % of below-norm seasons; EM catches 48.4 % of them.
 
 In every fig4 panel, a labelled annotation shows the climatology reference
 (POD = 0, HSS = 0, base rate) so the gain from any real model is immediately
@@ -439,7 +541,7 @@ distinct concepts:
 |-----------|-----------|-------------|-------------|
 | Climatology | Always predicts norm, never alarms | 0.000 | 0.000 |
 | Naive Mean  | Unweighted average of all model outputs | ~0.8–0.9 | ~0.8–0.9 |
-| EM (best ensemble) | Skill-weighted ensemble | 0.928 | 0.871 |
+| EM (best ensemble) | Skill-weighted ensemble | 0.899 | 0.847 |
 
 In fig4, Naive Mean appears with a **purple** tick label (family "Unweighted
 mean"), clearly separated from the green skill-weighted ensembles (EM, NE,
@@ -451,10 +553,11 @@ For short-term horizons (where LR is directly available), LR is included as a
 named model.  For long-term horizons, LR_Base is the proxy.
 
 Summary of best model vs. climatology vs. LR:
-- **Pentad EM**: HSS 0.871 — far above climatology (0.00). Beats LR (0.783).
-- **Decade EM**: HSS 0.840 — far above climatology. Beats LR (0.683).
-- **Month L0 EM**: HSS 0.864 — strong skill. Naive Mean HSS 0.804.
-- **Season L0 EM**: HSS 0.419 — positive but modest; LR_Base similar (0.361).
+- **Pentad EM**: HSS 0.847 — far above climatology (0.00). Beats LR (0.778).
+- **Decade EM**: HSS 0.791 — far above climatology. Beats LR (0.684).
+- **Month L0 EM** (hindcast): HSS 0.875 — strong skill. Naive Mean HSS 0.794.
+- **Season L0 EM** (hindcast): HSS 0.490 — positive but modest; LR_Base similar
+  (0.419).
 
 For pentad/decade, ML ensemble models (EM, NE) substantially exceed the LR
 baseline. For season, the gap narrows and LR_Base is competitive with EM.
@@ -472,23 +575,27 @@ canonical provenance; comparison model = EM except day = TFT):
 
 | Horizon | Persistence POD | Persistence FAR | Persistence HSS | n_matched |
 |---------|----------------|----------------|----------------|-----------|
-| day     | 0.987 | 0.154 | **0.854** | 632 |
-| pentad  | 0.851 | 0.141 | 0.742 | 11 329 |
-| decade  | 0.785 | 0.144 | 0.659 | 5 063 |
-| month L0 | 0.528 | 0.403 | 0.461 | 9 391 |
-| quarter L1 | 0.229 | 0.678 | 0.203 | 2 507 |
-| season L0 | 0.376 | 0.624 | 0.202 | 1 390 |
+| day     | 1.000 | 0.152 | **0.821** | 56 |
+| pentad  | 0.859 | 0.156 | 0.745 | 3 380 |
+| decade  | 0.780 | 0.216 | 0.639 | 1 876 |
+| month L0 | 0.583 | 0.369 | 0.496 | 7 057 |
+| quarter Q1 | 0.368 | 0.671 | 0.287 | 846 |
+| season L0 | 0.376 | 0.606 | 0.226 | 847 |
+
+(Short-term rows are operational and de-leaked, matched to the same instances as
+the comparison model — hence n_matched drops with the de-leaked archive. Month /
+quarter / season rows are hindcast, matched to the EM hindcast.)
 
 **Three-way skill ladder — climatology / persistence / best model:**
 
 | Horizon | Climatology HSS | Persistence HSS | Best model HSS | Winner |
 |---------|:--------------:|:--------------:|:-------------:|--------|
-| day     | 0 | 0.854 | 0.538 (TFT) | **Persistence** |
-| pentad  | 0 | 0.742 | 0.871 (EM)   | EM |
-| decade  | 0 | 0.659 | 0.840 (EM)   | EM |
-| month L0 | 0 | 0.461 | 0.864 (EM)  | EM |
-| quarter L1 | 0 | 0.203 | 0.427 (EM) | EM |
-| season L0 | 0 | 0.202 | 0.419 (EM)  | EM |
+| day     | 0 | 0.821 | 0.536 (TFT) | **Persistence** |
+| pentad  | 0 | 0.745 | 0.847 (EM)   | EM |
+| decade  | 0 | 0.639 | 0.791 (EM)   | EM |
+| month L0 | 0 | 0.496 | 0.875 (EM)  | EM |
+| quarter Q1 | 0 | 0.287 | 0.607 (EM) | EM |
+| season L0 | 0 | 0.226 | 0.490 (EM)  | EM |
 
 Key findings:
 
@@ -497,15 +604,15 @@ Key findings:
   below both persistence and the trained models.
 - **Candidate models beat persistence from pentad onwards.**  At pentad and
   longer horizons the ensemble and ML models consistently outperform
-  persistence, with the gap growing at longer leads: +0.13 at pentad,
-  +0.18 at decade, +0.40 at month L0.  This is the expected pattern for
+  persistence, with the gap growing at longer leads: +0.10 at pentad,
+  +0.15 at decade, +0.38 at month L0.  This is the expected pattern for
   well-trained models — as persistence degrades with longer forecast lead,
   the models' learned climatological signal takes over.
 - **At the day scale, persistence beats our thin ML models.**  Day-horizon
-  persistence achieves HSS 0.85 against only 0.44–0.54 for TFT/TSMixer/TiDE.
-  This is largely a sample-size effect: day-horizon ML forecasts are drawn
-  from a very small operational archive (n = 632–1 090 vs ~12 000+ at pentad).
-  With more operational data the gap would likely close, but day-ahead
+  persistence achieves HSS 0.82 against only 0.40–0.54 for TFT/TSMixer/TiDE.
+  This is largely a sample-size effect: after de-leaking, day-horizon ML
+  forecasts are drawn from a tiny operational archive (n = 56–108 vs ~3 400 at
+  pentad).  With more operational data the gap would likely close, but day-ahead
   persistence (last observed flow) is a very strong competitor at this scale.
 
 The three-way ladder is visualised in **fig5_persistence_vs_models.png**.
@@ -516,17 +623,22 @@ persistence as reference annotations in the lower-right corner.
 
 ## Lead-time stratification summary
 
+Long-term rows are hindcast (the robust regime).
+
 | Horizon | Best lead | HSS (best) | HSS (worst shown) | Degradation |
 |---------|-----------|-----------|-------------------|-------------|
-| day     | n/a (no lead) | 0.538 (TFT) | — | — |
-| pentad  | n/a       | 0.871 (EM) | — | — |
-| decade  | n/a       | 0.840 (EM) | — | — |
-| month   | L0        | 0.864 (EM) | 0.704 (L3) | −0.16 over 3 leads |
-| quarter | L4        | 0.661 (EM) | 0.427 (L1) | varies non-monotonically |
-| season  | L0        | 0.419 (EM) | 0.311 (L3) | −0.11 over 3 leads |
+| day     | n/a (no lead) | 0.536 (TFT) | — | — |
+| pentad  | n/a       | 0.847 (EM) | — | — |
+| decade  | n/a       | 0.791 (EM) | — | — |
+| month   | L0        | 0.875 (EM) | 0.719 (L3) | −0.16 over 3 leads |
+| quarter | Q1 (target qtr) | 0.607 (EM) | 0.315 (Q4) | by target quarter, not lead |
+| season  | L0        | 0.490 (EM) | 0.306 (L3) | −0.18 over 3 leads |
 
 Month shows the clearest monotonic degradation with lead. Season degrades more
-slowly but is moderate at all leads.
+slowly but is moderate-to-weak at all leads. **Quarter is no longer
+lead-stratified** — it is now reported per target quarter (Q1–Q4); Q1 (Jan–Mar)
+is the best-sampled, strongest quarter (HSS 0.607) and Q4 (Oct–Dec) the hardest
+(HSS 0.315), so the "best/worst" columns above are Q1 and Q4 rather than leads.
 
 ---
 
@@ -538,8 +650,10 @@ Phase-2 re-run splits every metric into three season cuts:
 - **non_irrigation** — Oct–Mar (low-demand period)
 - **all** — full year (same as the numbers in the sections above)
 
-All rows below are **operational regime, POOLED, basin = all, EM model,
-canonical provenance**.
+All rows below are **basin = all, EM model, canonical provenance**. Short-term
+horizons (pentad, decade) are **operational** (de-leaked); month L0 and
+season L0 are **hindcast** (the robust regime these long-term sections lead
+with).
 
 ### Seasonal POD / FAR / HSS table (EM, POOLED)
 
@@ -549,26 +663,26 @@ Both events are shown. **The two events are not comparable cell-for-cell**
 
 | Horizon | Event | Season | n | POD | FAR | HSS | POD CI 95 % |
 |---------|-------|--------|---|-----|-----|-----|-------------|
-| pentad | 0.80 | all | 11 342 | 0.928 | 0.072 | 0.871 | [0.920, 0.935] |
-| pentad | 0.80 | irrigation (Apr–Sep) | 6 820 | **0.933** | 0.072 | 0.856 | [0.924, 0.941] |
-| pentad | 0.80 | non-irrigation (Oct–Mar) | 4 522 | 0.916 | 0.071 | **0.885** | [0.900, 0.929] |
-| pentad | 1.0  | all | 11 342 | 0.957 | 0.045 | 0.855 | [0.952, 0.961] |
-| pentad | 1.0  | irrigation (Apr–Sep) | 6 820 | 0.958 | 0.040 | 0.839 | [0.952, 0.963] |
-| pentad | 1.0  | non-irrigation (Oct–Mar) | 4 522 | 0.955 | 0.054 | 0.868 | [0.947, 0.962] |
-| decade | 0.80 | all | 5 086 | 0.905 | 0.069 | 0.840 | [0.893, 0.916] |
-| decade | 0.80 | irrigation (Apr–Sep) | 2 821 | **0.905** | 0.066 | 0.799 | [0.890, 0.918] |
-| decade | 0.80 | non-irrigation (Oct–Mar) | 2 265 | 0.904 | 0.075 | **0.869** | [0.882, 0.923] |
-| decade | 1.0  | all | 5 086 | 0.951 | 0.049 | 0.825 | [0.943, 0.957] |
-| decade | 1.0  | irrigation (Apr–Sep) | 2 821 | 0.949 | 0.047 | 0.756 | [0.939, 0.957] |
-| decade | 1.0  | non-irrigation (Oct–Mar) | 2 265 | 0.953 | 0.052 | 0.870 | [0.941, 0.963] |
-| month L0 | 0.80 | all | 9 417 | 0.853 | 0.071 | 0.864 | [0.836, 0.868] |
-| month L0 | 0.80 | irrigation (Apr–Sep) | 3 664 | **0.864** | 0.081 | 0.844 | [0.843, 0.883] |
-| month L0 | 0.80 | non-irrigation (Oct–Mar) | 5 753 | 0.834 | 0.054 | **0.871** | [0.804, 0.859] |
-| month L0 | 1.0  | all | 9 417 | 0.917 | 0.050 | 0.885 | [0.908, 0.925] |
-| month L0 | 1.0  | irrigation (Apr–Sep) | 3 664 | 0.922 | 0.052 | 0.858 | [0.909, 0.933] |
-| month L0 | 1.0  | non-irrigation (Oct–Mar) | 5 753 | 0.911 | 0.048 | 0.896 | [0.898, 0.923] |
-| season L0 | 0.80 | all / irrigation | 1 439 | 0.411 | 0.312 | 0.419 | [0.359, 0.466] |
-| season L0 | 1.0  | all / irrigation | 1 439 | 0.677 | 0.215 | 0.500 | [0.642, 0.711] |
+| pentad | 0.80 | all | 3 384 | 0.899 | 0.080 | 0.847 | [0.883, 0.914] |
+| pentad | 0.80 | irrigation (Apr–Sep) | 1 687 | 0.893 | 0.086 | 0.814 | [0.870, 0.912] |
+| pentad | 0.80 | non-irrigation (Oct–Mar) | 1 697 | **0.908** | 0.071 | **0.877** | [0.882, 0.929] |
+| pentad | 1.0  | all | 3 384 | 0.943 | 0.056 | 0.831 | [0.932, 0.951] |
+| pentad | 1.0  | irrigation (Apr–Sep) | 1 687 | 0.940 | 0.060 | 0.788 | [0.925, 0.952] |
+| pentad | 1.0  | non-irrigation (Oct–Mar) | 1 697 | **0.946** | 0.052 | **0.864** | [0.930, 0.958] |
+| decade | 0.80 | all | 1 894 | 0.845 | 0.100 | 0.791 | [0.818, 0.869] |
+| decade | 0.80 | irrigation (Apr–Sep) | 909 | 0.844 | 0.103 | 0.763 | [0.807, 0.876] |
+| decade | 0.80 | non-irrigation (Oct–Mar) | 985 | **0.846** | 0.096 | **0.813** | [0.804, 0.881] |
+| decade | 1.0  | all | 1 894 | 0.932 | 0.077 | 0.783 | [0.917, 0.945] |
+| decade | 1.0  | irrigation (Apr–Sep) | 909 | 0.924 | 0.085 | 0.716 | [0.901, 0.942] |
+| decade | 1.0  | non-irrigation (Oct–Mar) | 985 | **0.940** | 0.069 | **0.833** | [0.919, 0.957] |
+| month L0 (hind) | 0.80 | all | 7 081 | 0.871 | 0.064 | 0.875 | [0.854, 0.887] |
+| month L0 (hind) | 0.80 | irrigation (Apr–Sep) | 2 853 | **0.872** | 0.070 | 0.850 | [0.850, 0.892] |
+| month L0 (hind) | 0.80 | non-irrigation (Oct–Mar) | 4 228 | 0.869 | 0.055 | **0.890** | [0.841, 0.894] |
+| month L0 (hind) | 1.0  | all | 7 081 | 0.928 | 0.046 | 0.887 | [0.919, 0.936] |
+| month L0 (hind) | 1.0  | irrigation (Apr–Sep) | 2 853 | **0.930** | 0.048 | 0.856 | [0.916, 0.941] |
+| month L0 (hind) | 1.0  | non-irrigation (Oct–Mar) | 4 228 | 0.926 | 0.044 | **0.901** | [0.913, 0.937] |
+| season L0 (hind) | 0.80 | all / irrigation | 883 | 0.484 | 0.283 | 0.490 | [0.414, 0.555] |
+| season L0 (hind) | 1.0  | all / irrigation | 883 | 0.718 | 0.205 | 0.535 | [0.674, 0.758] |
 
 **Note on season horizon:** All season-ahead forecasts (Apr–Sep seasonal
 runoff) target the irrigation season by definition.  There is no
@@ -576,24 +690,26 @@ non-irrigation split for the season horizon.
 
 ### Interpretation
 
-**POD is slightly higher in the irrigation season than out-of-season:**
-at the pentad scale (0.80 × norm), EM detects 93.3 % of below-norm events
-during Apr–Sep vs 91.6 % during Oct–Mar (difference 1.7 pp, within CI overlap
-but consistent across models).  At month L0, the irrigation-season advantage is
-3.0 pp (86.4 % vs 83.4 %). The same in-season / out-of-season ordering holds for
-the 1.0 × norm event.
+**POD is essentially comparable in and out of the irrigation season.**
+After de-leaking, the earlier in-season POD advantage disappears: at the pentad
+scale (0.80 × norm), EM detects 89.3 % of below-norm events during Apr–Sep vs
+90.8 % during Oct–Mar (difference −1.5 pp, well within CI overlap); at decade the
+two are effectively equal (84.4 % vs 84.6 %); at month L0 in-season is marginally
+higher (87.2 % vs 86.9 %). The takeaway is that **detection is stable across the
+year** — there is no meaningful in-season penalty, which is what matters
+operationally.
 
-**HSS is slightly lower in-season** despite higher POD.  This is a
-base-rate effect: below-norm events are more frequent in the irrigation
-season (higher base rate → harder to beat chance), which compresses HSS
-even when detection improves.
+**HSS is lower in-season** at every horizon (pentad 0.814 vs 0.877; decade 0.763
+vs 0.813; month L0 0.850 vs 0.890).  This is a base-rate effect: below-norm
+events are more frequent in the irrigation season (e.g. pentad base rate 0.49
+in-season vs 0.34 out-of-season), which raises the chance baseline and compresses
+HSS even though raw detection is unchanged.
 
-**Operational significance:** the irrigaton season is precisely when the
-limit-plan decision matters most.  The finding confirms that the EM model
-detects shortages at least as well — and somewhat better on raw POD — in
-the months when under-detection is most costly.  Irrigation managers can
-rely on the pooled-year skill estimates as a conservative lower bound for
-in-season performance.
+**Operational significance:** the irrigation season is precisely when the
+limit-plan decision matters most.  The finding confirms that the EM model detects
+shortages just as well in-season as out-of-season, so irrigation managers can
+rely on the pooled-year skill estimates as a representative estimate of in-season
+performance.
 
 The seasonal disaggregation figures are shown in **fig6_season_pod.png**
 (POD with Wilson CI, irrigation vs non-irrigation vs all, for pentad,
@@ -606,24 +722,28 @@ decade, and month L0).
 The key operational question is: **what fraction of true below-norm runoff
 events are missed** (FN rate = 1 − POD)?
 
-- **Pentad/decade (ML models):** FN rate 7–12 %. False alarms (FP rate relative
-  to positive events) ≈ 7–13 %. Both are operationally low. An irrigation
-  manager using EM pentad forecasts would miss approximately 1 in 14 genuine
-  shortage events.
-- **Pentad/decade (LR):** FN rate 19–30 %. LR is FN-heavy — much more likely
+- **Pentad/decade (ML models):** FN rate 10–16 % (pentad EM 10 %, decade EM
+  15 %). False alarms (FP rate relative to positive events) ≈ 8–15 %. Both are
+  operationally low. An irrigation manager using EM pentad forecasts would miss
+  roughly 1 in 10 genuine shortage events.
+- **Pentad/decade (LR):** FN rate 19–29 %. LR is FN-heavy — much more likely
   to miss a genuine shortage. ML models offer a clear advantage.
-- **Month L0 (EM / Skilled Mean):** FN rate ≈ 15 %. Strong skill, comparable
-  to short-term ML. Monthly forecasts are reliable enough to inform seasonal
-  irrigation planning one month ahead.
-- **Month L3 (EM):** FN rate 36 %. Skill degrades substantially at 3-month
-  lead. Three-month-ahead seasonal signals should be treated as directional
-  guidance only.
-- **Quarter / Season:** FN rate 59–66 % at all leads (EM). More than half of
-  true limit-plan events are missed. These horizons provide only weak, positive
-  skill — useful for ensemble signal but not for firm operational decisions. FAR
-  is also elevated (31–43 %).
-- **Day (exploratory):** FN rate 38–55 %. Low coverage and inherent day-scale
-  variability mean day-ahead limit-plan decisions carry substantial uncertainty.
+- **Month L0 (EM / Skilled Mean, hindcast):** FN rate ≈ 12–13 %. Strong skill,
+  comparable to short-term ML. Monthly forecasts are reliable enough to inform
+  seasonal irrigation planning one month ahead. (Genuine-2026 operational month
+  data is too thin to score — see the Month section.)
+- **Month L3 (EM, hindcast):** FN rate 35 %. Skill degrades substantially at
+  3-month lead. Three-month-ahead seasonal signals should be treated as
+  directional guidance only.
+- **Quarter (by target quarter) / Season (by lead) (hindcast):** FN rate ≈
+  49–75 % (EM) — quarter Q1 ≈ 49 % rising to ≈ 75 % at Q4; season 52–68 % across
+  leads. In most cells more than half of true limit-plan events are missed. These
+  horizons provide only weak-to-moderate positive skill (strongest at quarter
+  Q1) — useful for ensemble signal but not, in general, for firm operational
+  decisions. FAR is also elevated (17–42 %).
+- **Day (exploratory):** FN rate 43–49 %. Very low coverage after de-leaking
+  (n = 56–108) and inherent day-scale variability mean day-ahead limit-plan
+  decisions carry substantial uncertainty.
 
 **Recommendation:** rely on pentad/decade ML ensemble (EM or NE) for the core
 irrigation planning decision. Monthly (L0–L1) forecasts can support 1–2 month
@@ -652,37 +772,37 @@ norm), so each station/period carries its own seasonal thresholds. The
 contingency machinery is identical to the below-norm case: positive class =
 event occurred (below the threshold for low-flow, above it for high-flow).
 
-Numbers below are from the phase-2c re-run
-(`apps/forecast_skill_eval/artifacts/rerun_2026-07-01_phase2c_events/`), which
-adds the four percentile events and **reproduces the below-norm numbers above
-identically**. Rows are **EM, operational, POOLED, basin = all, season = all,
-canonical provenance**; long-term horizons use the smallest lead (month /
-season L0, quarter L1).
+Numbers below are from the corrected run (`rerun_2026-07-03_corrected/`), which
+carries the four percentile events alongside the below-norm events. Rows are
+**EM, POOLED, basin = all, season = all, canonical provenance**; short-term
+horizons are **operational** (de-leaked), long-term horizons use **hindcast** at
+the smallest lead (month / season L0) and first target quarter (quarter Q1) —
+matching the regime the long-term sections lead with.
 
-### Table — EM operational, POOLED, canonical provenance, season = all
+### Table — EM, POOLED, canonical provenance, season = all (short-term operational, long-term hindcast)
 
 | Horizon | Event | base rate | POD | FAR | HSS | POD 95 % CI | n |
 |---------|-------|:---------:|:---:|:---:|:---:|:-----------:|---:|
-| pentad | low_p5 | 0.14 | 0.77 | 0.25 | 0.72 | [0.75, 0.79] | 11 238 |
-| pentad | low_p10 | 0.22 | 0.83 | 0.18 | 0.78 | [0.82, 0.85] | 11 238 |
-| pentad | high_p90 | 0.07 | 0.76 | 0.22 | 0.75 | [0.73, 0.79] | 11 238 |
-| pentad | high_p95 | 0.05 | 0.67 | 0.25 | 0.70 | [0.63, 0.71] | 11 238 |
-| decade | low_p5 | 0.17 | 0.78 | 0.29 | 0.68 | [0.75, 0.81] | 5 032 |
-| decade | low_p10 | 0.26 | 0.86 | 0.20 | 0.76 | [0.84, 0.88] | 5 032 |
-| decade | high_p90 | 0.06 | 0.70 | 0.26 | 0.70 | [0.65, 0.75] | 5 032 |
-| decade | high_p95 | 0.03 | 0.68 | 0.36 | 0.65 | [0.60, 0.74] | 5 032 |
-| month L0 | low_p5 | 0.06 | 0.58 | 0.26 | 0.63 | [0.53, 0.63] | 6 315 |
-| month L0 | low_p10 | 0.10 | 0.64 | 0.21 | 0.68 | [0.60, 0.68] | 6 315 |
-| month L0 | high_p90 | 0.11 | **0.78** | 0.11 | **0.82** | [0.75, 0.81] | 6 315 |
-| month L0 | high_p95 | 0.07 | 0.49 | 0.24 | 0.58 | [0.44, 0.54] | 6 315 |
-| quarter L1 | low_p5 | 0.07 | 0.21 | 0.49 | 0.27 | [0.15, 0.29] | 1 866 |
-| quarter L1 | low_p10 | 0.12 | 0.21 | 0.43 | 0.26 | [0.16, 0.27] | 1 866 |
-| quarter L1 | high_p90 | 0.11 | 0.28 | 0.39 | 0.34 | [0.22, 0.34] | 1 866 |
-| quarter L1 | high_p95 | 0.06 | 0.18 | 0.58 | 0.22 | [0.12, 0.26] | 1 866 |
-| season L0 | low_p5 | 0.10 | 0.07 | 0.53 | 0.10 | [0.04, 0.13] | 1 323 |
-| season L0 | low_p10 | 0.16 | 0.11 | 0.48 | 0.14 | [0.07, 0.16] | 1 323 |
-| season L0 | high_p90 | 0.10 | 0.25 | 0.43 | 0.31 | [0.19, 0.33] | 1 323 |
-| season L0 | high_p95 | 0.07 | 0.14 | 0.54 | 0.19 | [0.08, 0.22] | 1 323 |
+| pentad | low_p5 | 0.13 | 0.70 | 0.25 | 0.68 | [0.66, 0.74] | 3 358 |
+| pentad | low_p10 | 0.21 | 0.77 | 0.20 | 0.73 | [0.74, 0.80] | 3 358 |
+| pentad | high_p90 | 0.09 | 0.75 | 0.24 | 0.73 | [0.70, 0.80] | 3 358 |
+| pentad | high_p95 | 0.06 | 0.64 | 0.27 | 0.67 | [0.57, 0.71] | 3 358 |
+| decade | low_p5 | 0.14 | 0.61 | 0.30 | 0.60 | [0.55, 0.67] | 1 879 |
+| decade | low_p10 | 0.22 | 0.74 | 0.20 | 0.71 | [0.69, 0.78] | 1 879 |
+| decade | high_p90 | 0.09 | 0.68 | 0.20 | 0.71 | [0.61, 0.75] | 1 879 |
+| decade | high_p95 | 0.05 | 0.62 | 0.26 | 0.66 | [0.53, 0.72] | 1 879 |
+| month L0 (hind) | low_p5 | 0.12 | 0.49 | 0.18 | 0.58 | [0.46, 0.53] | 7 035 |
+| month L0 (hind) | low_p10 | 0.17 | 0.69 | 0.14 | 0.72 | [0.66, 0.71] | 7 035 |
+| month L0 (hind) | high_p90 | 0.08 | **0.74** | 0.18 | **0.76** | [0.71, 0.78] | 7 035 |
+| month L0 (hind) | high_p95 | 0.05 | 0.43 | 0.24 | 0.53 | [0.38, 0.48] | 7 035 |
+| quarter Q1 (hind) | low_p5 | 0.05 | 0.23 | 0.52 | 0.29 | [0.13, 0.38] | 862 |
+| quarter Q1 (hind) | low_p10 | 0.10 | 0.30 | 0.38 | 0.36 | [0.21, 0.40] | 862 |
+| quarter Q1 (hind) | high_p90 | 0.11 | 0.32 | 0.36 | 0.38 | [0.24, 0.42] | 862 |
+| quarter Q1 (hind) | high_p95 | 0.05 | 0.29 | 0.48 | 0.35 | [0.18, 0.43] | 862 |
+| season L0 (hind) | low_p5 | 0.07 | 0.11 | 0.50 | 0.17 | [0.06, 0.22] | 882 |
+| season L0 (hind) | low_p10 | 0.11 | 0.15 | 0.50 | 0.19 | [0.10, 0.24] | 882 |
+| season L0 (hind) | high_p90 | 0.10 | 0.32 | 0.41 | 0.37 | [0.23, 0.42] | 882 |
+| season L0 (hind) | high_p95 | 0.07 | 0.18 | 0.54 | 0.23 | [0.10, 0.29] | 882 |
 
 **Day horizon:** no percentile events are reported. The `min_years ≥ 10` gate
 cannot form daily percentile thresholds — a daily percentile needs ~10 years of
@@ -693,23 +813,23 @@ an empirical percentile, so it is unaffected.)
 ### Key findings
 
 - **High-flow detection is genuinely skilful at pentad, decade, and month L0.**
-  EM catches 70–78 % of 90th-percentile high-flow events (HSS 0.70–0.82), with
-  **month L0 the strongest** (POD 0.78, HSS 0.82, FAR 0.11). This is the
+  EM catches 68–75 % of 90th-percentile high-flow events (HSS 0.71–0.76), with
+  **month L0 the strongest** (POD 0.74, HSS 0.76, FAR 0.18). This is the
   principal new result: the same models that drive the irrigation decision also
   provide usable flood / high-flow signal at short-to-medium range.
 - **Extreme tails are harder than moderate tails.** Detection drops from the
   moderate percentile to the extreme one at every horizon — e.g. pentad
-  high_p90 0.76 → high_p95 0.67; month L0 high_p90 0.78 → high_p95 0.49. Rarer
+  high_p90 0.75 → high_p95 0.64; month L0 high_p90 0.74 → high_p95 0.43. Rarer
   events (lower base rate) are intrinsically harder to catch and carry wider
   CIs.
 - **Low-flow percentiles track the below-norm story but are more demanding.**
   The 10th/5th percentiles are stricter thresholds than 0.80 × norm, so POD is
-  lower than the below-norm POD at the same horizon (pentad low_p10 0.83 vs
-  below-norm 0.93; month L0 low_p10 0.64 vs 0.86). Pentad/decade still catch
-  77–86 % of moderate (10th-percentile) low-flow events.
+  lower than the below-norm POD at the same horizon (pentad low_p10 0.77 vs
+  below-norm 0.90; month L0 low_p10 0.69 vs 0.87). Pentad/decade still catch
+  74–77 % of moderate (10th-percentile) low-flow events.
 - **Quarter and season remain weak across all percentile events** (POD
-  0.07–0.28), consistent with the below-norm finding — long-range extreme
-  detection is risk-screening only.
+  0.10–0.32; quarter shown at target quarter Q1), consistent with the below-norm
+  finding — long-range extreme detection is risk-screening only.
 
 **Caveats specific to percentile events:**
 
@@ -727,20 +847,31 @@ an empirical percentile, so it is unaffected.)
 
 ## Return-period detection (flood / hydropower)
 
+> **Status — not recomputed in the corrected run.** Return-period (EVT) events
+> were **not** part of the corrected `rerun_2026-07-03_corrected/` artifact, so
+> the table below still carries the earlier **phase-2c geometry**: the
+> short-term rows are **pre-de-leaking** (leaked intraday re-issues included,
+> hence the larger n) and the long-term rows are the old flag-based
+> "operational" (largely pre-2026 backfill = effectively hindcast). Read the
+> whole section as **indicative pending a corrected RP re-run**, not as
+> de-leaked skill. The below-norm and percentile sections above supersede it for
+> any decision.
+
 Return periods restate the high-flow question in the language flood and
 hydropower operators use — not "above the 90th percentile" but "a 5-, 10-, 30-,
 or 100-year event". Return levels are estimated **per station and per
 period-of-year** by fitting a GEV (`scipy.stats.genextreme`) to each period's
 annual realisations and taking the `1 − 1/T` quantile; an event is a period
 whose runoff exceeds its own `T`-year return level. By construction the low
-return periods approximate the percentile events (rp10 ≈ 90th percentile —
-cross-check: pentad rp10 POD 0.81 / HSS 0.80 vs `high_p90` 0.76 / 0.75); the
-value of the EVT framing is the explicit rarity scale and the (extrapolated)
-rarer levels.
+return periods approximate the percentile events (rp10 ≈ 90th percentile — in
+the corrected percentile run above `high_p90` reads 0.75 / 0.73 at pentad, close
+to the phase-2c rp10 0.81 / 0.80); the value of the EVT framing is the explicit
+rarity scale and the (extrapolated) rarer levels.
 
-Rows are **EM, operational, POOLED, basin = all, season = all, canonical
-provenance** (long-term = smallest lead), phase-2c re-run. `pos_events` =
-observed return-level exceedances (TP + FN) — the effective sample per cell.
+Rows are **EM, POOLED, basin = all, season = all, canonical provenance**
+(long-term = smallest lead), **phase-2c re-run (pre-correction — see status note
+above)**. `pos_events` = observed return-level exceedances (TP + FN) — the
+effective sample per cell.
 
 | Horizon | RP | base rate | POD [95 % CI] | FAR | HSS | pos_events |
 |---------|----|:---------:|:-------------:|:---:|:---:|:----------:|
@@ -765,8 +896,10 @@ observed return-level exceedances (TP + FN) — the effective sample per cell.
 | season | rp30 | 0.05 | 0.05 [0.02, 0.14] | 0.77 | 0.07 | 59 |
 | season | rp100 | 0.01 | 0.07 [0.01, 0.30] | 0.83 | 0.09 | 15 |
 
-(n_pairs per horizon: pentad 11 238, decade 5 032, month 6 315, quarter 1 866,
-season 1 323.)
+(n_pairs per horizon, **pre-correction phase-2c counts**: pentad 11 238,
+decade 5 032, month 6 315, quarter 1 866, season 1 323. A corrected re-run would
+shrink the short-term counts sharply, as it did for the de-leaked below-norm and
+percentile events above.)
 
 ### Key findings
 
@@ -822,18 +955,18 @@ hydropower / flood operators) actually act on.
 - **Brier / Brier skill score** — scores the forecast *probability* of the
   below-norm event (from the band) rather than the binary flag.
 
-Numbers are from the flagged run (`SAPPHIRE_SKILL_PROB`,
-`artifacts/prob_2026-07-01/`), **EM, operational, POOLED, canonical provenance,
-season = all** (long-term = smallest lead). Only models that emit a usable band
+Numbers are from the corrected run (`rerun_2026-07-03_corrected/`), **EM, POOLED,
+canonical provenance, season = all**; short-term **operational** (de-leaked),
+long-term **hindcast** at the smallest lead. Only models that emit a usable band
 are scored; **GBT / SM_GBT\* long-term models carry no band and stay point-only**.
 
 | Horizon | Grid | n | CRPSS | Coverage 90 % | Coverage 80 % | Reliability | Sharpness (norm) | Brier SS |
 |---------|------|---:|:-----:|:-------------:|:-------------:|:-----------:|:----------------:|:--------:|
-| pentad | short5 | 11 335 | **0.68** | 0.92 | — | 0.02 | 0.25 | **0.82** |
-| decade | short5 | 5 059 | 0.59 | 0.87 | — | 0.03 | 0.24 | 0.79 |
-| month L0 | long7 | 6 387 | 0.62 | 0.92 | 0.86 | 0.02 | 0.28 | 0.79 |
-| quarter L1 | long7 | 1 887 | 0.28 | 0.91 | 0.83 | 0.01 | 0.58 | 0.39 |
-| season L0 | long7 | 1 331 | 0.23 | 0.82 | 0.71 | 0.08 | 0.59 | 0.30 |
+| pentad | short5 | 3 384 | **0.68** | 0.90 | — | 0.00 | 0.28 | 0.79 |
+| decade | short5 | 1 894 | 0.65 | 0.90 | — | 0.00 | 0.31 | 0.77 |
+| month L0 (hind) | long7 | 7 081 | **0.72** | 0.94 | 0.87 | 0.04 | 0.28 | **0.81** |
+| quarter Q1 (hind) | long7 | 865 | 0.52 | 0.96 | 0.91 | 0.06 | 0.53 | 0.51 |
+| season L0 (hind) | long7 | 883 | 0.27 | 0.85 | 0.77 | 0.05 | 0.59 | 0.38 |
 
 *(Coverage 90 ideal = 0.90; Coverage 80 ideal = 0.80; Reliability = |coverage −
 nominal|, lower is better; CRPSS / Brier SS > 0 beats climatology.)*
@@ -844,22 +977,22 @@ day-scale probabilistic scores exist only for TFT / TiDE / TSMixer (short5).
 ### Key findings
 
 - **The forecasts are well calibrated.** EM's 90 % bands actually contain
-  87–92 % of observations at pentad/decade/month/quarter (reliability 0.01–0.03)
+  90–96 % of observations at pentad/decade/month/quarter (reliability 0.00–0.06)
   — the stated uncertainty is trustworthy, not over- or under-confident. Only
-  the **season** horizon is mildly under-covered (0.82 vs 0.90). This is the
-  headline probabilistic result: operators can take the EM interval at face
-  value at short-to-medium range.
+  the **season** horizon is mildly under-covered (0.85 vs 0.90, reliability
+  0.05). This is the headline probabilistic result: operators can take the EM
+  interval at face value at short-to-medium range.
 - **The full distribution beats climatology at every horizon** (CRPSS
-  0.23–0.68), strongest at pentad (0.68), month (0.62), decade (0.59); weaker
-  but positive at quarter/season (0.23–0.28) — the same short-good / long-weak
-  gradient as the point scores.
+  0.25–0.72), strongest at month (0.72), pentad (0.68), decade (0.65), moderate
+  at quarter Q1 (0.52); weakest at season (0.27) — the same short-good /
+  long-weak gradient as the point scores.
 - **Sharpness matches confidence to horizon.** Bands are tight relative to the
-  norm at pentad/decade/month (~0.24–0.28) and appropriately wide at
-  quarter/season (~0.58–0.59) — the models widen their intervals where skill is
+  norm at pentad/decade/month (~0.28–0.31) and appropriately wide at
+  quarter/season (~0.53–0.59) — the models widen their intervals where skill is
   genuinely lower rather than staying falsely narrow.
 - **Probabilistic below-norm skill (Brier SS)** is strong at pentad/decade/month
-  (0.79–0.82) and drops at quarter/season (0.30–0.39), consistent with the
-  deterministic contingency results.
+  (0.77–0.81) and drops at quarter Q1 (0.51) / season (0.38), consistent with
+  the deterministic contingency results.
 
 **Caveats specific to probabilistic scores:**
 
@@ -879,9 +1012,9 @@ day-scale probabilistic scores exist only for TFT / TiDE / TSMixer (short5).
 The contingency and probabilistic sections score *whether the decision was
 right* and *whether the uncertainty is trustworthy*. This section scores the two
 things left: **how accurate the magnitude is** (continuous/volume) and **how
-much the decision is worth** (economic value). Numbers are from the flagged run
-(`SAPPHIRE_SKILL_VALUE`, `artifacts/value_2026-07-01/`), **EM, operational,
-canonical provenance** (long-term = smallest lead).
+much the decision is worth** (economic value). Numbers are from the corrected run
+(`rerun_2026-07-03_corrected/`), **EM, canonical provenance**; short-term
+**operational** (de-leaked), long-term **hindcast** at the smallest lead.
 
 ### Continuous / volume accuracy
 
@@ -892,29 +1025,37 @@ canonical provenance** (long-term = smallest lead).
   over/under-forecast of total water — the number that matters for allocation
   and reservoir/hydropower planning.
 
-| Horizon | KGE (per-station median) | NSE (per-station median) | rel. volume error | n stations |
+| Horizon | KGE (per-station median) † | NSE (per-station median) † | rel. volume error ‡ | n stations |
 |---------|:------------------------:|:------------------------:|:-----------------:|:----------:|
-| pentad | **0.96** | 0.97 | +0.5 % | 51 |
-| decade | 0.95 | 0.95 | +1.3 % | 50 |
-| month L0 | **0.97** | 0.98 | +0.9 % | 53 |
-| quarter L1 | 0.78 | 0.75 | +0.9 % | 53 |
-| season L0 | **0.41** | 0.23 | +0.1 % | 51 |
+| pentad | **0.96** | 0.97 | +1.1 % | 51 |
+| decade | 0.95 | 0.95 | +0.9 % | 50 |
+| month L0 | **0.97** | 0.98 | +0.5 % | 53 |
+| quarter Q1 | 0.78 | 0.75 | +0.4 % | 53 |
+| season L0 | **0.41** | 0.23 | −0.3 % | 51 |
+
+† **Per-station KGE/NSE could not be recomputed in this POOLED-only refresh** —
+the per-station distribution lives in the station-coded artifacts, which are out
+of scope for the sanitized run. The per-station medians above are **carried from
+the prior run as indicative**; the methodology (per-station fit) is unchanged by
+the corrections, which affect regime labelling and de-leaking rather than the
+shape of each station's series. ‡ **rve is refreshed from the corrected POOLED
+run** (relative volume error is pooling-invariant).
 
 **Key findings:**
 
 - **EM tracks each station's flow very well at pentad/decade/month** (per-station
-  median KGE 0.95–0.97, NSE 0.95–0.98) and is **essentially volume-unbiased at
-  every horizon** (rve within ±1.5 %). For water-accounting, EM neither
-  systematically over- nor under-allocates.
+  median KGE 0.95–0.97, NSE 0.95–0.98, indicative) and is **essentially
+  volume-unbiased at every horizon** (corrected rve within ±1.1 %). For
+  water-accounting, EM neither systematically over- nor under-allocates.
 - **Skill falls off at seasonal range** (per-station KGE 0.41, NSE 0.23) — the
   same short-good / long-weak gradient as every other metric family.
 - **CRITICAL reporting caveat — do not use pooled KGE/NSE.** Aggregated across
   all stations, KGE/NSE are badly **inflated** because between-station variance
-  (small creeks vs large rivers) dominates the denominator: pooled season NSE is
-  **0.97** vs the honest per-station median of **0.23**. The table above uses the
-  **per-station median**; the dashboard's Value view shows the full per-station
-  distribution. (rve and the REV below are not affected — rve is relative and
-  REV is derived from the contingency table.)
+  (small creeks vs large rivers) dominates the denominator: the corrected pooled
+  season NSE is **0.97** vs the honest per-station median of **0.23**. The table
+  above uses the **per-station median**; the dashboard's Value view shows the
+  full per-station distribution. (rve and the REV below are not affected — rve is
+  relative and REV is derived from the contingency table.)
 
 ### Relative economic value (cost–loss)
 
@@ -925,16 +1066,17 @@ the Peirce skill score) at `α = base rate`:
 
 | Horizon | V_max (peak value) | at α* (base rate) |
 |---------|:------------------:|:-----------------:|
-| pentad | **0.87** | 0.44 |
-| decade | 0.84 | 0.49 |
-| month L0 | **0.85** | 0.21 |
-| quarter L1 | 0.36 | 0.10 |
-| season L0 | 0.36 | 0.22 |
+| pentad | **0.84** | 0.41 |
+| decade | 0.78 | 0.40 |
+| month L0 (hind) | **0.85** | 0.23 |
+| quarter Q1 (hind) | 0.50 | 0.08 |
+| season L0 (hind) | 0.43 | 0.21 |
 
 - **The below-norm forecast delivers high decision value at pentad/decade/month**
-  (V_max 0.84–0.87 — a consumer captures ~85 % of the value a perfect forecast
+  (V_max 0.78–0.85 — a consumer captures ~80–85 % of the value a perfect forecast
   would, at their optimal cost-loss ratio), and **moderate value at
-  quarter/season** (0.36). The full `V(α)` curve per model is in the dashboard;
+  quarter/season** (0.43–0.50; quarter shown at target quarter Q1). The full
+  `V(α)` curve per model is in the dashboard;
   it is not clamped, so a skill-negative model/α shows `V < 0` (acting on it
   loses money vs climatology).
 
@@ -947,25 +1089,30 @@ matters directly for allocation and hydropower.
 
 ## Caveats and limitations
 
-1. **DAY horizon is thin and exploratory.** n_pairs 632–1 090 across models;
-   CIs span ±10–15 pp. Use for direction only.
+1. **DAY horizon is thin and exploratory.** After de-leaking, n_pairs is only
+   56–108 across models; CIs span ±15–17 pp. Use for direction only.
 2. **Long-term coverage is Kyrgyz-dominated.** 65 of 83 stations are Kyrgyz;
-   Tajik operational-month pairs at leads ≥ 2 are scarce. Tajik seasonal skill
+   Tajik hindcast-month pairs at leads ≥ 2 are scarce. Tajik seasonal skill
    estimates carry wide CIs and may not generalise.
 3. **Rolling-window product excluded** (549 868 rows): confirms the exclusion
    filter is working correctly. The remaining month metrics reflect only
    calendar-aligned monthly forecasts.
-4. **Operational vs. hindcast gap:** hindcast HSS is available for month L0–L3
-   and season L0–L3 and is systematically higher than operational (typical
-   optimism of hindcast-trained models). Report operational figures for real-world
-   assessment.
+4. **Long-term operational is genuinely thin; the sections lead with hindcast.**
+   Real-time long-term forecasting only began ~2026, so the genuine-operational
+   archive is tiny (month L0 n = 40, quarter Q1 n = 40, season L0 n = 49) and
+   cannot carry a reliable skill estimate. The robust long-term skill is the
+   **hindcast** (full pre-2026 archive: month L0 n = 7 081, quarter Q1 n = 865,
+   season L0 n = 883), which the long-term sections report as the headline. The
+   genuine-2026 operational numbers are shown only as preliminary footnotes.
+   fig3 contrasts the two; because they are not sample-matched, any cell where
+   operational ≥ hindcast is a sample-composition artefact.
 5. **Two thresholds reported side by side, not comparable.** The operational
    story is the **0.80 × norm** limit-plan event; the **1.0 × norm** plain
    below-average event is reported alongside it for reference only. The two have
    different base rates, so their POD/FAR/HSS must not be compared cell-for-cell
    (HSS is base-rate sensitive). The tool supports re-running with any threshold.
-6. **Quarter L2 artefact:** 83 pairs, POD = 1.00 — artefact of small n. Treat
-   that cell as unreliable.
+6. **Quarter Q2 artefact:** 82 pairs, POD = 1.00 — a zero-miss, small-n
+   artefact. Treat that cell as unreliable.
 7. **`min_years = 10`** filter applied: stations with fewer than 10 years of
    paired data were excluded from long-term norm computation.
 
@@ -989,24 +1136,33 @@ All figures are in `doc/plans/working/forecast_skill_eval_figures/`:
   grid as in the combined diagram.
 
 - **fig1_month.png / fig1_quarter.png / fig1_season.png** — per-horizon Roebber
-  diagrams for each long-term horizon. Markers are coloured by **lead** (plasma
-  colormap; 4 distinct colours). Approved lead ranges: month L0–L3,
-  quarter L1–L4, season L0–L3. Legend: model shape (upper-left) and lead colour
-  (lower-left). These reveal how skill degrades with increasing lead and which
-  models maintain consistent performance across leads.
+  diagrams for each long-term horizon. Markers are coloured by **lead** for
+  month/season and by **target quarter** for quarter (plasma colormap; 4 distinct
+  colours). Approved ranges: month L0–L3, quarter Q1–Q4, season L0–L3. Legend:
+  model shape (upper-left) and lead/target-quarter colour (lower-left). For
+  month/season these reveal how skill degrades with increasing lead; for quarter
+  they contrast the four target quarters (Q1 strongest, Q4 hardest). **Preliminary:** the
+  long-term per-horizon operational diagrams are drawn from the thin genuine-2026
+  operational archive; read them as indicative and rely on the hindcast tables
+  (and **fig3**) for the robust long-term estimate.
 
 - **fig2_hss_heatmap.png** — HSS heatmap, model × h_label, operational regime.
-  Columns: `day`, `pentad`, `decade`, `month L0`–`month L3`, `quarter L1`–
-  `quarter L4`, `season L0`–`season L3`. Month leads L4–L12 are excluded
-  (deprecated, sparse data).
+  Columns: `day`, `pentad`, `decade`, `month L0`–`month L3`, `quarter Q1`–
+  `quarter Q4`, `season L0`–`season L3`. Month leads L4–L12 are excluded
+  (deprecated, sparse data). **Note:** the long-term (month/quarter/season)
+  columns reflect the thin genuine-2026 operational archive and are preliminary;
+  the hindcast tables in the long-term sections are the robust reference.
 
-- **fig3_operational_vs_hindcast_hss.png** — operational vs hindcast HSS by
-  lead for month / quarter / season (best-sampled model per horizon). Each bar
-  is annotated with its n_pairs. **CAVEAT:** Operational and hindcast are NOT
-  sample-matched (different stations / dates / n; e.g. month operational
-  n ≈ 110–150 vs hindcast n ≈ 7 000). Where operational HSS ≥ hindcast HSS it
-  is a sample-composition artifact, not genuine skill. Treat as indicative
-  only. Month limited to L0–L3 (L4–L12 deprecated).
+- **fig3_operational_vs_hindcast_hss.png** — **the key long-term figure**:
+  operational vs hindcast HSS by lead (month / season) and target quarter
+  (quarter) for the best-sampled model per horizon. Each bar is annotated with
+  its n_pairs, making the
+  thin-operational-vs-robust-hindcast contrast explicit. **CAVEAT:** Operational
+  and hindcast are NOT sample-matched (different stations / dates / n; e.g. month
+  EM operational L0 n ≈ 40 vs hindcast n ≈ 7 081). Where operational HSS ≥
+  hindcast HSS it is a sample-composition artifact, not genuine skill. The
+  genuine-2026 operational bars are preliminary; the hindcast bars are the robust
+  estimate. Month limited to L0–L3 (L4–L12 deprecated).
 
 - **fig4_day.png / fig4_pentad.png / fig4_decade.png** — per-model POD (green)
   and FAR (red) bar chart for each short-term horizon, all models, operational
@@ -1021,17 +1177,20 @@ All figures are in `doc/plans/working/forecast_skill_eval_figures/`:
   the full three-way ranking at a glance.
 
 - **fig4_month.png / fig4_quarter.png / fig4_season.png** — same POD / FAR /
-  FP layout as the short-term fig4 figures, but faceted by lead (month L0–L3,
-  quarter L1–L4, season L0–L3). The canonical lead panel (L0 for month/season,
-  L1 for quarter) carries both climatology and persistence reference
-  annotations; other lead panels carry climatology only. Family colour-coding
+  FP layout as the short-term fig4 figures, but faceted by lead for month/season
+  and by target quarter for quarter (month L0–L3, quarter Q1–Q4, season L0–L3).
+  The canonical panel (L0 for month/season, Q1 for quarter) carries both
+  climatology and persistence reference annotations; other panels carry
+  climatology only. Family colour-coding
   (see above) enables direct ML-vs-LR-vs-ensemble comparison; Naive Mean
-  appears in purple ("Unweighted mean") not in grey.
+  appears in purple ("Unweighted mean") not in grey. **Preliminary:** these
+  long-term per-lead operational diagrams are 2026-only (thin); the hindcast
+  tables and **fig3** carry the robust long-term skill.
 
 - **fig5_persistence_vs_models.png** — grouped bar chart: for each horizon
   (x-axis), three bars show HSS of climatology (light grey, HSS = 0),
   persistence (dark grey), and the best skilled model (coloured by horizon).
-  Long-term horizons use their canonical lead (month/season L0, quarter L1).
+  Long-term horizons use their canonical panel (month/season L0, quarter Q1).
   This is the "three-way skill ladder": climatology ◀ persistence ◀ skilled
   models (for pentad and longer); at day scale persistence beats the thin ML
   models.
@@ -1039,18 +1198,85 @@ All figures are in `doc/plans/working/forecast_skill_eval_figures/`:
 - **fig6_season_pod.png** — three-panel figure (pentad / decade / month L0),
   each showing POD with Wilson 95 % CI whiskers for three season cuts:
   non-irrigation (Oct–Mar, blue), all year (grey), and irrigation (Apr–Sep,
-  orange). Model = EM, operational, POOLED. Confirms that detection is at
-  least as strong — and slightly better on raw POD — during the irrigation
-  season when limit-plan decisions are most consequential.
+  orange). Model = EM; short-term operational, month L0 hindcast; POOLED.
+  Confirms that detection is comparable in and out of the irrigation season
+  (within CI overlap) — there is no meaningful in-season penalty when limit-plan
+  decisions are most consequential.
+
+### Figures — hindcast (full archive)
+
+The figures above depict the **operational** regime — the genuine real-time
+forecast archive, which is thin, especially for the long-term horizons (e.g.
+month L0 operational n = 40). The `*_hindcast.png` figures below mirror them
+one-for-one but are computed on the **full historical hindcast archive
+(2000–2025)**, so their samples are far larger (e.g. month L0 hindcast n ≈ 7 081
+vs operational n = 40). This is the robust view, and for the long-term horizons
+(month / quarter / season) it is the one to trust; the operational figures above
+reflect the still-thin genuine real-time regime. Short-term horizons are already
+well-sampled operationally, so the hindcast panels there mainly confirm the
+operational picture on the longer archive. All hindcast figures are in the same
+directory (`doc/plans/working/forecast_skill_eval_figures/`, `_hindcast` suffix).
+There is no `fig3` hindcast variant — **fig3** is itself the
+operational-vs-hindcast contrast.
+
+- **fig1_performance_diagram_hindcast.png** — Roebber performance diagram
+  (success ratio vs POD) for all (h_label, model) combinations, **hindcast
+  regime**. Same encoding as `fig1_performance_diagram.png` (colour = base
+  horizon, marker shape = model), but every point rests on the full-archive
+  sample.
+
+- **fig1_day_hindcast.png / fig1_pentad_hindcast.png /
+  fig1_decade_hindcast.png** — per-horizon Roebber diagrams for each short-term
+  horizon, hindcast regime. Counterparts to the operational `fig1_{day,pentad,
+  decade}.png`.
+
+- **fig1_month_hindcast.png / fig1_quarter_hindcast.png /
+  fig1_season_hindcast.png** — per-horizon Roebber diagrams for each long-term
+  horizon, markers coloured by lead for month/season and by target quarter for
+  quarter (month L0–L3, quarter Q1–Q4, season L0–L3), hindcast regime. **These
+  are the robust long-term Roebber diagrams**: unlike
+  their operational counterparts (drawn from the thin genuine-2026 archive), they
+  are computed on the full hindcast archive and should be read as the reliable
+  long-term view.
+
+- **fig2_hss_heatmap_hindcast.png** — HSS heatmap, model × h_label, **hindcast
+  regime**. Same columns as `fig2_hss_heatmap.png`; the long-term columns here
+  are the robust full-archive estimate rather than the thin operational one.
+
+- **fig4_day_hindcast.png / fig4_pentad_hindcast.png /
+  fig4_decade_hindcast.png** — per-model POD (green) / FAR (red) bar charts for
+  each short-term horizon, hindcast regime. Same layout, family colour-coding and
+  climatology/persistence reference annotations as the operational `fig4_{day,
+  pentad,decade}.png`, computed on the full archive.
+
+- **fig4_month_hindcast.png / fig4_quarter_hindcast.png /
+  fig4_season_hindcast.png** — per-model POD / FAR faceted by lead for
+  month/season and by target quarter for quarter (month L0–L3, quarter Q1–Q4,
+  season L0–L3), **hindcast regime**. **The robust long-term
+  per-lead view**: these carry the full-archive samples the operational
+  `fig4_{month,quarter,season}.png` lack, so they are the ones to rely on for
+  long-term per-lead skill.
+
+- **fig5_persistence_vs_models_hindcast.png** — three-way skill ladder
+  (climatology ◀ persistence ◀ best skilled model, HSS per horizon), hindcast
+  regime. Counterpart to `fig5_persistence_vs_models.png` with long-term bars
+  drawn from the robust full-archive sample.
+
+- **fig6_season_pod_hindcast.png** — three-panel POD-with-Wilson-CI figure
+  (pentad / decade / month L0) across the three season cuts (non-irrigation /
+  all / irrigation), hindcast regime. Counterpart to `fig6_season_pod.png`; the
+  month L0 panel in particular is far better sampled here.
 
 ---
 
 ## Related documents
 
 - Planner prompt / locked requirements: `forecast_skill_eval_planner_prompt.md`
-- Run configuration: `apps/forecast_skill_eval/artifacts/rerun_2026-07-02_both_thresholds/run_config.json`
-- Phase-2 artifacts: `apps/forecast_skill_eval/artifacts/rerun_2026-07-02_both_thresholds/`
-  (canonical source; both thresholds `below_norm` 0.80 × norm and `below_norm_100`
-  1.0 × norm, season column, persistence baseline)
+- Run configuration: `apps/forecast_skill_eval/artifacts/rerun_2026-07-03_corrected/run_config.json`
+- Corrected artifacts: `apps/forecast_skill_eval/artifacts/rerun_2026-07-03_corrected/`
+  (canonical source; short-term de-leaked + date-based long-term regime split +
+  LR issue→target repair; both thresholds `below_norm` 0.80 × norm and
+  `below_norm_100` 1.0 × norm, season column, persistence baseline, percentile /
+  probabilistic / value metrics)
 - Lead-aware figure script: `doc/plans/working/forecast_skill_eval_figures/make_figures.py`
-- Summary (auto-generated): `apps/forecast_skill_eval/artifacts/rerun_2026-07-02_both_thresholds/summary.md`
+- Summary (auto-generated): `apps/forecast_skill_eval/artifacts/rerun_2026-07-03_corrected/summary.md`

--- a/doc/plans/working/lr_issue_indexing_optionB_coordination.md
+++ b/doc/plans/working/lr_issue_indexing_optionB_coordination.md
@@ -2,7 +2,14 @@
 
 **To:** owner of `sapphire/services/` + the shared postprocessing DB
 **From:** forecast-tools side (read-only investigation; nothing changed)
-**Status:** DRAFT for sign-off. No writes executed. Requires colleague approval — touches `sapphire/services/postprocessing` semantics and the shared DB.
+**Status:** DRAFT for sign-off (rev. 2). No writes executed. Requires colleague approval — touches `sapphire/services/postprocessing` semantics and the shared DB.
+
+## 0. Revisions from independent review (2026-07-03) — fold these in before running
+1. **Stale skill rows are NOT replaced by a plain recompute (blocking).** `skill_metrics` upserts on `(horizon_type, code, model_type, date, horizon_in_year, horizon_value)`, so recomputed rows get INSERTED alongside the old issue-labeled rows; the dashboard then dedups by latest `date` (`db.py:548`), not by provenance. → **Back up `skill_metrics` and add an explicit DELETE/REPLACE of the stale pentad/decade rows** in the affected date/year scope before/around the recompute (see §3).
+2. **Remap must not assume every LR `date` is a period boundary (blocking).** `period_of(date) + 1` only equals the target when `date` is the last day of the prior period. → **Compute the target as `period_of(date + interval '1 day')`** (matching the recompute reader `data_reader.py:1934`) and validate against `date + 1`, not `issue + 1`. Add a **preflight count of non-boundary LR dates** (see §4).
+3. **Set `SAPPHIRE_SKILL_METRICS_YEAR` explicitly (medium).** The wrapper passes only `..._START_YEAR`, so the write-year defaults to current year (`recalculate_skill_metrics.py:230`). Set it deliberately for the migration run (see §3).
+
+Reviewer confirmed as correct: LR constraint-safety (only `(horizon_type,code,date)` is unique) and the single dashboard lockstep change `utils.py:352`.
 
 ## 1. Bug, root cause, volume
 - `lr_forecasts.horizon_in_year` should be the **TARGET** pentad/decade period. For LR short-term rows generated/migrated **before 2026-04-13** it holds the **ISSUE** period (`target = issue + 1`).
@@ -29,6 +36,8 @@
 
 ## 4. Remap design (DRAFT — do not run without sign-off)
 Detection = SQL translation of the eval shim: a row is issue-indexed iff `horizon_in_year == period_of(date)`. Cleanly bimodal (target rows are `issue+1 ≠ issue`), catches the 2024 tail, skips the target-indexed minority. `lr_forecasts` has no `target` column, so no year-wrap field to touch — only `horizon_in_year`/`horizon_value`.
+
+> ⚠️ **Rev. 2 (see §0.2):** before running, change the target derivation to `period_of(date + interval '1 day')` (not `period_of(date) + 1`) and validate against `date + 1`. First run a **preflight count of non-boundary LR dates** — `SELECT count(*) FROM lr_forecasts WHERE horizon_type IN ('pentad','decade') AND EXTRACT(DAY FROM date)::int NOT IN (5,10,15,20,25,31 /* + decade/pentad boundaries */)` — to confirm how many rows the boundary assumption would misclassify. The SQL below is the pre-review draft kept for reference.
 
 ```sql
 -- PENTAD. Count first; run UPDATE in one txn AFTER backup.

--- a/doc/plans/working/lr_issue_indexing_optionB_coordination.md
+++ b/doc/plans/working/lr_issue_indexing_optionB_coordination.md
@@ -1,0 +1,73 @@
+# Coordination note — Option B: one-time in-DB remap of `lr_forecasts.horizon_in_year` (issue→target)
+
+**To:** owner of `sapphire/services/` + the shared postprocessing DB
+**From:** forecast-tools side (read-only investigation; nothing changed)
+**Status:** DRAFT for sign-off. No writes executed. Requires colleague approval — touches `sapphire/services/postprocessing` semantics and the shared DB.
+
+## 1. Bug, root cause, volume
+- `lr_forecasts.horizon_in_year` should be the **TARGET** pentad/decade period. For LR short-term rows generated/migrated **before 2026-04-13** it holds the **ISSUE** period (`target = issue + 1`).
+- Root cause: the generation-side fix runs only for NEW forecasts (`apps/linear_regression/linear_regression.py:930-938`); the CSV→DB migrator copies the label verbatim with no +1 (`sapphire/services/postprocessing/app/data_migrator.py:288` pentad, `:315` decade).
+- Two-vintage overlay: upsert key is `(horizon_type, code, date)` only — `horizon_in_year` excluded (`models.py:190-193`, `crud.py:204-211`) → last-writer-wins per issue date.
+- Volume: ≈117,700 short-term LR rows mislabeled (≈78.4k pentad + 39.3k decade), ~all pre-2024; plus a pre-2024 **already-target-indexed minority** (≈21.1k pentad / 10.6k decade) to leave untouched → detection must be **per-row against `date`**, not a year threshold.
+
+## 2. Consumer inventory / blast radius
+- **Service read** `GET /lr-forecast/` → `crud.get_lr_forecast` (`crud.py:248-274`): filters on `horizon_type/code/date` only, returns `horizon_in_year` verbatim. Transparent to the fix. **No risk.**
+- **MUST flip in lockstep (forecast-tools-side):** `apps/forecast_dashboard/dashboard/utils.py:352` — `df[df[horizon_in_year] == (horizon_value - 1)]`. The `-1` compensates for issue-indexing; after remap it must be `== horizon_value`. Only period-level ±1 compensation in the dashboard.
+- **Pre-existing inconsistency:** `src/vizualization.py:3400-3403` already filters `== horizon_value` (no offset) → disagrees with `utils.py:352` today; the fix resolves it.
+- **Agnostic / become-correct after remap:** `src/db.py:439,487-496` (pass-through), `data_manager.py:355-360` (bulletin metadata), `processing.py:1358-1360` (best models), `widgets.py:333-346,605-622` (labels).
+- **Join to watch (benefits):** `src/db.py:821` merges LR↔skill on `[code, pentad/decad_in_year, model_short]` with no offset; aligns once LR is remapped **and** skill is recomputed/relabeled.
+- **Not consumers of this label:** `apps/postprocessing_forecasts` recalc drops `horizon_in_year` and derives period from `date`; ML/preprocessing use other tables.
+
+**Net: exactly one line (`utils.py:352`) changes in lockstep; everything else agnostic or already-correct.**
+
+## 3. Skill-metric recompute — REQUIRED (for labeling)
+- Recalc read path derives target from `date + 1 day` and **drops** `horizon_in_year` (`apps/postprocessing_forecasts/src/data_reader.py:1934-1956`); pairing on `[code,date]` (`skill_metrics.py:1847-1849`). A fresh recompute yields correct, date-derived, target-labeled skill regardless of the remap.
+- BUT currently-stored LR skill rows may carry an issue-period label (skill CSV→DB migrator copies `horizon_in_year` verbatim and synthesizes `date` from it — `data_migrator.py:483-490`; cf. `.bak_corrupted` skill CSVs). So the dashboard skill tile for target P may actually be P+1, and `db.py:821` would mismatch.
+- **Action:** one-time recompute after remap to relabel LR pentad/decad skill to date-derived target.
+- **Trigger:** `bash bin/yearly_skill_metrics_recalculation.sh <config/.env>` (`SAPPHIRE_PREDICTION_MODE=BOTH`; scope via `PENTAD`/`DECAD`, `SAPPHIRE_RECALC_STATION_CODE`, `..._START_YEAR`). Entry `apps/postprocessing_forecasts/recalculate_skill_metrics.py:208/480`; writes `skill_metrics` (upsert key `(horizon_type,code,model_type,date,horizon_in_year,horizon_value)`).
+- **Caveat (top risk):** pentad/decad recalc has historically produced degenerate `n_pairs∈{1,2}`. **Validate n_pairs on a full local-DB dry run before any server.**
+
+## 4. Remap design (DRAFT — do not run without sign-off)
+Detection = SQL translation of the eval shim: a row is issue-indexed iff `horizon_in_year == period_of(date)`. Cleanly bimodal (target rows are `issue+1 ≠ issue`), catches the 2024 tail, skips the target-indexed minority. `lr_forecasts` has no `target` column, so no year-wrap field to touch — only `horizon_in_year`/`horizon_value`.
+
+```sql
+-- PENTAD. Count first; run UPDATE in one txn AFTER backup.
+UPDATE lr_forecasts AS t
+SET horizon_in_year = CASE WHEN p.issue = 72 THEN 1 ELSE p.issue + 1 END,
+    horizon_value   = ((CASE WHEN p.issue = 72 THEN 1 ELSE p.issue + 1 END) - 1) % 6 + 1
+FROM (
+  SELECT id,
+    ((EXTRACT(MONTH FROM date)::int - 1) * 6
+      + LEAST((EXTRACT(DAY FROM date)::int - 1) / 5 + 1, 6)) AS issue
+  FROM lr_forecasts WHERE horizon_type = 'pentad'
+) AS p
+WHERE t.id = p.id AND t.horizon_in_year = p.issue;   -- idempotency + selectivity guard
+```
+Decade analog: `horizon_type='decade'`, `issue = (month-1)*3 + CASE WHEN day<=10 THEN 1 WHEN day<=20 THEN 2 ELSE 3 END`, wrap `36→1`, `horizon_value=((target-1)%3)+1`.
+
+- **Constraint safety:** `horizon_in_year`/`horizon_value` in no unique constraint/index (`models.py:189-193`) → cannot violate uniqueness.
+- **Backup (before UPDATE):** `CREATE TABLE lr_forecasts_backup_20260703 AS SELECT * FROM lr_forecasts WHERE horizon_type IN ('pentad','decade');` — keep until skill validated.
+- **Idempotency:** `AND t.horizon_in_year = p.issue` self-limits; second run matches nothing.
+
+## 5. Validation
+```sql
+-- Expect 0 (every short-term LR row target-indexed):
+SELECT count(*) FROM (
+  SELECT horizon_in_year,
+    ((EXTRACT(MONTH FROM date)::int-1)*6 + LEAST((EXTRACT(DAY FROM date)::int-1)/5+1,6)) AS issue
+  FROM lr_forecasts WHERE horizon_type='pentad') s
+WHERE horizon_in_year <> (CASE WHEN issue=72 THEN 1 ELSE issue+1 END);
+```
+Row counts before/after identical; matched-update count ≈ 78.4k pentad / 39.3k decade; post-recompute spot-check `n_pairs` sane (not 1–2) and `db.py:821` LR↔skill periods align.
+
+## 6. Option A (eval shim) interaction
+`api_readers._repair_lr_issue_indexing` (default off) only remaps `H == issue_period_of(date)`. After B, all rows are `issue+1 ≠ issue` → shim skips every row = **verified no-op**. Safe to leave enabled as a guard.
+
+## 7. Residual risks (ranked — need sign-off)
+1. **Skill-recompute `n_pairs` degeneracy (highest)** — mandatory relabel step; do a full local dry run + inspect n_pairs first.
+2. **`utils.py:352` lockstep** — ship the dashboard change with the DB remap or period shifts by one.
+3. **Pre-2024 target-indexed minority provenance** — confirm it's just post-override re-runs; no third `H==issue` population.
+4. **Stored skill provenance** — recompute fixes both cases; low risk given (1).
+5. **Shared-DB coordination** — sequence: backup → count → UPDATE (txn) → validate → skill recompute (BOTH) → validate n_pairs → deploy `utils.py:352`. Per-org-env.
+
+**Coordinated (colleague / shared DB):** the UPDATE, backup table, skill-recompute writes. **Forecast-tools-side:** only `apps/forecast_dashboard/dashboard/utils.py:352` (lands together with the remap).


### PR DESCRIPTION
## Summary

Adds a plain **below-norm (1.0×norm)** event to `forecast_skill_eval` and — in the course of that — a full module-correctness review that surfaced and fixed several real bugs. All new behaviour is **flag-gated and default byte-identical**; existing outputs are unchanged unless a flag is set.

## What's in here

**Feature**
- `below_norm_100` (value < 1.0×norm) event with full parity across contingency, prob-Brier, economic value, and baselines; the existing `below_norm` (0.80×norm) output is byte-identical (regression-tested).

**Correctness fixes (each flag-gated, default off)**
1. **Short-term observation leakage** — the eval scored every intraday re-issue, including in-period nowcasts that had already observed part of their own target. Now: genuine forecasts only (issued before the target period), one per target (`--short-term-issue-before-target`, `--short-term-dedup-one-per-target`).
2. **Long-term regime mislabel** — "operational" was flag-based and dominated by pre-2026 backfills. Now a date-based split (`--regime-source date`) makes "operational" genuinely post-2026; the pre-2026 archive is hindcast.
3. **Historical LR off-by-one** — pre-2024 LR short-term forecasts were issue-indexed, not target-indexed. Repaired on read (`--short-term-lr-repair`).
4. **Quarter mis-stratified** — `horizon_value` is overloaded (holds the quarter-of-year, not a lead), with two sources pooled + re-issues double-counted. Now the true lead is derived from dates, the sources are deduped, and quarter is stratified by **target quarter Q1–Q4** (`--long-term-derive-lead`); season keeps its genuine leads 0–3.
5. **operational_proxy baseline** — compared model vs proxy on unequal samples; now equal-n per matched key.
6. **Metrics** — HSS emits 0 (not NaN) on zero-event rows; `rank_calibration_error` redefined to a proper 0-at-calibration divergence; CRPSS uses the paired finite subset; Brier `n_pairs` is the band-valid count.
7. **Figures** (dev tooling) — plotted per-basin points as if leads (missing `basin=="all"` filter); fixed, plus a parallel hindcast figure set, model-fallback for the short-term hindcast (EM is operational-only), and consistent quarter Q1–Q4 labels.

**Dashboard**
- The Streamlit skill-eval viewer resolved a stale default run and could show "No valid CSV path" out of the box; now it resolves the default dynamically and falls back to it when the sidebar box is blank.

**Docs**
- Refreshes the tracked skill-eval draft to the corrected numbers (short-term de-leaked, long-term leads with the robust hindcast, quarter by Q1–Q4 with the finding that **Q4 is much harder to forecast than Q1**). POOLED aggregates only, no station codes.
- Adds a coordination note for a durable in-DB LR-indexing fix (colleague-owned; follow-up, not in this PR).

## Testing
- `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh forecast_skill_eval` → **730 passed, 0 skips**. Ruff clean. Pre-commit hooks pass.
- Every flag defaults off with regression tests pinning byte-identical output.

## Notes for review
- The H1 funder report and standalone annex are **untracked deliverables** (git-excluded), intentionally not part of this PR.
- The dashboard-side skill-metrics lead handling (`skill_lead_aware` project) and the in-DB LR remap are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
