### PR TITLE
postprocessing: relax long-term Skilled-Mean pool to NSE>0

### DIFF
--- a/apps/postprocessing_forecasts/src/ensemble_calculator.py
+++ b/apps/postprocessing_forecasts/src/ensemble_calculator.py
@@ -252,6 +252,7 @@ def create_monthly_ensemble_forecasts(
     from src.skill_metrics import (
         _QUANTILE_COLS,
         _append_to_joint,
+        _long_term_threshold_overrides,
         filter_for_highly_skilled_forecasts,
     )
 
@@ -281,12 +282,18 @@ def create_monthly_ensemble_forecasts(
     if "horizon_value" in forecasts.columns:
         group_cols.append("horizon_value")
 
-    # --- EM (threshold-filtered average) ---
+    # --- EM (threshold-filtered average, DEFAULT gate — EM must not change) ---
     skill_filtered = filter_for_highly_skilled_forecasts(skill_stats)
     merge_keys = ["month_in_year", "code", "model_short"]
 
-    # Normalize types for merge
-    for df in (joint, skill_filtered):
+    # Long-term Skilled-Mean pool: relaxed NSE>0 gate.  Split from the EM pool
+    # so EM membership/output stays byte-identical while Skilled Mean widens.
+    skill_filtered_lt = filter_for_highly_skilled_forecasts(
+        skill_stats, **_long_term_threshold_overrides()
+    )
+
+    # Normalize types for merge (both pools, matching joint)
+    for df in (joint, skill_filtered, skill_filtered_lt):
         if "month_in_year" in df.columns:
             df["month_in_year"] = pd.to_numeric(df["month_in_year"], errors="coerce")
         if "code" in df.columns:
@@ -332,10 +339,10 @@ def create_monthly_ensemble_forecasts(
             em_avg["flag"] = 0
             joint = _append_to_joint(joint, em_avg)
 
-    # --- Skilled Mean (1/MAE weighted average) ---
+    # --- Skilled Mean (1/MAE weighted average, relaxed NSE>0 pool) ---
     joint = _add_skilled_mean_monthly(
         joint,
-        skill_filtered,
+        skill_filtered_lt,
         baselines,
         _QUANTILE_COLS,
         group_cols,
@@ -361,7 +368,9 @@ def _add_skilled_mean_monthly(
 ) -> pd.DataFrame:
     """Add Skilled Mean rows (1/MAE weighted) to joint forecasts.
 
-    Uses the same threshold-filtered model pool as EM.
+    Uses the long-term Skilled-Mean pool (relaxed to NSE>0 via
+    ``_long_term_threshold_overrides``), which is broader than EM's
+    default-gated pool.
     """
     from src.skill_metrics import _append_to_joint
 
@@ -372,7 +381,13 @@ def _add_skilled_mean_monthly(
     if filtered.empty:
         return joint
 
-    mae_df = filtered[["month_in_year", "code", "model_short", "mae"]].copy()
+    # Lead-aware ONLY when horizon_value is present on BOTH sides; a one-sided
+    # presence must keep the 3-key merge (a 4-key merge with horizon_value on one
+    # side only would mismatch and drop every row).
+    use_hv = "horizon_value" in joint.columns and "horizon_value" in skill_filtered.columns
+    key_cols = ["month_in_year"] + (["horizon_value"] if use_hv else []) + ["code", "model_short"]
+
+    mae_df = filtered[[*key_cols, "mae"]].copy()
     mae_df = mae_df.dropna(subset=["mae"])
     if mae_df.empty:
         return joint
@@ -382,13 +397,13 @@ def _add_skilled_mean_monthly(
     eps = mean_mae / 100.0 if mean_mae > 0 else 1e-10
     mae_df["weight"] = 1.0 / (mae_df["mae"] + eps)
 
-    qualifying_keys = mae_df[["month_in_year", "code", "model_short"]].drop_duplicates()
+    qualifying_keys = mae_df[key_cols].drop_duplicates()
 
     # Filter joint (non-baseline) to qualifying models
     pool = joint[~joint["model_short"].isin(baselines)].copy()
     pool = pool.merge(
         qualifying_keys,
-        on=["month_in_year", "code", "model_short"],
+        on=key_cols,
         how="inner",
     )
     pool = pool.dropna(subset=["forecasted_discharge"]).copy()
@@ -397,8 +412,8 @@ def _add_skilled_mean_monthly(
 
     # Attach weights
     pool = pool.merge(
-        mae_df[["month_in_year", "code", "model_short", "weight"]],
-        on=["month_in_year", "code", "model_short"],
+        mae_df[[*key_cols, "weight"]],
+        on=key_cols,
         how="left",
     )
 
@@ -575,6 +590,7 @@ def _create_aggregated_ensemble_forecasts(
     """
     from src.skill_metrics import (
         _QUANTILE_COLS,
+        _long_term_threshold_overrides,
         filter_for_highly_skilled_forecasts,
     )
 
@@ -607,7 +623,11 @@ def _create_aggregated_ensemble_forecasts(
     time_group_cols = [c for c in time_group_cols if c in joint.columns]
 
     # --- EM (two-LR average; not skill-gated for quarter/season) ---
-    skill_filtered = filter_for_highly_skilled_forecasts(skill_stats)
+    # EM below derives its pool from AGGREGATED_EM_RAW_MODELS and never reads
+    # skill_filtered, so the relaxed NSE>0 pool feeds only the Skilled Mean.
+    skill_filtered = filter_for_highly_skilled_forecasts(
+        skill_stats, **_long_term_threshold_overrides()
+    )
 
     # Normalize types for merge
     if period_col in joint.columns:

--- a/apps/postprocessing_forecasts/src/skill_metrics.py
+++ b/apps/postprocessing_forecasts/src/skill_metrics.py
@@ -103,6 +103,70 @@ THRESHOLD_METRICS = {
 }
 
 # ---------------------------------------------------------------------------
+# Long-term (month/quarter/season) Skilled-Mean threshold overrides
+# ---------------------------------------------------------------------------
+# The long-term "Skilled Mean" pool admits ALL long-term models with NSE > 0.
+# This is expressed as per-metric overrides to filter_for_highly_skilled_forecasts:
+# keep nse > 0.0 and disable both the sdivsigma and accuracy gates.  The canonical
+# filter treats the exact string "False" as "gate disabled".  These vars are
+# LONG-TERM ONLY — the short-term env vars/defaults are untouched.
+_LONG_TERM_THRESHOLD_ENV = {
+    "nse": ("ieasyhydroforecast_nse_threshold_long_term", "0.0"),
+    "sdivsigma": ("ieasyhydroforecast_efficiency_threshold_long_term", "False"),
+    "accuracy": ("ieasyhydroforecast_accuracy_threshold_long_term", "False"),
+}
+
+# Case-insensitive tokens that disable a threshold gate.
+_THRESHOLD_DISABLE_TOKENS = frozenset({"false", "off", "none", "disable", "disabled", ""})
+
+
+def _parse_threshold_env(raw: str) -> "float | bool":
+    """Parse a long-term threshold env value into a float or a disable sentinel.
+
+    Disable tokens (case-insensitive: false/off/none/disable/disabled/empty)
+    map to the boolean ``False`` whose ``str()`` is ``"False"`` — the sentinel
+    the canonical filter recognizes as "gate disabled".  Otherwise the value is
+    parsed as a float.  An invalid value raises a clear ``ValueError`` naming the
+    offending value, never a bare ``float("banana")`` error.
+
+    Args:
+        raw: The raw env-var string.
+
+    Returns:
+        ``False`` for a disable token, otherwise the parsed float.
+
+    Raises:
+        ValueError: If *raw* is neither a disable token nor a valid number.
+    """
+    token = str(raw).strip().lower()
+    if token in _THRESHOLD_DISABLE_TOKENS:
+        return False
+    try:
+        return float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Invalid long-term skill threshold: {raw!r} (expected a number or a "
+            f"disable token like 'false'/'off'/'none')"
+        ) from exc
+
+
+def _long_term_threshold_overrides() -> dict:
+    """Return the per-metric override dict for the long-term Skilled-Mean filter.
+
+    Reads the long-term-only env vars (defaulting to the NSE>0-only behavior)
+    and parses each through :func:`_parse_threshold_env`.  Returns e.g.
+    ``{"nse": 0.0, "sdivsigma": False, "accuracy": False}`` under defaults.
+    This dict is splatted as ``**overrides`` into
+    :func:`filter_for_highly_skilled_forecasts`, which treats a ``False`` value
+    (``str(threshold) == "False"``) as a disabled gate.
+    """
+    overrides: dict = {}
+    for metric_key, (env_var, default) in _LONG_TERM_THRESHOLD_ENV.items():
+        overrides[metric_key] = _parse_threshold_env(os.getenv(env_var, default))
+    return overrides
+
+
+# ---------------------------------------------------------------------------
 # Monthly skill groupby keys (PP-038: per-lead stratification)
 # These constants define the groupby keys for all monthly skill groupbys and
 # the ensemble aggregation groupby.  Threading them through every site avoids
@@ -1558,7 +1622,9 @@ def _add_skilled_mean(
     q50 forecasts, where w_i = 1 / (MAE_i + eps).
     eps = mean(MAE) / 100 to avoid division by zero.
 
-    Only models passing the same threshold filter as EM are included.
+    Models are selected by the long-term Skilled-Mean gate (NSE>0; the
+    efficiency and accuracy gates disabled) — broader than EM's
+    default-gated pool.
     EM, Naive Mean, and Skilled Mean themselves are excluded from
     the model pool. Single-model groups are discarded.
 
@@ -1572,8 +1638,8 @@ def _add_skilled_mean(
     if skill_stats.empty or merged.empty:
         return skill_stats, joint_forecasts
 
-    # 1. Filter for highly skilled models (same pool as EM)
-    filtered = filter_for_highly_skilled_forecasts(skill_stats)
+    # 1. Filter for highly skilled models (long-term Skilled-Mean pool: NSE>0)
+    filtered = filter_for_highly_skilled_forecasts(skill_stats, **_long_term_threshold_overrides())
 
     # 2. Exclude baselines from the model pool
     excluded = {"EM", "Naive Mean", "Skilled Mean"}
@@ -2534,7 +2600,7 @@ def _add_skilled_mean_aggregated(
     if skill_stats.empty or merged.empty:
         return skill_stats, joint_forecasts
 
-    filtered = filter_for_highly_skilled_forecasts(skill_stats)
+    filtered = filter_for_highly_skilled_forecasts(skill_stats, **_long_term_threshold_overrides())
     excluded = {"EM", "Naive Mean", "Skilled Mean"}
     filtered = filtered[~filtered["model_short"].isin(excluded)].copy()
     if filtered.empty:

--- a/apps/postprocessing_forecasts/tests/test_lt_skilled_mean_nse_threshold.py
+++ b/apps/postprocessing_forecasts/tests/test_lt_skilled_mean_nse_threshold.py
@@ -1,0 +1,547 @@
+"""Locked tests for the LONG-TERM Skilled-Mean NSE>0 relaxation.
+
+Owner-locked goal
+-----------------
+The LONG-TERM (month/quarter/season) "Skilled Mean" ensemble should include
+ALL long-term models with NSE > 0.  SHORT-TERM (pentad/decad) is UNCHANGED.
+**EM MUST NOT CHANGE** — neither membership, skill, nor forecast output.
+
+These tests are LOCKED: they assert the target (post-fix) behavior.  Where they
+describe NEW behavior they MUST fail against current code and pass after the
+fix.  Where they lock EXISTING behavior (EM byte-identity, short-term gate,
+single-model discard) they must pass both before and after.
+
+Mechanism under test
+---------------------
+- filter_for_highly_skilled_forecasts(skill_stats, **overrides) AND-filters over
+  THRESHOLD_METRICS keyed exactly {sdivsigma, nse, accuracy}; the exact string
+  "False" (and, after the fix, any parsed disable token) disables a gate.
+- Identity: NSE = 1 - sdivsigma^2.  "NSE>0 only" for long-term requires
+  nse=0.0 AND both sdivsigma and accuracy gates disabled.
+- New config surface (to be added by the implementer):
+    ieasyhydroforecast_nse_threshold_long_term        (default 0.0)
+    ieasyhydroforecast_efficiency_threshold_long_term (default disabled)
+    ieasyhydroforecast_accuracy_threshold_long_term   (default disabled)
+  plus a shared robust parser and a single _long_term_threshold_overrides()
+  helper returning the override dict for the Skilled-Mean calls.
+
+Placeholder station code 19999 only.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src import skill_metrics as sm_mod
+from src.ensemble_calculator import create_monthly_ensemble_forecasts
+from src.skill_metrics import filter_for_highly_skilled_forecasts
+
+CODE = "19999"
+
+# Short-term / EM DEFAULT gate (unchanged behavior).
+DEFAULT_ENV = {
+    "ieasyhydroforecast_efficiency_threshold": "0.6",
+    "ieasyhydroforecast_nse_threshold": "0.8",
+    "ieasyhydroforecast_accuracy_threshold": "0.8",
+}
+
+# Env with the long-term-only vars explicitly unset so defaults apply.
+_LT_ENV_KEYS = (
+    "ieasyhydroforecast_nse_threshold_long_term",
+    "ieasyhydroforecast_efficiency_threshold_long_term",
+    "ieasyhydroforecast_accuracy_threshold_long_term",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders (mirror test_monthly_ensemble_creation.py conventions)
+# ---------------------------------------------------------------------------
+
+_SKILL_COLS = [
+    "month_in_year",
+    "horizon_value",
+    "code",
+    "model_short",
+    "sdivsigma",
+    "nse",
+    "delta",
+    "accuracy",
+    "mae",
+    "n_pairs",
+]
+
+_FC_COLS = [
+    "code",
+    "year",
+    "month",
+    "month_in_year",
+    "horizon_value",
+    "model_short",
+    "forecasted_discharge",
+    "q05",
+    "q10",
+    "q25",
+    "q50",
+    "q75",
+    "q90",
+    "q95",
+    "valid_from",
+    "valid_to",
+    "date",
+    "flag",
+]
+
+
+def _skill(rows, cols=_SKILL_COLS):
+    return pd.DataFrame(rows, columns=cols)
+
+
+def _forecasts(rows, cols=_FC_COLS):
+    return pd.DataFrame(rows, columns=cols)
+
+
+def _fc_row(model, q50, *, hv=1, month=3, spread=20.0):
+    """One monthly forecast row with a symmetric quantile fan around q50."""
+    return (
+        CODE,
+        2025,
+        month,
+        month,
+        hv,
+        model,
+        q50,
+        q50 - spread,
+        q50 - spread * 0.75,
+        q50 - spread * 0.5,
+        q50,
+        q50 + spread * 0.5,
+        q50 + spread * 0.75,
+        q50 + spread,
+        "2025-03-01",
+        "2025-03-31",
+        "2025-03-01",
+        0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Config parsing helper (NEW — fails on current code: helpers absent)
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdEnvParsing:
+    """Robust parser for the long-term threshold env vars."""
+
+    def _parser(self):
+        parser = getattr(sm_mod, "_parse_threshold_env", None)
+        if parser is None:
+            pytest.fail(
+                "skill_metrics._parse_threshold_env missing — the shared robust "
+                "threshold parser has not been implemented yet."
+            )
+        return parser
+
+    def test_numeric_string_returns_float(self):
+        parse = self._parser()
+        assert parse("0.0") == pytest.approx(0.0)
+        assert parse("0.8") == pytest.approx(0.8)
+
+    @pytest.mark.parametrize(
+        "token", ["False", "false", "off", "none", "None", "disable", "DISABLE", ""]
+    )
+    def test_disable_tokens_disable_gate(self, token):
+        """Disable tokens parse to a value that disables the gate in the filter.
+
+        The filter treats str(threshold) == "False" as "skip this gate", so the
+        parser must map every disable token to something whose str() is "False"
+        (i.e. the bool/str sentinel False), never to a float.
+        """
+        parse = self._parser()
+        result = parse(token)
+        assert str(result) == "False", (
+            f"disable token {token!r} must disable the gate (str(result) must be "
+            f"'False'), got {result!r}"
+        )
+
+    def test_case_insensitive_false(self):
+        parse = self._parser()
+        assert str(parse("FALSE")) == "False"
+        assert str(parse("fAlSe")) == "False"
+
+    def test_invalid_value_raises_clear_error(self):
+        """An invalid value raises a clear config error, not a bare ValueError
+        from float('banana')."""
+        parse = self._parser()
+        with pytest.raises(Exception) as excinfo:
+            parse("banana")
+        msg = str(excinfo.value).lower()
+        assert "banana" in msg or "threshold" in msg or "invalid" in msg, (
+            "config error message should name the offending value or be about a "
+            f"threshold; got: {excinfo.value!r}"
+        )
+
+
+class TestLongTermOverridesHelper:
+    """_long_term_threshold_overrides() returns the NSE>0-only override dict."""
+
+    def _helper(self):
+        helper = getattr(sm_mod, "_long_term_threshold_overrides", None)
+        if helper is None:
+            pytest.fail(
+                "skill_metrics._long_term_threshold_overrides missing — the LT "
+                "override helper has not been implemented yet."
+            )
+        return helper
+
+    def test_defaults_are_nse_zero_others_disabled(self):
+        helper = self._helper()
+        with patch.dict(os.environ, {}, clear=False):
+            for k in _LT_ENV_KEYS:
+                os.environ.pop(k, None)
+            overrides = helper()
+        assert set(overrides.keys()) == {"sdivsigma", "nse", "accuracy"}
+        assert float(overrides["nse"]) == pytest.approx(0.0)
+        assert str(overrides["sdivsigma"]) == "False"
+        assert str(overrides["accuracy"]) == "False"
+
+    def test_env_can_override_lt_nse(self):
+        helper = self._helper()
+        env = {"ieasyhydroforecast_nse_threshold_long_term": "0.5"}
+        with patch.dict(os.environ, env):
+            overrides = helper()
+        assert float(overrides["nse"]) == pytest.approx(0.5)
+
+    def test_lt_overrides_broaden_filter_regardless_of_sdivsigma_accuracy(self):
+        """Applying the LT overrides to the filter keeps NSE>0 models with
+        arbitrary (failing) sdivsigma/accuracy and drops NSE<=0."""
+        helper = self._helper()
+        # nse independent of sdivsigma in the fixture — deliberately violates
+        # the physical identity to prove the gate depends ONLY on nse.
+        skill = _skill(
+            [
+                (3, 1, CODE, "M_neg", 5.0, -0.2, 5.0, 0.10, 3.0, 10),
+                (3, 1, CODE, "M_low", 5.0, 0.10, 5.0, 0.10, 3.0, 10),
+                (3, 1, CODE, "M_mid", 5.0, 0.64, 5.0, 0.10, 3.0, 10),
+                (3, 1, CODE, "M_high", 5.0, 0.90, 5.0, 0.10, 3.0, 10),
+                (3, 1, CODE, "M_zero", 5.0, 0.00, 5.0, 0.99, 1.0, 10),  # NSE==0 excluded
+            ]
+        )
+        with patch.dict(os.environ, DEFAULT_ENV):
+            for k in _LT_ENV_KEYS:
+                os.environ.pop(k, None)
+            overrides = helper()
+            kept = filter_for_highly_skilled_forecasts(skill, **overrides)
+        kept_models = set(kept["model_short"])
+        assert kept_models == {"M_low", "M_mid", "M_high"}, (
+            f"LT filter should keep exactly NSE>0 models, got {kept_models}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Short-term gate UNCHANGED (regression lock — passes before and after)
+# ---------------------------------------------------------------------------
+
+
+class TestShortTermGateUnchanged:
+    """Pentad/decad still require NSE>0.8 AND sdivsigma<0.6 AND accuracy>0.8."""
+
+    def _st_skill(self):
+        return _skill(
+            [
+                # passes all three
+                (3, 1, CODE, "PASS", 0.30, 0.95, 5.0, 0.90, 2.0, 10),
+                # NSE ok but sdivsigma too high
+                (3, 1, CODE, "BAD_SDIV", 0.90, 0.90, 5.0, 0.90, 2.0, 10),
+                # sdivsigma ok, accuracy too low
+                (3, 1, CODE, "BAD_ACC", 0.30, 0.90, 5.0, 0.10, 2.0, 10),
+                # sdivsigma/accuracy ok, NSE too low (but >0)
+                (3, 1, CODE, "BAD_NSE", 0.30, 0.50, 5.0, 0.90, 2.0, 10),
+            ]
+        )
+
+    def test_default_gate_keeps_only_all_pass(self):
+        with patch.dict(os.environ, DEFAULT_ENV):
+            kept = filter_for_highly_skilled_forecasts(self._st_skill())
+        assert set(kept["model_short"]) == {"PASS"}
+
+    def test_nse_between_zero_and_point8_rejected_by_default(self):
+        """A model with 0 < NSE < 0.8 is rejected by the DEFAULT (short-term)
+        gate — this is the behavior long-term relaxes but short-term keeps."""
+        with patch.dict(os.environ, DEFAULT_ENV):
+            kept = filter_for_highly_skilled_forecasts(self._st_skill())
+        assert "BAD_NSE" not in set(kept["model_short"])
+
+
+# ---------------------------------------------------------------------------
+# 3. Monthly forecast side: EM UNCHANGED while Skilled Mean broadens
+# ---------------------------------------------------------------------------
+
+
+def _mixed_pool():
+    """Three models: two pass the DEFAULT gate (EM pool), one only passes
+    the relaxed NSE>0 gate (extra Skilled-Mean member).
+
+    - LR  : passes default (sdivsigma<0.6, nse>0.8, accuracy>0.8)
+    - TFT : passes default
+    - GBT : NSE=0.3 (>0) but accuracy 0.1 and sdivsigma 0.9 -> only in LT pool
+    """
+    skill = _skill(
+        [
+            (3, 1, CODE, "LR", 0.30, 0.95, 5.0, 0.90, 2.0, 10),
+            (3, 1, CODE, "TFT", 0.40, 0.88, 5.0, 0.85, 4.0, 10),
+            (3, 1, CODE, "GBT", 0.90, 0.30, 5.0, 0.10, 6.0, 10),
+        ]
+    )
+    forecasts = _forecasts(
+        [
+            _fc_row("LR", 100.0),
+            _fc_row("TFT", 120.0),
+            _fc_row("GBT", 300.0),
+        ]
+    )
+    return skill, forecasts
+
+
+def _em_signature(result):
+    """Byte-identical EM signature: key columns + composition + discharge +
+    every quantile, as a sorted tuple of rounded tuples."""
+    em = result[result["model_short"] == "EM"].copy()
+    qcols = ["q05", "q10", "q25", "q50", "q75", "q90", "q95"]
+    keep = ["code", "year", "month", "composition", "forecasted_discharge", *qcols]
+    if "horizon_value" in em.columns:
+        keep.insert(3, "horizon_value")
+    em = em[keep].sort_values(keep).reset_index(drop=True)
+    rows = []
+    for _, r in em.iterrows():
+        rows.append(
+            tuple(
+                round(float(r[c]), 9) if c in ("forecasted_discharge", *qcols) else r[c]
+                for c in keep
+            )
+        )
+    return tuple(rows)
+
+
+class TestEMUnchangedForecastOutput:
+    """The relaxed Skilled Mean must NOT perturb the EM forecast row."""
+
+    def test_em_row_byte_identical_to_default(self):
+        """EM output with the relaxation active is byte-identical to EM output
+        under the default gate applied uniformly.
+
+        Baseline: force the SAME gate everywhere by making the LT vars equal to
+        the short-term defaults (so nothing is relaxed).  Then run with the LT
+        relaxation defaults active.  The EM row must match exactly."""
+        skill, forecasts = _mixed_pool()
+
+        # Baseline: LT vars mirror the default gate -> no relaxation anywhere.
+        baseline_env = dict(DEFAULT_ENV)
+        baseline_env.update(
+            {
+                "ieasyhydroforecast_nse_threshold_long_term": "0.8",
+                "ieasyhydroforecast_efficiency_threshold_long_term": "0.6",
+                "ieasyhydroforecast_accuracy_threshold_long_term": "0.8",
+            }
+        )
+        with patch.dict(os.environ, baseline_env):
+            baseline = create_monthly_ensemble_forecasts(forecasts.copy(), skill.copy())
+
+        # Relaxed: LT defaults (NSE>0 only) active.
+        with patch.dict(os.environ, DEFAULT_ENV):
+            for k in _LT_ENV_KEYS:
+                os.environ.pop(k, None)
+            relaxed = create_monthly_ensemble_forecasts(forecasts.copy(), skill.copy())
+
+        assert _em_signature(relaxed) == _em_signature(baseline), (
+            "EM forecast row changed when the Skilled-Mean relaxation was enabled "
+            "— EM MUST be byte-identical."
+        )
+
+    def test_em_is_only_lr_tft_mean(self):
+        """EM composition and discharge reflect ONLY the default-gate models,
+        even though GBT now enters the Skilled-Mean pool."""
+        skill, forecasts = _mixed_pool()
+        with patch.dict(os.environ, DEFAULT_ENV):
+            for k in _LT_ENV_KEYS:
+                os.environ.pop(k, None)
+            result = create_monthly_ensemble_forecasts(forecasts, skill)
+        em = result[result["model_short"] == "EM"]
+        assert len(em) == 1
+        assert em.iloc[0]["composition"] == "LR, TFT"
+        assert em.iloc[0]["forecasted_discharge"] == pytest.approx((100.0 + 120.0) / 2.0)
+
+    def test_skilled_mean_admits_extra_lt_model(self):
+        """NEW: Skilled Mean includes GBT (NSE>0) — its composition is the
+        3-model set, distinct from EM's 2-model set."""
+        skill, forecasts = _mixed_pool()
+        with patch.dict(os.environ, DEFAULT_ENV):
+            for k in _LT_ENV_KEYS:
+                os.environ.pop(k, None)
+            result = create_monthly_ensemble_forecasts(forecasts, skill)
+        sm = result[result["model_short"] == "Skilled Mean"]
+        assert len(sm) == 1, "Expected one Skilled Mean row"
+        assert sm.iloc[0]["composition"] == "GBT, LR, TFT", (
+            "Skilled Mean must admit the extra NSE>0 long-term model (GBT)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Lead-aware BOTH-SIDES and one-sided-absence regression
+# ---------------------------------------------------------------------------
+
+
+class TestLeadAwareSkilledMean:
+    """Monthly Skilled Mean selection must be per-(code, month, horizon_value)
+    when horizon_value is present on BOTH the forecast and skill sides; a
+    one-sided presence must fall back to the 3-key legacy merge without
+    mismatch."""
+
+    def test_both_sides_lead_aware_pool_per_horizon(self):
+        """Two leads (hv=1, hv=2) for the same month.  Each lead has its own
+        qualifying pool; Skilled Mean must not blend across leads."""
+        skill = _skill(
+            [
+                # hv=1: LR + GBT qualify (NSE>0)
+                (3, 1, CODE, "LR", 0.30, 0.95, 5.0, 0.90, 2.0, 10),
+                (3, 1, CODE, "GBT", 0.90, 0.30, 5.0, 0.10, 4.0, 10),
+                # hv=2: only TFT has NSE>0; the other is NSE<=0 (excluded)
+                (3, 2, CODE, "TFT", 0.40, 0.50, 5.0, 0.10, 3.0, 10),
+                (3, 2, CODE, "GBT", 0.90, -0.10, 5.0, 0.10, 4.0, 10),
+            ]
+        )
+        forecasts = _forecasts(
+            [
+                _fc_row("LR", 100.0, hv=1),
+                _fc_row("GBT", 300.0, hv=1),
+                _fc_row("TFT", 200.0, hv=2),
+                _fc_row("GBT", 500.0, hv=2),
+            ]
+        )
+        with patch.dict(os.environ, DEFAULT_ENV):
+            for k in _LT_ENV_KEYS:
+                os.environ.pop(k, None)
+            result = create_monthly_ensemble_forecasts(forecasts, skill)
+
+        sm = result[result["model_short"] == "Skilled Mean"]
+        # hv=1: two-model SM (LR, GBT) -> a row exists
+        sm1 = sm[sm["horizon_value"] == 1]
+        assert len(sm1) == 1, "hv=1 should produce one Skilled Mean row"
+        assert sm1.iloc[0]["composition"] == "GBT, LR"
+        # hv=2: only TFT qualifies -> single-model -> discarded, no blend into hv=1
+        sm2 = sm[sm["horizon_value"] == 2]
+        assert len(sm2) == 0, "hv=2 single-model Skilled Mean must be discarded"
+
+    def test_one_sided_absence_falls_back_to_3key(self):
+        """REGRESSION: forecasts carry horizon_value but skill rows do NOT.
+        The merge must fall back to the 3-key legacy form (no horizon_value)
+        and still produce a Skilled Mean, not silently drop everything to a
+        4-key mismatch."""
+        # Skill side has NO horizon_value column.
+        skill = _skill(
+            [
+                (3, CODE, "LR", 0.30, 0.95, 5.0, 0.90, 2.0, 10),
+                (3, CODE, "TFT", 0.40, 0.88, 5.0, 0.85, 4.0, 10),
+            ],
+            cols=[
+                "month_in_year",
+                "code",
+                "model_short",
+                "sdivsigma",
+                "nse",
+                "delta",
+                "accuracy",
+                "mae",
+                "n_pairs",
+            ],
+        )
+        forecasts = _forecasts(
+            [
+                _fc_row("LR", 100.0, hv=1),
+                _fc_row("TFT", 120.0, hv=1),
+            ]
+        )
+        with patch.dict(os.environ, DEFAULT_ENV):
+            for k in _LT_ENV_KEYS:
+                os.environ.pop(k, None)
+            result = create_monthly_ensemble_forecasts(forecasts, skill)
+
+        sm = result[result["model_short"] == "Skilled Mean"]
+        assert len(sm) == 1, (
+            "One-sided horizon_value must fall back to 3-key merge and still "
+            "produce a Skilled Mean row (no mismatch)."
+        )
+        assert sm.iloc[0]["composition"] == "LR, TFT"
+
+
+# ---------------------------------------------------------------------------
+# 5. Edge cases: single positive model, empty pool, NaN NSE
+# ---------------------------------------------------------------------------
+
+
+class TestSkilledMeanEdgeCases:
+    def test_single_positive_model_no_skilled_mean_row(self):
+        """Only one model has NSE>0 -> single-model -> Skilled Mean discarded."""
+        skill = _skill(
+            [
+                (3, 1, CODE, "LR", 0.30, 0.95, 5.0, 0.90, 2.0, 10),
+                (3, 1, CODE, "GBT", 0.90, -0.50, 5.0, 0.10, 6.0, 10),  # NSE<0
+            ]
+        )
+        forecasts = _forecasts(
+            [
+                _fc_row("LR", 100.0),
+                _fc_row("GBT", 300.0),
+            ]
+        )
+        with patch.dict(os.environ, DEFAULT_ENV):
+            for k in _LT_ENV_KEYS:
+                os.environ.pop(k, None)
+            result = create_monthly_ensemble_forecasts(forecasts, skill)
+        sm = result[result["model_short"] == "Skilled Mean"]
+        assert len(sm) == 0, "Single positive model must not yield a Skilled Mean row"
+
+    def test_empty_pool_no_row_no_crash(self):
+        """No model has NSE>0 -> no Skilled Mean row, no exception."""
+        skill = _skill(
+            [
+                (3, 1, CODE, "LR", 0.90, -0.10, 5.0, 0.10, 2.0, 10),
+                (3, 1, CODE, "GBT", 0.90, -0.50, 5.0, 0.10, 6.0, 10),
+            ]
+        )
+        forecasts = _forecasts(
+            [
+                _fc_row("LR", 100.0),
+                _fc_row("GBT", 300.0),
+            ]
+        )
+        with patch.dict(os.environ, DEFAULT_ENV):
+            for k in _LT_ENV_KEYS:
+                os.environ.pop(k, None)
+            result = create_monthly_ensemble_forecasts(forecasts, skill)
+        assert result[result["model_short"] == "Skilled Mean"].empty
+
+    def test_nan_nse_never_passes(self):
+        """A model with NaN NSE is never admitted by the NSE>0 gate."""
+        helper = getattr(sm_mod, "_long_term_threshold_overrides", None)
+        if helper is None:
+            pytest.fail(
+                "skill_metrics._long_term_threshold_overrides missing — cannot "
+                "verify NaN NSE handling under the LT gate."
+            )
+        skill = _skill(
+            [
+                (3, 1, CODE, "GOOD", 5.0, 0.30, 5.0, 0.10, 3.0, 10),
+                (3, 1, CODE, "NANMODEL", 5.0, np.nan, 5.0, 0.10, 3.0, 10),
+            ]
+        )
+        with patch.dict(os.environ, DEFAULT_ENV):
+            for k in _LT_ENV_KEYS:
+                os.environ.pop(k, None)
+            kept = filter_for_highly_skilled_forecasts(skill, **helper())
+        assert set(kept["model_short"]) == {"GOOD"}, "NaN NSE must not pass NSE>0"

--- a/apps/postprocessing_forecasts/tests/test_monthly_ensemble_creation.py
+++ b/apps/postprocessing_forecasts/tests/test_monthly_ensemble_creation.py
@@ -529,11 +529,15 @@ class TestSkilledMeanCreation:
         assert sm.iloc[0]["composition"] == "LR, TFT"
 
     def test_skilled_mean_single_model_discarded(self):
-        """Skilled Mean is not created with only one qualifying model."""
+        """Skilled Mean is not created with only one qualifying model.
+
+        The monthly Skilled Mean pool is the long-term NSE>0 gate, so TFT must
+        have NSE<=0 to be the single-model-discard case (only LR qualifies).
+        """
         skill = _make_skill(
             [
                 (3, "S1", "LR", 0.3, 0.95, 5.0, 0.90, 2.0, 10),
-                (3, "S1", "TFT", 0.9, 0.50, 5.0, 0.50, 8.0, 10),  # fails
+                (3, "S1", "TFT", 0.9, -0.50, 5.0, 0.50, 8.0, 10),  # NSE<=0: excluded
             ]
         )
         forecasts = _two_model_forecasts()
@@ -1391,11 +1395,16 @@ class TestEdgeCases:
         assert "TFT" not in em.iloc[0]["composition"]
 
     def test_no_models_pass_thresholds(self):
-        """No ensembles created when all models fail thresholds."""
+        """No ensembles created when all models fail thresholds.
+
+        EM uses the default gate; the monthly Skilled Mean uses the long-term
+        NSE>0 gate, so both models must have NSE<=0 for the Skilled-Mean pool to
+        be empty as well.
+        """
         skill = _make_skill(
             [
-                (3, "S1", "LR", 0.9, 0.50, 5.0, 0.50, 8.0, 10),
-                (3, "S1", "TFT", 0.9, 0.40, 5.0, 0.40, 9.0, 10),
+                (3, "S1", "LR", 0.9, -0.50, 5.0, 0.50, 8.0, 10),
+                (3, "S1", "TFT", 0.9, -0.40, 5.0, 0.40, 9.0, 10),
             ]
         )
         forecasts = _two_model_forecasts()


### PR DESCRIPTION
## Summary

Relaxes the **long-term Skilled Mean** model pool to include **all long-term models with NSE > 0** (the previous gate — NSE > 0.8 ∧ sdivsigma < 0.6 ∧ accuracy > 0.8 — was too restrictive and starved the pool). Short-term (pentad/decad) skill gating is **unchanged**, and **EM is not touched** at any horizon.

Owner-locked spec: LT Skilled Mean = NSE>0 only (efficiency + accuracy gates disabled for LT); short-term stays at NSE>0.8; EM membership/output must not change.

## Changes
- `skill_metrics.py` — new long-term-only threshold override (`nse=0.0`, `sdivsigma`/`accuracy` disabled) applied **only at the LT Skilled-Mean call sites**; a shared, case-insensitive env parser (`false/off/none/disable/''` → gate off, numeric → float, invalid → clear config error). Two docstrings corrected to describe the LT pool.
- `ensemble_calculator.py` — split the monthly forecast-side pool so **EM keeps the default gate** while Skilled Mean uses the relaxed gate; made the monthly Skilled-Mean merge/weight keys **lead-aware** (`horizon_value`) only when present on both sides, with a 3-key legacy fallback. Quarter/season EM (fixed `mean(LR_BASE, LR_SM)`) untouched.
- New tests `tests/test_lt_skilled_mean_nse_threshold.py`; small update to `tests/test_monthly_ensemble_creation.py`.

## Tests / validation
- `SAPPHIRE_TEST_ENV=True bash run_tests.sh postprocessing_forecasts` — full suite green (1445 pass / 0 skip); ruff clean.
- **EM byte-invariance locked**: `test_em_row_byte_identical_to_default` asserts the EM row's keys, composition, forecasted_discharge, and quantiles are byte-identical to default behavior while the relaxed Skilled Mean admits extra members.
- **Operational validation** (local Tajik `postprocessing_db`, full monthly recalc): the relaxation is live and correct — **456 member-inclusions across 219 Skilled-Mean rows over 17 sites** where the member's own NSE ∈ (0, 0.8] (impossible under the old gate); smallest included member NSE = 0.002, none negative (NSE>0 lower bound respected).

## Notes
- Separate, lower-priority follow-up filed for an unrelated latent ensemble-exclusion form inconsistency (display-form vs DB-form) in the same module — not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)