### PR TITLE
Fix pentad/decad hydrograph date not JSON-serializable on live write

### DIFF
--- a/apps/preprocessing_runoff/sync_short_horizon_hydrograph.py
+++ b/apps/preprocessing_runoff/sync_short_horizon_hydrograph.py
@@ -386,7 +386,7 @@ def _build_short_horizon_records(
         record = {
             "horizon_type": horizon_type,
             "code": str(code),
-            "date": config["get_issue_date"](period, target_year),
+            "date": config["get_issue_date"](period, target_year).date().isoformat(),
             "horizon_value": config["get_value_in_month"](period),
             "horizon_in_year": period,
             "day_of_year": config["get_day_of_year"](period, target_year),

--- a/apps/preprocessing_runoff/test/test_short_horizon_actuals_m2.py
+++ b/apps/preprocessing_runoff/test/test_short_horizon_actuals_m2.py
@@ -49,11 +49,13 @@ Fake station code '19999'; no real discharge values.
 
 import calendar
 import datetime as dt
+import json
 import os
 import sys
 
 import pandas as pd
 import pytest
+import requests
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "iEasyHydroForecast"))
@@ -666,3 +668,52 @@ def test_decad_build_does_not_silently_store_a_non_numeric_sdk_value():
     current = _row(records, 2)["current"]
     assert current is not garbage  # never the raw garbage object
     assert not isinstance(current, _NotANumber)
+
+
+# --------------------------------------------------------------------------
+# Regression — the "date" field must be JSON-serializable (ISO date string),
+# not a raw pandas.Timestamp. A real API write does
+# ``requests.post(..., json=records)``, and ``json.dumps`` cannot serialize a
+# ``pandas.Timestamp`` -> ``TypeError: Object of type Timestamp is not JSON
+# serializable``. Month/quarter/season rows already emit ISO strings; this
+# pins pentad/decad to the same contract.
+# --------------------------------------------------------------------------
+def test_pentad_and_decad_date_field_is_json_serializable():
+    _require_module()
+    daily_by_year = {
+        2024: [{"code": CODE, "date": "2024-01-01", "discharge": 10.0}],
+        2025: [{"code": CODE, "date": "2025-01-01", "discharge": 20.0}],
+    }
+    pentad_records = shh.build_pentad_records(
+        code=CODE,
+        norms=PENTAD_NORMS,
+        daily_by_year=daily_by_year,
+        sdk_current={},
+        sdk_previous={},
+        target_year=2025,
+        today=dt.date(2025, 7, 1),
+    )
+    decad_records = shh.build_decad_records(
+        code=CODE,
+        norms=DECAD_NORMS,
+        daily_by_year=daily_by_year,
+        sdk_current={},
+        sdk_previous={},
+        target_year=2025,
+        today=dt.date(2025, 7, 1),
+    )
+
+    for records in (pentad_records, decad_records):
+        for record in records:
+            assert isinstance(record["date"], str), (
+                f"date must be a JSON-serializable str, got {type(record['date'])!r}: "
+                f"{record['date']!r}"
+            )
+        # The real failure mode: json.dumps (and by extension the requests
+        # `json=` kwarg used by the API client) must not raise.
+        json.dumps({"data": records})
+        # Exercise the actual serialization path used by
+        # `client.write_hydrograph(records)` -> sapphire_api_client -> requests.
+        requests.Session().prepare_request(
+            requests.Request("POST", "http://x/", json={"data": records})
+        )


### PR DESCRIPTION
## Problem

`build_pentad_records` / `build_decad_records` set the record `"date"` to a raw
`pandas.Timestamp` (from `get_issue_date_from_pentad` / `_from_decad`). The real write
path — `client.write_hydrograph(records)` → `sapphire-api-client` → `requests(json=…)`
→ `json.dumps` — cannot serialize a `Timestamp`, so **every live pentad/decad write
raised `TypeError: Object of type Timestamp is not JSON serializable`**.

- **Operational path:** the exception is caught non-fatally and logged at ERROR, so
  pentad/decad hydrograph rows **silently never wrote** (the forecast run continues).
- **Backfill path:** the live write hard-failed.
- Month/quarter/season were unaffected — they already emit ISO string dates.

Reproduced independently with synthetic data (raw `Timestamp` → `requests`
`complexjson.dumps(allow_nan=False)` → `TypeError`; `sapphire-api-client==0.5.0` has no
coercion layer). The tests missed it because they use mocked/capturing clients that
never JSON-serialize; the dry-run doesn't write; the live parity checks were reads. The
first real live write (a historical backfill) surfaced it.

## Fix

Stringify the issue date at build time — one line, matching the month path's `YYYY-MM-DD`
format:

```python
"date": config["get_issue_date"](period, target_year).date().isoformat()
```

Plus a regression test that builds pentad + decad records and asserts the date is a
`str` and that `json.dumps` **and** `requests`' `json=` serialization path do not raise —
the serialization the mocked-client tests never exercised.

## Testing

`preprocessing_runoff` — 417 pass / 2 pre-existing skips / 0 fail; ruff clean.

## Note

Independent review also flagged an adjacent, **latent** robustness gap (`_json_safe`
doesn't normalize numpy *integer* scalars, which would break `allow_nan=False`). That is
out of scope here — short-horizon norms are discharge floats, and `_json_safe` lives in
`sync_long_horizon_hydrograph.py`, which a separate branch is actively editing — and is
being handed to that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)