### PR TITLE
Postprocessing skill correctness: M2–M5 (gates, NaN masks, canonical CRPS, eval dedup)

### DIFF
--- a/apps/forecast_skill_eval/src/forecast_skill_eval/cli.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/cli.py
@@ -167,10 +167,13 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--short-term-dedup-one-per-target",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help=(
-            "Short-term correctness gate (default off): keep only the latest "
-            "issue per (code, period_key, year, model) for day/pentad/decade."
+            "Short-term correctness gate (default ON): keep only the latest "
+            "issue per (code, period_key, year, model) for day/pentad/decade, "
+            "matching the operational one-pair-per-target convention. Pass "
+            "--no-short-term-dedup-one-per-target to opt out."
         ),
     )
     parser.add_argument(
@@ -197,9 +200,12 @@ def _parser() -> argparse.ArgumentParser:
 
 
 def _config_from_args(args: argparse.Namespace) -> ForecastSkillEvalConfig:
-    # SAPPHIRE_SKILL_FORECAST_ONLY=1/true turns BOTH short-term correctness gates
-    # on, mirroring the existing SAPPHIRE_SKILL_* env-flag convention.  The CLI
-    # flags are OR-ed with it so either mechanism can enable a gate.
+    # SAPPHIRE_SKILL_FORECAST_ONLY=1/true forces BOTH short-term correctness gates
+    # ON, mirroring the existing SAPPHIRE_SKILL_* env-flag convention.  The CLI
+    # flags are OR-ed with it so either mechanism can enable a gate.  Note
+    # short_term_dedup_one_per_target now defaults ON (D4/#7): its arg is a
+    # BooleanOptionalAction defaulting True, so the OR keeps it ON by default and
+    # honours the --no-... opt-out, while FORECAST_ONLY still force-enables it.
     forecast_only = _env_flag("SAPPHIRE_SKILL_FORECAST_ONLY")
     lr_repair = _env_flag("SAPPHIRE_SKILL_LR_REPAIR")
     lt_lead = _env_flag("SAPPHIRE_SKILL_LT_LEAD")

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/config.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/config.py
@@ -76,13 +76,15 @@ class ForecastSkillEvalConfig:
     season_filter: str = "all"
     regime_source: str = "auto"
     # Short-term (day/pentad/decade) forecast-pairing correctness gates.
-    # Both default False so the default pairing behaviour is byte-identical.
     #   * short_term_issue_before_target: drop short-term forecasts issued on or
     #     after their target period start (observation leakage / mislabelled rows).
+    #     Defaults False so the default pairing behaviour is byte-identical.
     #   * short_term_dedup_one_per_target: keep only the latest genuine pre-period
     #     issue per (code, period_key, year, model) for short-term horizons.
+    #     Defaults True (D4/#7) so the default eval run matches the operational
+    #     one-pair-per-target convention; pass False explicitly to opt out.
     short_term_issue_before_target: bool = False
-    short_term_dedup_one_per_target: bool = False
+    short_term_dedup_one_per_target: bool = True
     #   * short_term_lr_repair_issue_indexing: correct historical issue-indexed LR
     #     pentad/decade forecasts to target-indexed at read time.  Default False so
     #     the default read behaviour is byte-identical.

--- a/apps/forecast_skill_eval/src/forecast_skill_eval/prob_metrics.py
+++ b/apps/forecast_skill_eval/src/forecast_skill_eval/prob_metrics.py
@@ -12,6 +12,11 @@ CRPS estimator (Design Decision 2):
     for the climatology and persistence reference CRPS (via
     crps_reference_from_samples), making CRPSS unbiased by estimator mismatch.
 
+    M4 (D3/#5+#6, postprocessing skill-correctness campaign): this estimator
+    now lives canonically in iEasyHydroForecast.probabilistic_metrics
+    (crps_single); crps_from_quantiles below is a thin wrapper so this app
+    and postprocessing_forecasts always compute IDENTICAL CRPS values.
+
 Cross-grid comparability (Design Decision 3):
     Raw crps is never ranked across fc_grid_id values.  The dashboard/report
     restrict CRPSS ranking to a single fc_grid_id.
@@ -25,6 +30,7 @@ from typing import Final, Literal
 
 import numpy as np
 import pandas as pd
+import probabilistic_metrics as pm
 
 from forecast_skill_eval.contingency import (
     ALL_BASIN,
@@ -189,6 +195,11 @@ def crps_from_quantiles(
     rewarded).  The IDENTICAL estimator is used for the climatology reference
     via :func:`crps_reference_from_samples`, so CRPSS is estimator-consistent.
 
+    M4 (D3/#5+#6): thin wrapper around the canonical
+    iEasyHydroForecast.probabilistic_metrics.crps_single, so
+    postprocessing_forecasts and forecast_skill_eval always compute
+    IDENTICAL CRPS values from the same (levels, quantiles, observed) input.
+
     Args:
         levels: Quantile probability levels (will be isotonic-repaired).
         quantiles: Corresponding quantile values.
@@ -198,46 +209,7 @@ def crps_from_quantiles(
         Approximate CRPS ≥ 0, or ``math.nan`` when fewer than 2 finite nodes
         remain after isotonic repair or when ``observed`` is non-finite.
     """
-    lev, qval, _ = isotonic_band(levels, quantiles)
-    if len(lev) < 2:
-        return math.nan
-    if not math.isfinite(observed):
-        return math.nan
-
-    obs = observed
-
-    def _pinball(tau: float, q: float) -> float:
-        if obs >= q:
-            return tau * (obs - q)
-        return (1.0 - tau) * (q - obs)
-
-    # --- Middle: trapezoidal integration between adjacent nodes ---
-    middle = 0.0
-    for i in range(len(lev) - 1):
-        dtau = lev[i + 1] - lev[i]
-        middle += dtau * (_pinball(lev[i], qval[i]) + _pinball(lev[i + 1], qval[i + 1])) / 2.0
-
-    # --- Left tail: [0, tau_min] flat at q_min ---
-    tau_min = lev[0]
-    q_min = qval[0]
-    if obs >= q_min:
-        # ∫₀^τ_min τ·(obs - q_min) dτ = (obs - q_min)·τ_min²/2
-        left_tail = (obs - q_min) * tau_min**2 / 2.0
-    else:
-        # ∫₀^τ_min (1-τ)·(q_min - obs) dτ = (q_min - obs)·(τ_min - τ_min²/2)
-        left_tail = (q_min - obs) * (tau_min - tau_min**2 / 2.0)
-
-    # --- Right tail: [tau_max, 1] flat at q_max ---
-    tau_max = lev[-1]
-    q_max = qval[-1]
-    if obs <= q_max:
-        # ∫_τ_max^1 (1-τ)·(q_max - obs) dτ = (q_max - obs)·(1 - τ_max)²/2
-        right_tail = (q_max - obs) * (1.0 - tau_max) ** 2 / 2.0
-    else:
-        # ∫_τ_max^1 τ·(obs - q_max) dτ = (obs - q_max)·(1 - τ_max²)/2
-        right_tail = (obs - q_max) * (1.0 - tau_max**2) / 2.0
-
-    return 2.0 * (left_tail + middle + right_tail)
+    return pm.crps_single(levels, quantiles, observed)
 
 
 def crps_reference_from_samples(

--- a/apps/forecast_skill_eval/tests/test_cli.py
+++ b/apps/forecast_skill_eval/tests/test_cli.py
@@ -154,11 +154,14 @@ def test_regime_source_cli_arg_parses_into_config() -> None:
 
 
 def test_short_term_gate_flags_default_off_in_cli() -> None:
+    # issue-before-target still defaults OFF in the CLI; dedup now defaults ON
+    # (D4/#7) -- its CLI default/opt-out is locked in
+    # test_short_term_dedup_default.py.
     parser = cli._parser()
     args = parser.parse_args([])
     config = cli._config_from_args(args)
     assert config.short_term_issue_before_target is False
-    assert config.short_term_dedup_one_per_target is False
+    assert config.short_term_dedup_one_per_target is True
 
 
 def test_short_term_gate_flags_parse_into_config() -> None:
@@ -207,13 +210,15 @@ def test_forecast_only_env_enables_both_short_term_gates(monkeypatch) -> None:
     assert config.short_term_dedup_one_per_target is True
 
 
-def test_forecast_only_env_unset_leaves_gates_off(monkeypatch) -> None:
+def test_forecast_only_env_unset_leaves_gates_at_their_defaults(monkeypatch) -> None:
+    # With FORECAST_ONLY unset, each gate keeps its own default: issue-before-target
+    # OFF, dedup ON (D4/#7).  FORECAST_ONLY only force-enables; it never disables.
     monkeypatch.delenv("SAPPHIRE_SKILL_FORECAST_ONLY", raising=False)
     parser = cli._parser()
     args = parser.parse_args([])
     config = cli._config_from_args(args)
     assert config.short_term_issue_before_target is False
-    assert config.short_term_dedup_one_per_target is False
+    assert config.short_term_dedup_one_per_target is True
 
 
 def test_lr_repair_cli_default_is_off(monkeypatch) -> None:

--- a/apps/forecast_skill_eval/tests/test_config.py
+++ b/apps/forecast_skill_eval/tests/test_config.py
@@ -101,11 +101,15 @@ def test_invalid_config_inputs_are_rejected(kwargs: dict[str, object]) -> None:
 
 
 def test_short_term_gate_flags_default_off() -> None:
-    """Both short-term correctness gates must default to False (byte-identical)."""
+    """The issue-before-target gate defaults to False (byte-identical).
+
+    ``short_term_dedup_one_per_target`` defaults to True as of D4/#7 (one pair
+    per target, matching the operational side) -- see
+    ``test_short_term_dedup_default.py`` for the locked default-value test.
+    """
     config = ForecastSkillEvalConfig()
 
     assert config.short_term_issue_before_target is False
-    assert config.short_term_dedup_one_per_target is False
 
 
 def test_short_term_gate_flags_can_be_enabled() -> None:

--- a/apps/forecast_skill_eval/tests/test_pairs.py
+++ b/apps/forecast_skill_eval/tests/test_pairs.py
@@ -1173,9 +1173,14 @@ def test_dedup_one_per_target_keeps_latest_issue(fake_client_factory) -> None:
     assert pairs.iloc[0]["period_key"] == 10
 
 
-def test_dedup_off_by_default_keeps_all_reissues(fake_client_factory) -> None:
+def test_dedup_explicitly_disabled_keeps_all_reissues(fake_client_factory) -> None:
+    # short_term_dedup_one_per_target defaults to True as of D4/#7; this test
+    # covers the explicit opt-out, which must still keep every re-issue.
     client = _reissue_client(fake_client_factory)
-    config = ForecastSkillEvalConfig(station_filter=[STATION_CODE])
+    config = ForecastSkillEvalConfig(
+        station_filter=[STATION_CODE],
+        short_term_dedup_one_per_target=False,
+    )
 
     pairs, _ledger = build_pairs(config, client, "day")
 
@@ -1212,11 +1217,14 @@ def test_long_term_horizons_unaffected_by_short_term_gates(
     assert ("pair", "forecast_issue_in_target_period") not in ledger.counts_by_stage_reason()
 
 
-def test_default_config_run_is_byte_identical_with_leakage_and_reissues(
+def test_default_config_run_dedups_reissues_but_not_leakage(
     fake_client_factory,
 ) -> None:
     # Fixture mixes a leaking issue (pk 6 issued after start) with three re-issues
-    # (pk 10).  With both gates off (default) every row must survive unchanged.
+    # (pk 10).  short_term_issue_before_target still defaults to False, so the
+    # leaking row survives unchanged; short_term_dedup_one_per_target now
+    # defaults to True (D4/#7), so the three pk-10 re-issues collapse to the
+    # single latest-issued row.
     client = fake_client_factory(
         forecasts_rows=[
             _short_forecast(5, 7.0, issue_date="2024-01-01"),
@@ -1236,8 +1244,9 @@ def test_default_config_run_is_byte_identical_with_leakage_and_reissues(
 
     pairs, ledger = build_pairs(config, client, "day")
 
-    assert len(pairs) == 5
-    assert sorted(pairs["period_key"].tolist()) == [5, 6, 10, 10, 10]
+    assert len(pairs) == 3
+    assert sorted(pairs["period_key"].tolist()) == [5, 6, 10]
+    assert pairs.loc[pairs["period_key"] == 10, "issue_date"].iloc[0] == "2024-01-03"
     assert ("pair", "forecast_issue_in_target_period") not in ledger.counts_by_stage_reason()
 
 

--- a/apps/forecast_skill_eval/tests/test_prob_metrics.py
+++ b/apps/forecast_skill_eval/tests/test_prob_metrics.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
 import pandas as pd
 import pytest
+from probabilistic_metrics import crps_from_quantiles as shared_crps_from_quantiles
+from probabilistic_metrics import crps_single as shared_crps_single
 
 from forecast_skill_eval.prob_metrics import (
     PROB_METRIC_COLUMNS,
@@ -246,6 +249,48 @@ class TestCrpsFromQuantiles:
         crps_near = crps_from_quantiles(self._LEVELS, self._QVALS, 85.0)
         crps_far = crps_from_quantiles(self._LEVELS, self._QVALS, 150.0)
         assert crps_far > crps_near
+
+
+# ===========================================================================
+# crps_from_quantiles — M4 (D3/#5+#6) canonical shared-estimator contract
+# ===========================================================================
+
+
+class TestCrpsFromQuantilesCanonicalDelegation:
+    """crps_from_quantiles must delegate to (produce identical values to) the
+    canonical iEasyHydroForecast.probabilistic_metrics estimator, so
+    postprocessing_forecasts and forecast_skill_eval always agree (M4 'same
+    value at both call sites' contract). See
+    postprocessing_forecasts/tests/test_crps.py for the mirrored check on
+    the other call site."""
+
+    _QUANTILE_LEVELS = [0.05, 0.10, 0.25, 0.50, 0.75, 0.90, 0.95]
+
+    def test_deterministic_band_matches_textbook_abs_diff(self):
+        """Locked M4 regression test: all quantiles == 100.0, observed ==
+        130.0 -> CRPS == 30.0. The OLD postprocessing_forecasts estimator
+        returned ~13.5 for the equivalent input (missing factor-2 + tails);
+        forecast_skill_eval's estimator already got this right."""
+        result = crps_from_quantiles(self._QUANTILE_LEVELS, [100.0] * 7, 130.0)
+        assert result == pytest.approx(30.0, abs=1e-9)
+
+    def test_matches_shared_crps_single_directly(self):
+        qvals = [20, 40, 60, 80, 100, 120, 140]
+        result = crps_from_quantiles(self._QUANTILE_LEVELS, qvals, 95.0)
+        expected = shared_crps_single(self._QUANTILE_LEVELS, qvals, 95.0)
+        assert result == pytest.approx(expected, rel=1e-12)
+
+    def test_matches_shared_batched_entry_point_for_one_row(self):
+        """Same value whether scored via the per-pair entry point used here,
+        or the (N,K) batched entry point used by postprocessing_forecasts —
+        proves the two call-site shapes agree, not just the two apps."""
+        observed = np.array([130.0])
+        quantile_forecasts = np.array([[100.0] * 7])
+        batched = shared_crps_from_quantiles(
+            observed, quantile_forecasts, np.array(self._QUANTILE_LEVELS)
+        )
+        single = crps_from_quantiles(self._QUANTILE_LEVELS, [100.0] * 7, 130.0)
+        assert single == pytest.approx(batched, rel=1e-12)
 
 
 # ===========================================================================

--- a/apps/forecast_skill_eval/tests/test_short_term_dedup_default.py
+++ b/apps/forecast_skill_eval/tests/test_short_term_dedup_default.py
@@ -1,0 +1,67 @@
+"""Locked regression test for M5 (design D4/#7).
+
+The default run must dedup short-term (day/pentad/decade) re-issues to one
+pair per target, matching the operational side.  This closes the
+eval-vs-operational divergence described in
+``doc/plans/postprocessing_skill_correctness_design.md`` (M5).  The opt-out
+(explicitly passing ``False``) must still work.
+"""
+
+from __future__ import annotations
+
+from forecast_skill_eval import cli
+from forecast_skill_eval.config import ForecastSkillEvalConfig
+
+
+def test_short_term_dedup_one_per_target_defaults_true() -> None:
+    """The default config must dedup short-term re-issues to one pair per target."""
+    config = ForecastSkillEvalConfig()
+
+    assert config.short_term_dedup_one_per_target is True
+
+
+def test_short_term_dedup_one_per_target_opt_out_still_works() -> None:
+    """A caller must still be able to explicitly disable the dedup gate."""
+    config = ForecastSkillEvalConfig(short_term_dedup_one_per_target=False)
+
+    assert config.short_term_dedup_one_per_target is False
+
+
+def test_cli_default_run_dedups_one_per_target(monkeypatch) -> None:
+    """A CLI run with no flag must resolve dedup ON (the operational default)."""
+    monkeypatch.delenv("SAPPHIRE_SKILL_FORECAST_ONLY", raising=False)
+    parser = cli._parser()
+    args = parser.parse_args([])
+    config = cli._config_from_args(args)
+
+    assert config.short_term_dedup_one_per_target is True
+
+
+def test_cli_opt_out_flag_disables_dedup(monkeypatch) -> None:
+    """The explicit opt-out flag must turn short-term dedup OFF."""
+    monkeypatch.delenv("SAPPHIRE_SKILL_FORECAST_ONLY", raising=False)
+    parser = cli._parser()
+    args = parser.parse_args(["--no-short-term-dedup-one-per-target"])
+    config = cli._config_from_args(args)
+
+    assert config.short_term_dedup_one_per_target is False
+
+
+def test_cli_legacy_on_flag_still_works(monkeypatch) -> None:
+    """The original --short-term-dedup-one-per-target flag must still turn it ON."""
+    monkeypatch.delenv("SAPPHIRE_SKILL_FORECAST_ONLY", raising=False)
+    parser = cli._parser()
+    args = parser.parse_args(["--short-term-dedup-one-per-target"])
+    config = cli._config_from_args(args)
+
+    assert config.short_term_dedup_one_per_target is True
+
+
+def test_cli_forecast_only_env_forces_dedup_even_with_opt_out(monkeypatch) -> None:
+    """SAPPHIRE_SKILL_FORECAST_ONLY must force dedup ON despite the opt-out flag."""
+    monkeypatch.setenv("SAPPHIRE_SKILL_FORECAST_ONLY", "1")
+    parser = cli._parser()
+    args = parser.parse_args(["--no-short-term-dedup-one-per-target"])
+    config = cli._config_from_args(args)
+
+    assert config.short_term_dedup_one_per_target is True

--- a/apps/iEasyHydroForecast/probabilistic_metrics.py
+++ b/apps/iEasyHydroForecast/probabilistic_metrics.py
@@ -1,0 +1,183 @@
+"""Canonical CRPS (Continuous Ranked Probability Score) estimator.
+
+Shared by ``postprocessing_forecasts`` and ``forecast_skill_eval`` so both apps
+compute IDENTICAL CRPS values from quantile forecasts. Prior to this module,
+each app had its own implementation and they disagreed by roughly a factor of
+2 (postprocessing_forecasts omitted the factor-2 term and the flat-tail
+terms). See design decision D3 and milestone M4 in
+``doc/plans/postprocessing_skill_correctness_design.md``.
+
+CRPS estimator (textbook):
+    CRPS = 2 * integral_0^1 pinball_loss(tau, obs) dtau
+
+Approximated by:
+    - trapezoidal integration between quantile grid nodes;
+    - explicit flat-tail terms on [0, tau_min] and [tau_max, 1], treating the
+      quantile function as flat (extrapolated) beyond the observed grid. This
+      penalises an observation that falls outside the forecast band instead
+      of rewarding an artificially narrow ("overconfident") band.
+
+For a degenerate/point quantile band (every node equal to the same value q),
+this estimator reduces exactly to CRPS = |obs - q|, independent of the
+specific quantile levels used — a useful sanity check.
+
+NaN handling (fixes issue #6 — "NaN-quantile poisoning"):
+    - A single (quantile band, observation) pair is scored via
+      :func:`crps_single`. Non-finite quantile *nodes* are dropped before
+      scoring (isotonic-repair keeps the remaining finite nodes and enforces
+      a non-decreasing quantile function); if fewer than 2 finite nodes
+      remain, or the observation itself is non-finite, the pair scores NaN.
+    - The batched aggregator :func:`crps_from_quantiles` (N observations x K
+      quantile levels -> scalar mean) scores each row independently via
+      :func:`crps_single` and reduces with a NaN-aware mean. A single bad row
+      (NaN observation, or a quantile row with too few finite levels) is
+      excluded from the mean instead of nulling the entire group's CRPS, as
+      the previous postprocessing_forecasts implementation did.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+import numpy as np
+
+
+def _isotonic_repair(
+    levels: Sequence[float], quantiles: Sequence[float]
+) -> tuple[list[float], list[float]]:
+    """Drop non-finite nodes, sort by level, enforce a non-decreasing quantile
+    function via cumulative max.
+
+    This mirrors ``forecast_skill_eval.prob_metrics.isotonic_band``'s node
+    repair algorithm. It is intentionally duplicated (not imported) so this
+    shared library — which ``postprocessing_forecasts`` also depends on — has
+    no reverse dependency on ``forecast_skill_eval``.
+
+    Returns:
+        Tuple of (repaired_levels, repaired_quantiles), both sorted by level.
+        Empty lists when there are no finite node pairs.
+    """
+    node_pairs: list[tuple[float, float]] = []
+    for lv, qv in zip(levels, quantiles, strict=False):
+        try:
+            lv_f = float(lv)
+            qv_f = float(qv)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(lv_f) and math.isfinite(qv_f):
+            node_pairs.append((lv_f, qv_f))
+
+    if not node_pairs:
+        return [], []
+
+    node_pairs.sort(key=lambda x: x[0])
+    sorted_levels = [p[0] for p in node_pairs]
+    sorted_quantiles = [p[1] for p in node_pairs]
+
+    repaired: list[float] = [sorted_quantiles[0]]
+    for qv in sorted_quantiles[1:]:
+        running_max = repaired[-1]
+        repaired.append(qv if qv >= running_max else running_max)
+
+    return sorted_levels, repaired
+
+
+def crps_single(
+    levels: Sequence[float],
+    quantiles: Sequence[float],
+    observed: float,
+) -> float:
+    """Score one (quantile band, observation) pair with the textbook CRPS
+    estimator. See the module docstring for the formula.
+
+    Args:
+        levels: Quantile probability levels (will be isotonic-repaired).
+        quantiles: Corresponding quantile values.
+        observed: The scalar observation to score.
+
+    Returns:
+        Approximate CRPS >= 0, or ``math.nan`` when fewer than 2 finite nodes
+        remain after isotonic repair or when ``observed`` is non-finite.
+    """
+    lev, qval = _isotonic_repair(levels, quantiles)
+    if len(lev) < 2:
+        return math.nan
+    try:
+        obs = float(observed)
+    except (TypeError, ValueError):
+        return math.nan
+    if not math.isfinite(obs):
+        return math.nan
+
+    def _pinball(tau: float, q: float) -> float:
+        if obs >= q:
+            return tau * (obs - q)
+        return (1.0 - tau) * (q - obs)
+
+    # --- Middle: trapezoidal integration between adjacent nodes ---
+    middle = 0.0
+    for i in range(len(lev) - 1):
+        dtau = lev[i + 1] - lev[i]
+        middle += dtau * (_pinball(lev[i], qval[i]) + _pinball(lev[i + 1], qval[i + 1])) / 2.0
+
+    # --- Left tail: [0, tau_min] flat at q_min ---
+    tau_min = lev[0]
+    q_min = qval[0]
+    if obs >= q_min:
+        # integral_0^tau_min tau * (obs - q_min) dtau = (obs - q_min) * tau_min^2 / 2
+        left_tail = (obs - q_min) * tau_min**2 / 2.0
+    else:
+        # integral_0^tau_min (1-tau) * (q_min - obs) dtau
+        #     = (q_min - obs) * (tau_min - tau_min^2/2)
+        left_tail = (q_min - obs) * (tau_min - tau_min**2 / 2.0)
+
+    # --- Right tail: [tau_max, 1] flat at q_max ---
+    tau_max = lev[-1]
+    q_max = qval[-1]
+    if obs <= q_max:
+        # integral_tau_max^1 (1-tau) * (q_max - obs) dtau = (q_max - obs) * (1-tau_max)^2/2
+        right_tail = (q_max - obs) * (1.0 - tau_max) ** 2 / 2.0
+    else:
+        # integral_tau_max^1 tau * (obs - q_max) dtau = (obs - q_max) * (1-tau_max^2)/2
+        right_tail = (obs - q_max) * (1.0 - tau_max**2) / 2.0
+
+    return 2.0 * (left_tail + middle + right_tail)
+
+
+def crps_from_quantiles(
+    observed: Sequence[float] | np.ndarray,
+    quantile_forecasts: Sequence[Sequence[float]] | np.ndarray,
+    quantile_levels: Sequence[float] | np.ndarray,
+) -> float:
+    """Mean textbook CRPS across (N, K) observation/quantile-forecast pairs.
+
+    This is the canonical, vectorised entry point — it is what
+    ``postprocessing_forecasts.skill_metrics.calculate_crps`` delegates to.
+    Internally each row is scored via :func:`crps_single`, so this function
+    and any direct caller of :func:`crps_single` always agree.
+
+    Args:
+        observed: shape (N,) — observed values.
+        quantile_forecasts: shape (N, K) — forecasted quantiles.
+        quantile_levels: shape (K,) — e.g. [0.05, 0.10, ..., 0.95].
+
+    Returns:
+        NaN-aware mean CRPS across valid observation rows (lower is better).
+        A row is invalid (excluded from the mean) when its observation is
+        non-finite, or when fewer than 2 finite quantile nodes remain after
+        isotonic repair (#6 — a single bad row no longer poisons the whole
+        group's mean). Returns NaN only when every row is invalid.
+    """
+    observed_arr = np.asarray(observed, dtype=np.float64)
+    quantile_forecasts_arr = np.asarray(quantile_forecasts, dtype=np.float64)
+    quantile_levels_arr = np.asarray(quantile_levels, dtype=np.float64)
+
+    n = observed_arr.shape[0]
+    per_obs = np.full(n, np.nan, dtype=np.float64)
+    for i in range(n):
+        per_obs[i] = crps_single(quantile_levels_arr, quantile_forecasts_arr[i], observed_arr[i])
+
+    if not np.any(np.isfinite(per_obs)):
+        return float("nan")
+    return float(np.nanmean(per_obs))

--- a/apps/iEasyHydroForecast/pyproject.toml
+++ b/apps/iEasyHydroForecast/pyproject.toml
@@ -42,6 +42,7 @@ include = [
     "__init__.py",
     "forecast_library.py",
     "long_term_horizon_resolver.py",
+    "probabilistic_metrics.py",
     "setup_library.py",
     "tag_library.py",
 ]

--- a/apps/iEasyHydroForecast/tests/test_probabilistic_metrics.py
+++ b/apps/iEasyHydroForecast/tests/test_probabilistic_metrics.py
@@ -1,0 +1,148 @@
+"""Tests for the canonical CRPS estimator in probabilistic_metrics.py.
+
+Milestone M4 (design decision D3, findings #5 + #6) of the postprocessing
+skill-correctness campaign
+(doc/plans/postprocessing_skill_correctness_design.md). Both
+postprocessing_forecasts.skill_metrics.calculate_crps and
+forecast_skill_eval.prob_metrics.crps_from_quantiles delegate to the
+functions tested here, so a correctness fix or regression here affects both
+apps identically.
+"""
+
+import math
+
+import numpy as np
+import pytest
+from probabilistic_metrics import crps_from_quantiles, crps_single
+
+QUANTILE_LEVELS = np.array([0.05, 0.10, 0.25, 0.50, 0.75, 0.90, 0.95])
+
+
+class TestCrpsSingleDeterministicBand:
+    """Deterministic (point) quantile band: CRPS must equal |obs - q|.
+
+    This is the textbook property that the OLD postprocessing_forecasts
+    estimator got wrong (it returned ~half this value because it omitted
+    the factor-2 term and the flat-tail terms).
+    """
+
+    def test_observed_above_band_equals_abs_diff(self):
+        result = crps_single(QUANTILE_LEVELS, [100.0] * 7, 130.0)
+        assert result == pytest.approx(30.0, abs=1e-9)
+
+    def test_observed_below_band_equals_abs_diff(self):
+        result = crps_single(QUANTILE_LEVELS, [100.0] * 7, 70.0)
+        assert result == pytest.approx(30.0, abs=1e-9)
+
+    def test_observed_at_band_is_zero(self):
+        result = crps_single(QUANTILE_LEVELS, [100.0] * 7, 100.0)
+        assert result == pytest.approx(0.0, abs=1e-9)
+
+    def test_property_independent_of_specific_levels(self):
+        """|obs - q| holds for any monotonic level grid, not just the
+        7-quantile SAPPHIRE grid."""
+        result = crps_single([0.25, 0.75], [50.0, 50.0], 70.0)
+        assert result == pytest.approx(20.0, abs=1e-9)
+
+
+class TestCrpsSingleNaNHandling:
+    def test_nan_observed_returns_nan(self):
+        assert math.isnan(crps_single(QUANTILE_LEVELS, [100.0] * 7, float("nan")))
+
+    def test_fewer_than_two_finite_nodes_returns_nan(self):
+        # Only one finite quantile node (q50) survives isotonic repair.
+        levels = [0.05, 0.10, 0.25, 0.50, 0.75, 0.90, 0.95]
+        quantiles = [np.nan, np.nan, np.nan, 100.0, np.nan, np.nan, np.nan]
+        assert math.isnan(crps_single(levels, quantiles, 100.0))
+
+    def test_single_nan_node_among_many_is_dropped_not_poisoning(self):
+        """A partially-NaN quantile row still scores using its remaining
+        finite nodes (isotonic repair), rather than propagating NaN."""
+        levels = [0.05, 0.10, 0.25, 0.50, 0.75, 0.90, 0.95]
+        quantiles = [80.0, 85.0, 92.0, 100.0, np.nan, 115.0, 120.0]
+        result = crps_single(levels, quantiles, 100.0)
+        assert math.isfinite(result)
+        assert result >= 0.0
+
+
+class TestCrpsFromQuantilesBatchedMatchesSingle:
+    """The (N,K) aggregator must reduce to crps_single for N=1, and to a
+    plain mean of per-row crps_single scores for N>1 with no invalid rows —
+    this is the "identical value at both call sites" contract (M4 test a)."""
+
+    def test_single_row_matches_crps_single(self):
+        observed = np.array([130.0])
+        quantile_forecasts = np.array([[100.0] * 7])
+        batched = crps_from_quantiles(observed, quantile_forecasts, QUANTILE_LEVELS)
+        single = crps_single(QUANTILE_LEVELS, quantile_forecasts[0], observed[0])
+        assert batched == pytest.approx(single, rel=1e-12)
+
+    def test_deterministic_band_batched_equals_abs_diff(self):
+        """Same textbook-expectation case as the single-pair test, but via
+        the vectorised entry point used by postprocessing_forecasts."""
+        observed = np.array([130.0])
+        quantile_forecasts = np.array([[100.0] * 7])
+        result = crps_from_quantiles(observed, quantile_forecasts, QUANTILE_LEVELS)
+        assert result == pytest.approx(30.0, abs=1e-9)
+
+    def test_multi_row_mean_of_identical_rows_equals_single_row(self):
+        observed = np.array([130.0, 130.0, 130.0])
+        quantile_forecasts = np.array([[100.0] * 7] * 3)
+        result = crps_from_quantiles(observed, quantile_forecasts, QUANTILE_LEVELS)
+        assert result == pytest.approx(30.0, abs=1e-9)
+
+
+class TestCrpsFromQuantilesNaNQuantilePoisoning:
+    """Regression tests for #6: a single bad row must not null the whole
+    group's mean CRPS."""
+
+    def test_one_all_nan_quantile_row_does_not_poison_group_mean(self):
+        # Row 0: perfectly valid (score = 0.0, obs matches all quantiles).
+        # Row 1: every quantile is NaN -> that row alone is unscoreable.
+        observed = np.array([100.0, 100.0])
+        quantile_forecasts = np.array(
+            [
+                [100.0] * 7,
+                [np.nan] * 7,
+            ]
+        )
+        result = crps_from_quantiles(observed, quantile_forecasts, QUANTILE_LEVELS)
+        assert math.isfinite(result), (
+            "A single fully-NaN quantile row must not null the whole group's CRPS"
+        )
+        assert result == pytest.approx(0.0, abs=1e-9)
+
+    def test_valid_rows_score_correctly_alongside_a_bad_row(self):
+        observed = np.array([130.0, 100.0])
+        quantile_forecasts = np.array(
+            [
+                [100.0] * 7,  # deterministic band, |130-100| = 30.0
+                [np.nan] * 7,  # unscoreable row
+            ]
+        )
+        result = crps_from_quantiles(observed, quantile_forecasts, QUANTILE_LEVELS)
+        assert result == pytest.approx(30.0, abs=1e-9)
+
+    def test_nan_observation_still_excluded(self):
+        observed = np.array([100.0, np.nan])
+        quantile_forecasts = np.array(
+            [
+                [80, 85, 92, 100, 108, 115, 120],
+                [80, 85, 92, 100, 108, 115, 120],
+            ],
+            dtype=float,
+        )
+        valid_only = crps_from_quantiles(np.array([100.0]), quantile_forecasts[:1], QUANTILE_LEVELS)
+        with_nan_obs = crps_from_quantiles(observed, quantile_forecasts, QUANTILE_LEVELS)
+        assert with_nan_obs == pytest.approx(valid_only, rel=1e-10)
+
+    def test_all_rows_invalid_returns_nan(self):
+        observed = np.array([np.nan, np.nan])
+        quantile_forecasts = np.array(
+            [
+                [np.nan] * 7,
+                [np.nan] * 7,
+            ]
+        )
+        result = crps_from_quantiles(observed, quantile_forecasts, QUANTILE_LEVELS)
+        assert math.isnan(result)

--- a/apps/postprocessing_forecasts/src/skill_metrics.py
+++ b/apps/postprocessing_forecasts/src/skill_metrics.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 
 import numpy as np
 import pandas as pd
+import probabilistic_metrics as pm
 from src.model_names import (
     AGGREGATED_EM_RAW_MODELS,
     AGGREGATED_ENSEMBLE_MODELS,
@@ -1124,9 +1125,20 @@ def calculate_crps(
 ) -> float:
     """Continuous Ranked Probability Score from quantile forecasts.
 
-    Uses trapezoidal integration of quantile (pinball) losses:
-        CRPS = (1/N) * sum_i trapz(rho_tau(y_i - q_ij), tau_j)
-    where rho_tau(u) = u * (tau - 1{u<0}) is the pinball loss.
+    Delegates to the canonical textbook estimator shared with
+    forecast_skill_eval (iEasyHydroForecast.probabilistic_metrics), so both
+    apps compute IDENTICAL CRPS values (design decision D3, milestone M4):
+        CRPS = 2 * integral_0^1 pinball_loss(tau, y_i) dtau
+    approximated via trapezoidal integration of the pinball loss between
+    quantile grid nodes PLUS explicit flat-tail terms for [0, tau_min] and
+    [tau_max, 1] (an observation outside the forecast band is still
+    penalised — narrow, overconfident bands are not rewarded).
+
+    NOTE (M4/#5): prior to this change, this function omitted the factor-2
+    term and the tail terms, so it returned roughly HALF the correct CRPS.
+    Stored postprocessing crps values will shift by ~2x on next recalc; this
+    is accepted (CRPS is informational, no gate depends on it — see the
+    postprocessing skill-correctness campaign design doc, D3).
 
     Args:
         observed: shape (N,) — observed values.
@@ -1134,38 +1146,14 @@ def calculate_crps(
         quantile_levels: shape (K,) — e.g. [0.05, 0.10, ..., 0.95].
 
     Returns:
-        Mean CRPS across valid observations (lower is better).
-        Returns NaN if no valid observations.
+        NaN-aware mean CRPS across valid observation rows (lower is better).
+        A row is excluded from the mean when its observation is NaN, or
+        when fewer than 2 finite quantile nodes remain after isotonic
+        repair (M4/#6 — a single bad row no longer poisons the whole
+        group's mean, unlike the previous plain np.mean over rows).
+        Returns NaN only when every row is invalid.
     """
-    observed = np.asarray(observed, dtype=np.float64)
-    quantile_forecasts = np.asarray(quantile_forecasts, dtype=np.float64)
-    quantile_levels = np.asarray(quantile_levels, dtype=np.float64)
-
-    # Mask out NaN observations
-    valid = ~np.isnan(observed)
-    if not np.any(valid):
-        return np.nan
-
-    obs = observed[valid]
-    qf = quantile_forecasts[valid]
-
-    # Compute pinball loss for each (observation, quantile_level) pair
-    # errors shape: (N, K)
-    errors = obs[:, np.newaxis] - qf
-
-    # rho_tau(u) = u * tau  if u >= 0
-    #            = u * (tau - 1)  if u < 0
-    pinball = np.where(
-        errors >= 0,
-        errors * quantile_levels[np.newaxis, :],
-        errors * (quantile_levels[np.newaxis, :] - 1.0),
-    )
-
-    # Integrate pinball loss over quantile levels for each observation
-    # using trapezoidal rule
-    crps_per_obs = np.trapezoid(pinball, quantile_levels, axis=1)
-
-    return float(np.mean(crps_per_obs))
+    return pm.crps_from_quantiles(observed, quantile_forecasts, quantile_levels)
 
 
 def calculate_pit_reliability(

--- a/apps/postprocessing_forecasts/src/skill_metrics.py
+++ b/apps/postprocessing_forecasts/src/skill_metrics.py
@@ -966,6 +966,15 @@ def calculate_all_skill_metrics(
         pd.Series with keys:
             sdivsigma, nse, mae, n_pairs, delta, accuracy,
             pbias, kgelf, nse_log
+
+        sdivsigma/nse/mae/pbias/kgelf/nse_log are point metrics computed
+        over rows where obs+sim are both finite (they do not use delta
+        at all, matching sdivsigma_nse()/mae()). n_pairs is the count of
+        those obs/sim-valid rows. accuracy/delta are computed over the
+        independently-filtered subset where obs, sim, AND delta are all
+        finite (matching forecast_accuracy_hydromet()) — that subset can
+        be smaller than n_pairs when delta is NaN/inf for some otherwise
+        obs/sim-valid rows.
     """
     nan_result = pd.Series(
         [0 if name == "n_pairs" else np.nan for name in METRIC_ORDER],
@@ -982,27 +991,21 @@ def calculate_all_skill_metrics(
     simulated = data[simulated_col].to_numpy(dtype=np.float64)
     delta_values = data[delta_col].to_numpy(dtype=np.float64)
 
-    # Common NaN/inf mask for all metrics
-    mask = (
-        ~np.isnan(observed)
-        & ~np.isnan(simulated)
-        & ~np.isnan(delta_values)
-        & ~np.isinf(observed)
-        & ~np.isinf(simulated)
-        & ~np.isinf(delta_values)
+    # Point-metric mask: obs/sim only. mae/sdivsigma/nse/pbias/kgelf/
+    # nse_log don't use delta at all, so they must not be starved by a
+    # NaN delta on an otherwise-valid obs/sim row (matches
+    # sdivsigma_nse()/mae(), which never look at delta).
+    obs_sim_mask = (
+        ~np.isnan(observed) & ~np.isnan(simulated) & ~np.isinf(observed) & ~np.isinf(simulated)
     )
-    if not np.any(mask):
-        return nan_result
-
-    obs = observed[mask]
-    sim = simulated[mask]
-    deltas = delta_values[mask]
-    n = len(obs)
-
-    # --- MAE + n_pairs (need >= 1 point) ---
+    n = int(obs_sim_mask.sum())
     if n < 1:
         return nan_result
 
+    obs = observed[obs_sim_mask]
+    sim = simulated[obs_sim_mask]
+
+    # --- MAE (need >= 1 obs/sim-valid point) ---
     differences = obs - sim
     abs_diff = np.abs(differences)
 
@@ -1013,30 +1016,43 @@ def calculate_all_skill_metrics(
     except (RuntimeWarning, FloatingPointError):
         mae_value = np.nan
 
-    # --- Accuracy + delta (need >= 1 point) ---
-    try:
-        accuracy = float(np.mean(abs_diff <= deltas))
-        # Delta is constant per (code, period_in_year) by design.
-        # Use first value; warn if they vary unexpectedly.
-        delta = float(deltas[0])
-        delta_range = float(np.ptp(deltas))
-        if delta_range > 1e-6:
-            logger.warning(
-                "Delta values vary within group: range=%.6f, "
-                "min=%.6f, max=%.6f (using first value %.6f)",
-                delta_range,
-                float(np.min(deltas)),
-                float(np.max(deltas)),
-                delta,
-            )
-        if not (0 <= accuracy <= 1) or not (0 <= delta < np.inf):
+    # --- Accuracy + delta: independent obs/sim/delta mask (need >= 1
+    # delta-valid point). This subset can be strictly smaller than
+    # obs_sim_mask when delta is NaN/inf for some obs/sim-valid rows —
+    # accuracy/delta must reflect only the delta-valid rows, exactly as
+    # forecast_accuracy_hydromet() does.
+    delta_mask = obs_sim_mask & ~np.isnan(delta_values) & ~np.isinf(delta_values)
+    if np.any(delta_mask):
+        try:
+            obs_d = observed[delta_mask]
+            sim_d = simulated[delta_mask]
+            deltas = delta_values[delta_mask]
+            abs_diff_d = np.abs(obs_d - sim_d)
+            accuracy = float(np.mean(abs_diff_d <= deltas))
+            # Delta is constant per (code, period_in_year) by design.
+            # Use first value; warn if they vary unexpectedly.
+            delta = float(deltas[0])
+            delta_range = float(np.ptp(deltas))
+            if delta_range > 1e-6:
+                logger.warning(
+                    "Delta values vary within group: range=%.6f, "
+                    "min=%.6f, max=%.6f (using first value %.6f)",
+                    delta_range,
+                    float(np.min(deltas)),
+                    float(np.max(deltas)),
+                    delta,
+                )
+            if not (0 <= accuracy <= 1) or not (0 <= delta < np.inf):
+                accuracy = np.nan
+                delta = np.nan
+        except (RuntimeWarning, FloatingPointError):
             accuracy = np.nan
             delta = np.nan
-    except (RuntimeWarning, FloatingPointError):
+    else:
         accuracy = np.nan
         delta = np.nan
 
-    # --- sdivsigma + NSE (need >= 2 points for std) ---
+    # --- sdivsigma + NSE (need >= 2 obs/sim-valid points for std) ---
     if n < 2:
         return pd.Series(
             [np.nan, np.nan, mae_value, n, delta, accuracy, np.nan, np.nan, np.nan],

--- a/apps/postprocessing_forecasts/src/skill_metrics.py
+++ b/apps/postprocessing_forecasts/src/skill_metrics.py
@@ -110,8 +110,13 @@ THRESHOLD_METRICS = {
 # keep nse > 0.0 and disable both the sdivsigma and accuracy gates.  The canonical
 # filter treats the exact string "False" as "gate disabled".  These vars are
 # LONG-TERM ONLY — the short-term env vars/defaults are untouched.
+#
+# The canonical filter's boundary is INCLUSIVE (>=), so the NSE default is a
+# small positive epsilon rather than exactly 0.0 — otherwise nse == 0.0 would
+# incorrectly pass the "NSE > 0" gate.
+_LONG_TERM_NSE_EPSILON = 1e-9
 _LONG_TERM_THRESHOLD_ENV = {
-    "nse": ("ieasyhydroforecast_nse_threshold_long_term", "0.0"),
+    "nse": ("ieasyhydroforecast_nse_threshold_long_term", str(_LONG_TERM_NSE_EPSILON)),
     "sdivsigma": ("ieasyhydroforecast_efficiency_threshold_long_term", "False"),
     "accuracy": ("ieasyhydroforecast_accuracy_threshold_long_term", "False"),
 }
@@ -127,7 +132,9 @@ def _parse_threshold_env(raw: str) -> "float | bool":
     map to the boolean ``False`` whose ``str()`` is ``"False"`` — the sentinel
     the canonical filter recognizes as "gate disabled".  Otherwise the value is
     parsed as a float.  An invalid value raises a clear ``ValueError`` naming the
-    offending value, never a bare ``float("banana")`` error.
+    offending value, never a bare ``float("banana")`` error.  Non-finite floats
+    (``nan``/``inf``/``-inf``) are also rejected — they would otherwise silently
+    pass through as a "threshold" that can never gate anything meaningfully.
 
     Args:
         raw: The raw env-var string.
@@ -136,18 +143,24 @@ def _parse_threshold_env(raw: str) -> "float | bool":
         ``False`` for a disable token, otherwise the parsed float.
 
     Raises:
-        ValueError: If *raw* is neither a disable token nor a valid number.
+        ValueError: If *raw* is neither a disable token nor a finite number.
     """
     token = str(raw).strip().lower()
     if token in _THRESHOLD_DISABLE_TOKENS:
         return False
     try:
-        return float(raw)
+        value = float(raw)
     except (TypeError, ValueError) as exc:
         raise ValueError(
             f"Invalid long-term skill threshold: {raw!r} (expected a number or a "
             f"disable token like 'false'/'off'/'none')"
         ) from exc
+    if not np.isfinite(value):
+        raise ValueError(
+            f"Invalid long-term skill threshold: {raw!r} (must be a finite number, "
+            f"got non-finite value {value})"
+        )
+    return value
 
 
 def _long_term_threshold_overrides() -> dict:
@@ -155,14 +168,29 @@ def _long_term_threshold_overrides() -> dict:
 
     Reads the long-term-only env vars (defaulting to the NSE>0-only behavior)
     and parses each through :func:`_parse_threshold_env`.  Returns e.g.
-    ``{"nse": 0.0, "sdivsigma": False, "accuracy": False}`` under defaults.
+    ``{"nse": 1e-9, "sdivsigma": False, "accuracy": False}`` under defaults.
     This dict is splatted as ``**overrides`` into
     :func:`filter_for_highly_skilled_forecasts`, which treats a ``False`` value
     (``str(threshold) == "False"``) as a disabled gate.
+
+    The long-term NSE gate may never be disabled — unlike sdivsigma/accuracy,
+    attempting to disable it (e.g. setting its env var to ``"false"``) raises
+    ``ValueError``.
+
+    Raises:
+        ValueError: If the long-term NSE env var resolves to a disable token.
     """
     overrides: dict = {}
     for metric_key, (env_var, default) in _LONG_TERM_THRESHOLD_ENV.items():
-        overrides[metric_key] = _parse_threshold_env(os.getenv(env_var, default))
+        raw_value = os.getenv(env_var, default)
+        parsed = _parse_threshold_env(raw_value)
+        if metric_key == "nse" and parsed is False:
+            raise ValueError(
+                f"The long-term NSE skill gate cannot be disabled (env var "
+                f"{env_var!r} resolved to disable token {raw_value!r}); sdivsigma "
+                f"and accuracy may be disabled long-term, NSE may not."
+            )
+        overrides[metric_key] = parsed
     return overrides
 
 
@@ -1873,16 +1901,20 @@ def filter_for_highly_skilled_forecasts(
     """
     result = skill_stats.copy()
     for name, entry in THRESHOLD_METRICS.items():
-        threshold = overrides.get(name)
-        if threshold is None:
-            threshold = os.getenv(entry["env_var"], entry["default_threshold"])
-        if str(threshold) == "False":
+        raw_threshold = overrides.get(name)
+        if raw_threshold is None:
+            raw_threshold = os.getenv(entry["env_var"], entry["default_threshold"])
+        # Route BOTH the override and env sources through the same lenient parser
+        # so disable-token handling and the isfinite guard apply identically
+        # regardless of where the threshold came from.
+        threshold = _parse_threshold_env(raw_threshold)
+        if threshold is False:
             continue
         threshold = float(threshold)
         if entry["higher_is_better"]:
-            result = result[result[name] > threshold].copy()
+            result = result[result[name] >= threshold].copy()
         else:
-            result = result[result[name] < threshold].copy()
+            result = result[result[name] <= threshold].copy()
     if min_pairs is not None:
         result = result[result["n_pairs"].fillna(0) >= min_pairs].copy()
     return result

--- a/apps/postprocessing_forecasts/tests/test_all_skill_metrics_masks.py
+++ b/apps/postprocessing_forecasts/tests/test_all_skill_metrics_masks.py
@@ -1,0 +1,146 @@
+"""Regression/contract tests for calculate_all_skill_metrics()'s per-metric
+NaN masking (M3, finding #2 in doc/plans/postprocessing_skill_correctness_design.md).
+
+Locks the fix that splits the single combined obs/sim/delta mask into:
+  - an obs/sim-only mask used for point metrics (mae, sdivsigma, nse,
+    pbias, kgelf, nse_log) and the stored n_pairs count
+  - an independent obs/sim/delta mask used only for accuracy/delta
+
+Before the fix, a single NaN in the delta column dropped an otherwise
+valid obs/sim row from EVERY metric (including nse/mae/n_pairs), which
+disagreed with the standalone sdivsigma_nse()/mae() helpers in the same
+module and silently starved NSE/MAE of valid obs/sim pairs whenever
+delta happened to be NaN for that row.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "iEasyHydroForecast"))
+
+from src.skill_metrics import (
+    calculate_all_skill_metrics,
+    forecast_accuracy_hydromet,
+    mae,
+    sdivsigma_nse,
+)
+
+
+def _base_df(nan_delta_at: int | None = 2) -> pd.DataFrame:
+    """10-row synthetic obs/sim/delta DataFrame.
+
+    obs/sim are fully finite and varied across all 10 rows so that
+    min-points-gated metrics (kgelf needs >= 10, sdivsigma/nse/nse_log
+    need >= 2) are actually computed rather than short-circuited by a
+    min-points guard.
+
+    If `nan_delta_at` is given, that row's delta is set to NaN (the
+    rest of delta stays finite and non-trivial/varied — not all equal
+    to a single value). Pass None for an all-finite-delta DataFrame
+    (used by the regression test, Test C).
+    """
+    df = pd.DataFrame(
+        {
+            "observed": [100.0, 110.0, 105.0, 115.0, 108.0, 120.0, 95.0, 130.0, 102.0, 111.0],
+            "simulated": [102.0, 108.0, 106.0, 112.0, 110.0, 118.0, 97.0, 125.0, 101.0, 113.0],
+            "delta": [5.0, 5.0, 3.0, 6.0, 4.0, 7.0, 5.0, 8.0, 5.0, 6.0],
+        }
+    )
+    if nan_delta_at is not None:
+        df.loc[nan_delta_at, "delta"] = np.nan
+    return df
+
+
+class TestObsSimOnlyMaskForPointMetrics:
+    """Test A (finding #2 / M3).
+
+    A NaN delta value must NOT drop an otherwise-valid obs/sim row from
+    the point metrics (nse, sdivsigma, mae), and the stored n_pairs must
+    reflect the obs/sim-only valid count, not the obs/sim/delta count.
+    """
+
+    def test_nan_delta_row_still_counts_for_nse_sdivsigma_mae(self):
+        df = _base_df(nan_delta_at=2)
+
+        result = calculate_all_skill_metrics(df, "observed", "simulated", "delta")
+
+        # The standalone helpers only ever mask on obs/sim finiteness
+        # (they don't even take a delta_col argument), so they
+        # naturally include all 10 rows, including the NaN-delta row.
+        standalone = sdivsigma_nse(df, "observed", "simulated")
+        standalone_mae = mae(df, "observed", "simulated")
+
+        assert result["nse"] == pytest.approx(standalone["nse"])
+        assert result["sdivsigma"] == pytest.approx(standalone["sdivsigma"])
+        assert result["mae"] == pytest.approx(standalone_mae["mae"])
+
+        # n_pairs = obs/sim-valid count (all 10 rows), NOT the
+        # obs/sim/delta-valid count (9 rows) that pre-fix code used.
+        assert result["n_pairs"] == len(df)
+
+
+class TestDeltaMaskStillExcludesNanDeltaRow:
+    """Test B (finding #2 / M3).
+
+    accuracy/delta must still be computed from the delta-valid subset
+    only — splitting the masks must not leak the NaN-delta row into
+    accuracy's denominator.
+    """
+
+    def test_accuracy_and_delta_match_delta_valid_subset(self):
+        df = _base_df(nan_delta_at=2)
+
+        result = calculate_all_skill_metrics(df, "observed", "simulated", "delta")
+
+        # forecast_accuracy_hydromet() already does its own correct
+        # obs/sim/delta masking over the full df, so comparing against
+        # it directly proves accuracy/delta come from the delta-valid
+        # subset (9 rows) only, not from all 10 obs/sim-valid rows.
+        expected = forecast_accuracy_hydromet(df, "observed", "simulated", "delta")
+
+        assert result["accuracy"] == pytest.approx(expected["accuracy"])
+        assert result["delta"] == pytest.approx(expected["delta"])
+
+
+class TestAllDeltaFiniteRegression:
+    """Test C (finding #2 / M3) — numerical-equivalence regression guard.
+
+    When delta is finite everywhere (the common real-world case — the
+    monthly reader fills delta with 0.0, never NaN), the split-mask fix
+    must be numerically UNCHANGED from today's single-combined-mask
+    behavior. Rather than hardcoding today's output values (brittle to
+    legitimate future changes elsewhere in the function), this asserts
+    equality against the standalone helpers directly: with no NaN
+    delta, the obs/sim-only mask and the obs/sim/delta mask select the
+    exact same rows, so old and new code necessarily agree here. This
+    doubles as both a correctness check and the "unchanged in the
+    common case" regression guard required by M3.
+    """
+
+    def test_all_finite_delta_matches_standalone_helpers(self):
+        df = _base_df(nan_delta_at=None)
+
+        result = calculate_all_skill_metrics(df, "observed", "simulated", "delta")
+
+        standalone = sdivsigma_nse(df, "observed", "simulated")
+        standalone_mae = mae(df, "observed", "simulated")
+        standalone_accuracy = forecast_accuracy_hydromet(df, "observed", "simulated", "delta")
+
+        assert result["nse"] == pytest.approx(standalone["nse"])
+        assert result["sdivsigma"] == pytest.approx(standalone["sdivsigma"])
+        assert result["mae"] == pytest.approx(standalone_mae["mae"])
+        assert result["accuracy"] == pytest.approx(standalone_accuracy["accuracy"])
+        assert result["delta"] == pytest.approx(standalone_accuracy["delta"])
+        assert result["n_pairs"] == len(df)
+
+        # Sanity: with >= 10 varied points and no NaNs, kgelf/nse_log/
+        # pbias should actually be computed, not NaN'd out by a
+        # min-points guard — otherwise this test wouldn't exercise the
+        # metrics it's meant to lock down.
+        assert np.isfinite(result["kgelf"])
+        assert np.isfinite(result["nse_log"])
+        assert np.isfinite(result["pbias"])

--- a/apps/postprocessing_forecasts/tests/test_calculate_all_skill_metrics.py
+++ b/apps/postprocessing_forecasts/tests/test_calculate_all_skill_metrics.py
@@ -170,7 +170,14 @@ class TestCalculateAllSkillMetricsAllNaN:
         assert np.isnan(result["mae"])
 
     def test_all_nan_delta(self):
-        """All NaN in delta -> nan_result."""
+        """All NaN in delta, but obs/sim both valid.
+
+        Re-baselined for M3 (finding #2, doc/plans/postprocessing_skill_correctness_design.md):
+        point metrics (mae, sdivsigma, nse) only need obs+sim to be
+        finite and must NOT be starved just because delta is entirely
+        NaN — n_pairs reflects the obs/sim-valid count. accuracy/delta
+        legitimately stay NaN since no row has a valid delta.
+        """
         data = pd.DataFrame(
             {
                 "obs": [100.0, 110.0],
@@ -179,8 +186,12 @@ class TestCalculateAllSkillMetricsAllNaN:
             }
         )
         result = skill_metrics.calculate_all_skill_metrics(data, "obs", "sim", "delta")
-        assert result["n_pairs"] == 0
-        assert np.isnan(result["mae"])
+        assert result["n_pairs"] == 2
+        assert result["mae"] == pytest.approx(2.0)
+        assert result["nse"] == pytest.approx(0.84)
+        assert result["sdivsigma"] == pytest.approx(0.4)
+        assert np.isnan(result["accuracy"])
+        assert np.isnan(result["delta"])
 
     def test_mixed_nan_filters_correctly(self):
         """Some NaN rows filtered, valid rows produce correct metrics.

--- a/apps/postprocessing_forecasts/tests/test_crps.py
+++ b/apps/postprocessing_forecasts/tests/test_crps.py
@@ -2,6 +2,18 @@
 
 Step 4 of Phase 4a: Monthly skill metrics.
 TDD — tests written before implementation.
+
+M4 (design decision D3, findings #5 + #6, postprocessing skill-correctness
+campaign): calculate_crps now delegates to the canonical, textbook
+crps_from_quantiles in iEasyHydroForecast.probabilistic_metrics (factor-2
+trapezoidal integration + explicit flat-tail terms). The previous estimator
+omitted the factor-2 term and the tail terms, so it returned roughly HALF
+the correct CRPS — the hand-calculated expectations in
+TestCrpsHandCalculated below are re-baselined accordingly (see each test's
+docstring for the old vs. new value). It also only masked NaN
+*observations*, not rows with NaN *quantiles*, so a single incomplete
+quantile row poisoned the whole group's mean via plain np.mean — see
+TestCrpsNaNQuantilePoisoning for the regression coverage of that fix (#6).
 """
 
 import os
@@ -11,7 +23,9 @@ import numpy as np
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "iEasyHydroForecast"))
 
+from probabilistic_metrics import crps_from_quantiles as shared_crps_from_quantiles
 from src.skill_metrics import calculate_crps
 
 # Standard quantile levels used in SAPPHIRE long-term forecasts
@@ -121,62 +135,41 @@ class TestCrpsHandCalculated:
     """
 
     def test_single_observation_above_all_quantiles(self):
-        """Observation above all quantile forecasts.
+        """Observation above a DETERMINISTIC (point) quantile band.
 
-        observed = 200, all quantiles = 100
-        For each level tau: u = 200 - 100 = 100 > 0
-            rho_tau(100) = 100 * tau
+        observed = 200, all quantiles = 100.
 
-        Pinball losses at each tau:
-            tau=0.05: 100*0.05 = 5.0
-            tau=0.10: 100*0.10 = 10.0
-            tau=0.25: 100*0.25 = 25.0
-            tau=0.50: 100*0.50 = 50.0
-            tau=0.75: 100*0.75 = 75.0
-            tau=0.90: 100*0.90 = 90.0
-            tau=0.95: 100*0.95 = 95.0
+        Textbook property: for a point band, CRPS = |obs - q| exactly,
+        independent of the specific quantile grid — because the flat-tail
+        terms and the factor-2 middle term combine algebraically to cancel
+        every level-dependent term. So expected = |200 - 100| = 100.0.
 
-        Trapezoidal integration over [0.05, 0.95]:
-            = sum of trapezoids between consecutive tau levels
+        RE-BASELINED (M4/D3/#5): the OLD estimator omitted the factor-2 term
+        and the flat-tail terms and only integrated the middle trapezoid,
+        giving trapz(100*tau, tau) = 45.0 — roughly HALF the correct value.
         """
         observed = np.array([200.0])
         quantile_forecasts = np.array([[100.0] * 7])
 
         result = calculate_crps(observed, quantile_forecasts, QUANTILE_LEVELS)
 
-        # Calculate expected via trapezoidal integration
-        taus = QUANTILE_LEVELS
-        losses = 100.0 * taus  # all u > 0 so rho = u * tau
-        expected = np.trapezoid(losses, taus)
-
-        assert result == pytest.approx(expected, rel=1e-6)
+        assert result == pytest.approx(100.0, rel=1e-9)
 
     def test_single_observation_below_all_quantiles(self):
-        """Observation below all quantile forecasts.
+        """Observation below a DETERMINISTIC (point) quantile band.
 
-        observed = 0, all quantiles = 100
-        For each level tau: u = 0 - 100 = -100 < 0
-            rho_tau(-100) = -100 * (tau - 1) = 100 * (1 - tau)
+        observed = 0, all quantiles = 100 -> expected = |0 - 100| = 100.0
+        (same textbook point-band property as the test above).
 
-        Pinball losses:
-            tau=0.05: 100*0.95 = 95.0
-            tau=0.10: 100*0.90 = 90.0
-            tau=0.25: 100*0.75 = 75.0
-            tau=0.50: 100*0.50 = 50.0
-            tau=0.75: 100*0.25 = 25.0
-            tau=0.90: 100*0.10 = 10.0
-            tau=0.95: 100*0.05 = 5.0
+        RE-BASELINED (M4/D3/#5): the OLD estimator gave
+        trapz(100*(1-tau), tau) = 45.0 — roughly HALF the correct value.
         """
         observed = np.array([0.0])
         quantile_forecasts = np.array([[100.0] * 7])
 
         result = calculate_crps(observed, quantile_forecasts, QUANTILE_LEVELS)
 
-        taus = QUANTILE_LEVELS
-        losses = 100.0 * (1.0 - taus)  # all u < 0 so rho = |u| * (1 - tau)
-        expected = np.trapezoid(losses, taus)
-
-        assert result == pytest.approx(expected, rel=1e-6)
+        assert result == pytest.approx(100.0, rel=1e-9)
 
     def test_symmetric_quantiles_observation_at_median(self):
         """Symmetric quantile distribution with observation at median.
@@ -184,7 +177,8 @@ class TestCrpsHandCalculated:
         observed = 100
         quantiles = [60, 70, 85, 100, 115, 130, 140]
 
-        For each (tau, q):
+        Per-node pinball losses (unchanged by the estimator fix — only the
+        AGGREGATION changed):
             tau=0.05, q=60:  u=40, rho = 40*0.05 = 2.0
             tau=0.10, q=70:  u=30, rho = 30*0.10 = 3.0
             tau=0.25, q=85:  u=15, rho = 15*0.25 = 3.75
@@ -192,15 +186,97 @@ class TestCrpsHandCalculated:
             tau=0.75, q=115: u=-15, rho = -15*(0.75-1) = 15*0.25 = 3.75
             tau=0.90, q=130: u=-30, rho = -30*(0.90-1) = 30*0.10 = 3.0
             tau=0.95, q=140: u=-40, rho = -40*(0.95-1) = 40*0.05 = 2.0
+
+        middle = trapz(losses, taus) = 2.2 (this is the OLD estimator's
+        entire result — RE-BASELINED below, M4/D3/#5).
+
+        Textbook estimator adds the flat tails and the factor 2:
+            left_tail  = (obs - q_min) * tau_min^2 / 2
+                       = (100-60) * 0.05^2 / 2 = 0.05
+            right_tail = (q_max - obs) * (1-tau_max)^2 / 2
+                       = (140-100) * 0.05^2 / 2 = 0.05
+            CRPS = 2 * (0.05 + 2.2 + 0.05) = 2 * 2.3 = 4.6
         """
         observed = np.array([100.0])
         quantile_forecasts = np.array([[60.0, 70.0, 85.0, 100.0, 115.0, 130.0, 140.0]])
         result = calculate_crps(observed, quantile_forecasts, QUANTILE_LEVELS)
 
-        losses = np.array([2.0, 3.0, 3.75, 0.0, 3.75, 3.0, 2.0])
-        expected = np.trapezoid(losses, QUANTILE_LEVELS)
+        assert result == pytest.approx(4.6, rel=1e-6)
 
-        assert result == pytest.approx(expected, rel=1e-6)
+    def test_deterministic_band_matches_textbook_abs_diff(self):
+        """Locked M4 regression test (task spec 'the deterministic band'
+        case): all quantiles == 100.0, observed == 130.0 -> CRPS == 30.0.
+
+        The OLD (WRONG) postprocessing estimator returned ~13.5 for this
+        input (trapz(30*tau, tau) over the 7-level SAPPHIRE grid, no
+        factor-2, no tails) — exactly half the correct answer plus the
+        missing tail contribution. This is the textbook sanity check that
+        motivated milestone M4 (D3/#5).
+        """
+        observed = np.array([130.0])
+        quantile_forecasts = np.array([[100.0] * 7])
+
+        result = calculate_crps(observed, quantile_forecasts, QUANTILE_LEVELS)
+
+        assert result == pytest.approx(30.0, abs=1e-9)
+
+    def test_matches_shared_canonical_estimator(self):
+        """calculate_crps must delegate to (produce identical values to) the
+        canonical iEasyHydroForecast.probabilistic_metrics.crps_from_quantiles
+        — the M4 'same value at both call sites' contract. forecast_skill_eval
+        delegates to the same shared primitive (see
+        forecast_skill_eval/tests/test_prob_metrics.py), so this indirectly
+        proves both apps agree.
+        """
+        observed = np.array([100.0, 130.0, 80.0])
+        quantile_forecasts = np.array(
+            [
+                [80, 85, 92, 100, 108, 115, 120],
+                [100.0] * 7,
+                [60, 65, 72, 80, 88, 95, 100],
+            ],
+            dtype=float,
+        )
+
+        result = calculate_crps(observed, quantile_forecasts, QUANTILE_LEVELS)
+        expected = shared_crps_from_quantiles(observed, quantile_forecasts, QUANTILE_LEVELS)
+
+        assert result == pytest.approx(expected, rel=1e-12)
+
+
+class TestCrpsNaNQuantilePoisoning:
+    """Regression tests for #6: a single row with NaN quantiles must not
+    null the whole group's mean CRPS (the OLD estimator masked NaN
+    *observations* but not NaN *quantile rows*, so np.mean(crps_per_obs)
+    propagated a single bad row's NaN to the entire group)."""
+
+    def test_one_all_nan_quantile_row_does_not_poison_group(self):
+        # Row 0: perfectly valid, observed matches every quantile -> CRPS 0.
+        # Row 1: every quantile is NaN -> unscoreable on its own, but must
+        # not null row 0's contribution to the group mean.
+        observed = np.array([100.0, 100.0])
+        quantile_forecasts = np.array(
+            [
+                [100.0] * 7,
+                [np.nan] * 7,
+            ]
+        )
+        result = calculate_crps(observed, quantile_forecasts, QUANTILE_LEVELS)
+        assert np.isfinite(result), (
+            "A single fully-NaN quantile row must not poison the group's CRPS mean"
+        )
+        assert result == pytest.approx(0.0, abs=1e-9)
+
+    def test_valid_row_scores_correctly_alongside_a_nan_quantile_row(self):
+        observed = np.array([130.0, 100.0])
+        quantile_forecasts = np.array(
+            [
+                [100.0] * 7,  # deterministic band, |130-100| = 30.0
+                [np.nan] * 7,  # unscoreable
+            ]
+        )
+        result = calculate_crps(observed, quantile_forecasts, QUANTILE_LEVELS)
+        assert result == pytest.approx(30.0, abs=1e-9)
 
 
 class TestCrpsEdgeCases:

--- a/apps/postprocessing_forecasts/tests/test_edge_cases.py
+++ b/apps/postprocessing_forecasts/tests/test_edge_cases.py
@@ -826,21 +826,24 @@ class TestThresholdBehavior:
         )
         assert len(result) == 3, "All should pass when filter disabled"
 
-    def test_threshold_case_sensitive(self, _three_model_skill):
-        """threshold_sdivsigma='false' (lowercase) raises ValueError.
-        Only 'False' (capital F) disables the filter. This documents
-        the case-sensitivity behavior: str('false') != 'False' so it
-        tries float('false') which is invalid."""
-        with pytest.raises(ValueError, match="could not convert"):
-            filter_for_highly_skilled_forecasts(
-                _three_model_skill,
-                threshold_sdivsigma="false",
-                threshold_accuracy=0.0,
-                threshold_nse=0.0,
-            )
+    def test_threshold_case_insensitive_disable(self, _three_model_skill):
+        """threshold_sdivsigma='false' (lowercase) disables the gate.
 
-    def test_exact_boundary_excluded(self):
-        """sdivsigma exactly at threshold (0.6) is excluded (< not <=)."""
+        M2: overrides and env vars are routed through the same lenient
+        parser (_parse_threshold_env), so any case-insensitive disable
+        token ('false', 'False', 'off', ...) disables that gate. With
+        sdivsigma disabled and accuracy/nse gates at 0.0 (inclusive),
+        all three models pass."""
+        result = filter_for_highly_skilled_forecasts(
+            _three_model_skill,
+            threshold_sdivsigma="false",
+            threshold_accuracy=0.0,
+            threshold_nse=0.0,
+        )
+        assert len(result) == 3, "lowercase 'false' should disable the sdivsigma gate"
+
+    def test_exact_boundary_included(self):
+        """sdivsigma exactly at threshold (0.6) is included (M2: inclusive <=)."""
         df = pd.DataFrame(
             [
                 _make_skill_row("10001", 1, "LR", sdivsigma=0.6),
@@ -852,7 +855,8 @@ class TestThresholdBehavior:
             threshold_accuracy=0.0,
             threshold_nse=0.0,
         )
-        assert len(result) == 0, "sdivsigma=0.6 should be excluded (< 0.6 is False)"
+        assert len(result) == 1, "sdivsigma=0.6 should be included (<= 0.6 is True)"
+        assert result.iloc[0]["model_short"] == "LR"
 
     def test_all_thresholds_must_pass(self):
         """Model passes sdivsigma and nse but fails accuracy -> excluded."""

--- a/apps/postprocessing_forecasts/tests/test_edge_cases.py
+++ b/apps/postprocessing_forecasts/tests/test_edge_cases.py
@@ -1186,10 +1186,15 @@ class TestDeltaEdgeCases:
     """
 
     def test_nan_delta_excluded_from_skill_metrics(self):
-        """NaN delta: calculate_all_skill_metrics filters row via NaN mask.
+        """NaN delta: only accuracy/delta filter the NaN-delta row.
 
-        Row 0: delta=NaN -> filtered
-        Row 1-2: valid -> n_pairs=2, metrics computed from those only.
+        Re-baselined for M3 (finding #2, doc/plans/postprocessing_skill_correctness_design.md):
+        obs/sim are valid on all 3 rows, so point metrics (n_pairs, mae)
+        use all 3 rows -- only accuracy/delta use the delta-valid
+        subset (rows 1-2), matching forecast_accuracy_hydromet().
+
+        Row 0: delta=NaN -> excluded from accuracy/delta only
+        Row 1-2: delta valid -> accuracy computed from those only.
         """
         data = pd.DataFrame(
             {
@@ -1199,10 +1204,11 @@ class TestDeltaEdgeCases:
             }
         )
         result = skill_metrics.calculate_all_skill_metrics(data, "obs", "sim", "delta")
-        assert result["n_pairs"] == 2, "NaN delta row should be filtered, leaving 2 valid pairs"
-        # MAE from valid rows: mean(|110-108|, |105-106|) = mean(2, 1) = 1.5
-        assert abs(result["mae"] - 1.5) < 1e-10
-        # Both within delta=5: accuracy = 1.0
+        assert result["n_pairs"] == 3, "NaN delta must not drop an obs/sim-valid row from n_pairs"
+        # MAE from all 3 obs/sim-valid rows: mean(|100-102|, |110-108|, |105-106|)
+        # = mean(2, 2, 1) = 1.666...
+        assert abs(result["mae"] - (5.0 / 3.0)) < 1e-10
+        # accuracy uses the delta-valid subset only (rows 1-2), both within delta=5.
         assert result["accuracy"] == 1.0
 
     def test_zero_delta_strict_matching(self):

--- a/apps/postprocessing_forecasts/tests/test_integration_postprocessing.py
+++ b/apps/postprocessing_forecasts/tests/test_integration_postprocessing.py
@@ -607,14 +607,19 @@ class TestOperationalDataRouting:
         # Date 2026-01-10: mean(LR=120.0, TFT=130.0) = 125.0
         assert abs(em_sorted.iloc[1]["forecasted_discharge"] - 125.0) < 0.01
 
-    def test_threshold_boundary_values_excluded(
+    def test_threshold_boundary_values_included(
         self,
         pentad_observed,
         env_setup,
     ):
-        """Metrics exactly at boundary are excluded (strict < / >)."""
-        # sdivsigma=0.6 (not < 0.6), accuracy=0.8 (not > 0.8),
-        # nse=0.8 (not > 0.8)
+        """Metrics exactly at boundary are INCLUDED (inclusive >= / <=).
+
+        M2 design decision D1: the skilled-forecast gate is inclusive, so a
+        model sitting exactly on every short-term default threshold
+        (sdivsigma=0.6, nse=0.8, accuracy=0.8) now PASSES. Both LR and TFT
+        qualify, so an EM row is created.
+        """
+        # sdivsigma=0.6 (<= 0.6), accuracy=0.8 (>= 0.8), nse=0.8 (>= 0.8)
         boundary_skill = pd.DataFrame(
             {
                 "pentad_in_year": [1, 1],
@@ -640,7 +645,12 @@ class TestOperationalDataRouting:
         )
 
         joint, _ = _make_ensemble(forecasts, boundary_skill)
-        assert "EM" not in joint["model_short"].values
+        em_rows = joint[joint["model_short"] == "EM"]
+        assert not em_rows.empty, (
+            "Boundary-exact models must PASS the inclusive gate and produce EM"
+        )
+        # EM = mean(LR=100.0, TFT=110.0) = 105.0
+        assert abs(em_rows.iloc[0]["forecasted_discharge"] - 105.0) < 0.01
 
     def test_three_stations_heterogeneous_outcomes(
         self,

--- a/apps/postprocessing_forecasts/tests/test_lt_skilled_mean_nse_threshold.py
+++ b/apps/postprocessing_forecasts/tests/test_lt_skilled_mean_nse_threshold.py
@@ -206,7 +206,9 @@ class TestLongTermOverridesHelper:
                 os.environ.pop(k, None)
             overrides = helper()
         assert set(overrides.keys()) == {"sdivsigma", "nse", "accuracy"}
-        assert float(overrides["nse"]) == pytest.approx(0.0)
+        # M2: long-term NSE default is now a small positive epsilon (not exactly
+        # 0.0) so that under the inclusive `>=` gate, nse == 0.0 still fails.
+        assert 0.0 < float(overrides["nse"]) < 1e-6
         assert str(overrides["sdivsigma"]) == "False"
         assert str(overrides["accuracy"]) == "False"
 

--- a/apps/postprocessing_forecasts/tests/test_skill_gate_inclusive_finite.py
+++ b/apps/postprocessing_forecasts/tests/test_skill_gate_inclusive_finite.py
@@ -1,0 +1,209 @@
+"""Locked tests for milestone M2 of the postprocessing skill-correctness campaign.
+
+M2 scope (see `src/skill_metrics.py`):
+
+1. The skill gate in `filter_for_highly_skilled_forecasts` becomes INCLUSIVE at
+   the boundary (`>=` / `<=`) instead of exclusive (`>` / `<`).
+2. The long-term NSE default moves from exactly ``0.0`` to a small positive
+   epsilon so that, under the new inclusive ``>=`` gate, ``nse == 0.0`` still
+   fails while any positive NSE still passes.
+3. The long-term NSE gate can no longer be disabled via env var — attempting
+   to disable it raises ``ValueError``. (sdivsigma/accuracy remain
+   disable-able for long-term; untouched by this milestone.)
+4. `_parse_threshold_env` now rejects non-finite floats (``nan``/``inf``/
+   ``-inf``) with a clear ``ValueError`` instead of silently returning them.
+5. The short-term direct env-var read in `filter_for_highly_skilled_forecasts`
+   now routes through the same lenient `_parse_threshold_env` parser used by
+   the long-term path, so a lowercase ``"false"`` or empty-string env value
+   cleanly disables the gate instead of crashing on a bare ``float()`` call.
+
+Placeholder station code 19999 only (never a real station code).
+"""
+
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.skill_metrics import (
+    _long_term_threshold_overrides,
+    _parse_threshold_env,
+    filter_for_highly_skilled_forecasts,
+)
+
+CODE = "19999"
+
+# Short-term default env vars, matching METRIC_REGISTRY defaults exactly
+# (nse=0.8, sdivsigma=0.6, accuracy=0.8).
+_SHORT_TERM_ENV_KEYS = (
+    "ieasyhydroforecast_efficiency_threshold",
+    "ieasyhydroforecast_nse_threshold",
+    "ieasyhydroforecast_accuracy_threshold",
+)
+SHORT_TERM_DEFAULT_ENV = {
+    "ieasyhydroforecast_efficiency_threshold": "0.6",
+    "ieasyhydroforecast_nse_threshold": "0.8",
+    "ieasyhydroforecast_accuracy_threshold": "0.8",
+}
+
+# Long-term-only env vars; unsetting all three restores documented defaults
+# (nse=epsilon, sdivsigma=disabled, accuracy=disabled).
+_LONG_TERM_ENV_KEYS = (
+    "ieasyhydroforecast_nse_threshold_long_term",
+    "ieasyhydroforecast_efficiency_threshold_long_term",
+    "ieasyhydroforecast_accuracy_threshold_long_term",
+)
+
+
+def _row(model_short, *, sdivsigma=0.3, nse=0.95, accuracy=0.95, n_pairs=10):
+    """Minimal skill-stats row dict for the columns the gate reads."""
+    return {
+        "code": CODE,
+        "model_short": model_short,
+        "sdivsigma": sdivsigma,
+        "nse": nse,
+        "accuracy": accuracy,
+        "n_pairs": n_pairs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# (a) Short-term: exact-boundary values on all three metrics are KEPT.
+# ---------------------------------------------------------------------------
+
+
+def test_short_term_exact_boundary_all_three_metrics_kept(monkeypatch):
+    """nse=0.8, accuracy=0.80, sdivsigma=0.6 (all exactly at their short-term
+    default thresholds) must be KEPT under the new inclusive gate."""
+    for key, value in SHORT_TERM_DEFAULT_ENV.items():
+        monkeypatch.setenv(key, value)
+
+    df = pd.DataFrame([_row("LR", sdivsigma=0.6, nse=0.8, accuracy=0.80)])
+    result = filter_for_highly_skilled_forecasts(df)
+
+    assert len(result) == 1, "Model exactly at all three default thresholds must be kept"
+    assert result.iloc[0]["model_short"] == "LR"
+
+
+# ---------------------------------------------------------------------------
+# (b) Long-term NSE epsilon: nse=0.0 excluded, nse=0.001 kept.
+# ---------------------------------------------------------------------------
+
+
+def test_long_term_nse_zero_excluded_small_positive_kept(monkeypatch):
+    """Under long-term default overrides, nse=0.0 must still fail (epsilon
+    default, not exactly 0.0) while nse=0.001 passes."""
+    for key in _LONG_TERM_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    overrides = _long_term_threshold_overrides()
+
+    df = pd.DataFrame(
+        [
+            _row("ZERO", nse=0.0, sdivsigma=5.0, accuracy=0.1),
+            _row("SMALL_POSITIVE", nse=0.001, sdivsigma=5.0, accuracy=0.1),
+        ]
+    )
+    result = filter_for_highly_skilled_forecasts(df, **overrides)
+    kept = set(result["model_short"])
+
+    assert "ZERO" not in kept, "nse=0.0 must still fail the long-term NSE gate"
+    assert "SMALL_POSITIVE" in kept, "nse=0.001 must pass the long-term NSE gate"
+
+
+# ---------------------------------------------------------------------------
+# (c) Long-term NSE gate cannot be disabled.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("token", ["false", "False", "", "off"])
+def test_long_term_nse_gate_cannot_be_disabled(monkeypatch, token):
+    """Any disable token on the long-term NSE env var must raise ValueError —
+    the long-term NSE gate may never be turned off, unlike sdivsigma/accuracy."""
+    monkeypatch.setenv("ieasyhydroforecast_nse_threshold_long_term", token)
+    with pytest.raises(ValueError):
+        _long_term_threshold_overrides()
+
+
+# ---------------------------------------------------------------------------
+# (d) _parse_threshold_env rejects non-finite values.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw", ["nan", "inf", "-inf"])
+def test_parse_threshold_env_rejects_non_finite(raw):
+    with pytest.raises(ValueError):
+        _parse_threshold_env(raw)
+
+
+# ---------------------------------------------------------------------------
+# (e) Short-term disable tokens ('false', '') cleanly disable the gate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("disable_token", ["false", ""])
+def test_short_term_sdivsigma_disable_token_disables_gate(monkeypatch, disable_token):
+    """A lowercase 'false' or empty-string sdivsigma env value must cleanly
+    disable that gate (no crash), while nse/accuracy stay strict at defaults."""
+    # sdivsigma=0.9 fails the default (<=0.6) gate; nse/accuracy pass defaults.
+    df = pd.DataFrame([_row("LR", sdivsigma=0.9, nse=0.95, accuracy=0.95)])
+
+    # Baseline: sdivsigma env unset (module default 0.6) -> excluded.
+    monkeypatch.delenv("ieasyhydroforecast_efficiency_threshold", raising=False)
+    result_default = filter_for_highly_skilled_forecasts(df)
+    assert len(result_default) == 0, "sdivsigma=0.9 must fail the default (0.6) gate"
+
+    # Disabled: sdivsigma env set to a lenient disable token -> kept, no crash.
+    monkeypatch.setenv("ieasyhydroforecast_efficiency_threshold", disable_token)
+    result_disabled = filter_for_highly_skilled_forecasts(df)
+    assert len(result_disabled) == 1, (
+        f"sdivsigma disable token {disable_token!r} must disable the gate cleanly"
+    )
+    assert result_disabled.iloc[0]["model_short"] == "LR"
+
+
+# ---------------------------------------------------------------------------
+# (f) The overrides path is routed through the SAME parser as the env path,
+#     so disable-token handling and the isfinite guard apply identically
+#     regardless of where the threshold value came from.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_override", [float("nan"), "nan", float("inf"), "inf"])
+def test_override_non_finite_raises(monkeypatch, bad_override):
+    """A non-finite threshold passed as an OVERRIDE (not via env) must raise
+    ValueError, mirroring the env-path isfinite guard."""
+    for key in _SHORT_TERM_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    df = pd.DataFrame([_row("LR")])
+    with pytest.raises(ValueError):
+        filter_for_highly_skilled_forecasts(df, sdivsigma=bad_override)
+
+
+@pytest.mark.parametrize("disable_token", ["off", "none", "disable", ""])
+def test_override_lenient_disable_token_disables_gate(monkeypatch, disable_token):
+    """A lenient disable token passed as an OVERRIDE disables that gate,
+    exactly like the env path (parity)."""
+    for key in _SHORT_TERM_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    # sdivsigma=0.9 fails the default (<=0.6) gate; disabling it via an override
+    # token keeps the model (nse/accuracy stay at inclusive defaults it meets).
+    df = pd.DataFrame([_row("LR", sdivsigma=0.9, nse=0.95, accuracy=0.95)])
+    result = filter_for_highly_skilled_forecasts(df, sdivsigma=disable_token)
+    assert len(result) == 1, "override disable token must disable the sdivsigma gate"
+    assert result.iloc[0]["model_short"] == "LR"
+
+
+def test_bool_false_override_still_disables_gates(monkeypatch):
+    """REGRESSION: the real long-term caller passes bool ``False`` for
+    sdivsigma/accuracy overrides — these must still disable those gates."""
+    for key in _SHORT_TERM_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    # Both metrics would fail a numeric gate; bool False must disable both so
+    # the model survives on its NSE alone.
+    df = pd.DataFrame([_row("LR", sdivsigma=0.9, nse=0.95, accuracy=0.05)])
+    result = filter_for_highly_skilled_forecasts(df, sdivsigma=False, accuracy=False, nse=0.001)
+    assert len(result) == 1, "bool False overrides must disable sdivsigma/accuracy"
+    assert result.iloc[0]["model_short"] == "LR"

--- a/doc/plans/postprocessing_skill_correctness_design.md
+++ b/doc/plans/postprocessing_skill_correctness_design.md
@@ -112,3 +112,30 @@ config-driven operational-issuance selection (parked plan accepted intra-lead re
 "rare" — we now know those are relics and select the operational one instead). Reconcile with the
 merged #411 min-n/tombstone (built after the parked P2). Recommend RESUMING the lead-aware
 plan/branch rather than building M1 from scratch.
+
+---
+
+## M2–M6 critical review — RESOLVED (2026-07-08)
+
+- **M2** (gates): operator = **global inclusive `>=`/`<=`** + **long-term NSE threshold = small epsilon**
+  so NSE=0 stays excluded (honours strict-positive without a horizon flag). Lock the long-term NSE
+  env var against disable tokens (metric-specific in `_parse_threshold_env`); add `isfinite` guard
+  (rejects nan/inf, closes #12); route the short-term direct-env read through the lenient parser
+  (closes #11). sdivsigma/accuracy stay disable-able long-term.
+- **M3** (per-metric masks, #2): split masks — NSE/MAE/pbias/kgelf/nse_log use obs/sim-only; delta
+  mask applies to accuracy/delta only. **Stored `n_pairs` = obs/sim pair count** (accuracy uses its
+  own delta-valid subset internally). Numerically identical where delta is finite (monthly fills 0.0).
+- **M4** (CRPS, D3/#5+#6): one canonical `crps_from_quantiles` (factor-2 + flat tails + NaN-quantile
+  handling) in **`iEasyHydroForecast`** (both apps already depend on it); both import it. Stored
+  postprocessing `crps` changes (~2x, informational, no gate) — **accept mixed old/new until next
+  recalc** (no special action).
+- **M5** (eval short-term dedup, D4/#7): flip `short_term_dedup_one_per_target` default **ON** using
+  the existing latest-issue rule; **minimal scope** — eval↔operational LONG-TERM parity is handled
+  inside M1's lead-aware resumption (its P4), not here.
+- **M6** (rp events, #8): **DEFERRED to the M7 tier** — eval-only feature-completeness (a silent
+  no-op), not a core skill/ensemble correctness/consistency fix. Backlog with #14/#15/#16.
+
+**Campaign scope is now M1–M5.** M1 = resume+refine the parked lead-aware project (config-driven
+operational-issuance selection + reconcile with merged #411). M2–M5 = independent, mostly single-file
+correctness/consistency fixes. M6 + M7 (#14/#15/#16) = deferred backlog issues. #9/#10 = colleague
+service coordination.

--- a/doc/plans/postprocessing_skill_correctness_design.md
+++ b/doc/plans/postprocessing_skill_correctness_design.md
@@ -77,3 +77,38 @@ park M1 & ship M2–M6.
 
 **M2–M6:** independent of the lead question; not yet critically reviewed with the user (pending).
 NOT fed to WF2 yet — no build until the user approves the path.
+
+---
+
+## M1 design pass — RESOLVED (2026-07-08, config-driven)
+
+Source of truth = deployment long-term configs (`<org>_data_forecast_tools/config/long_term_configs/`),
+NOT the relic-contaminated DB. Empirics: DB has ~32 issue-dates/target-year for MONTH (pentad-day
+relics from backfill/hindcast); operationally each mode issues ONCE.
+
+**Operational taxonomy (per org, from config `operational_issue_day` / `operational_month_lead_time`
+/ `target_*_month`):**
+- Kyrgyz: month_0 (d10,L0), month_1/2/3 (d25, L1/2/3), quarter (d25,L1), seasonal Jan/Feb/Mar/Apr
+  (d25, L3/2/1/0, target months 4–9). 9 modes.
+- Tajik: month_1/2/3 (d1, L0/1/2), quarter (d1,L0), seasonal_april (d1,L0, months 4–9). 5 modes.
+
+**Resolved M1 design:**
+1. Lead taxonomy = config modes (month-level lead); one `(horizon, target-window, lead,
+   operational_issue_day)` per mode per org. Stored in `horizon_value` (month-level → NO service
+   schema change). Matches the parked lead-aware derived `lead_months`.
+2. Pairing = ONE operational forecast per `(code, mode, target-year)`: **select by configured lead
+   across all history** — the issuance whose derived lead `(valid_from.y-date.y)*12 +
+   (valid_from.m-date.m)` == mode's `operational_month_lead_time`; among candidates prefer
+   `operational_issue_day`, else nearest/latest. Collapses relics; uses full hindcast history →
+   `n_pairs = number of target-years`.
+3. Skill + ensembles computed per mode/lead (preserves per-lead separation). Relics excluded from
+   operational skill (candidates for the merged stale-tombstone cleanup).
+4. Gates: #411 hard floor (MONTH≥4/QUARTER≥5/SEASON≥5) for ensemble-eligibility + per-lead
+   NaN-at-`n_pairs<2` for variance metrics (sdivsigma/nse).
+
+**Relationship to parked lead-aware project:** this IS that project, refined. Reuse its locked
+decisions + its already-built P2 reader lead-derivation (flag-gated, uncommitted); ADD the
+config-driven operational-issuance selection (parked plan accepted intra-lead re-issue pooling as
+"rare" — we now know those are relics and select the operational one instead). Reconcile with the
+merged #411 min-n/tombstone (built after the parked P2). Recommend RESUMING the lead-aware
+plan/branch rather than building M1 from scratch.

--- a/doc/plans/postprocessing_skill_correctness_design.md
+++ b/doc/plans/postprocessing_skill_correctness_design.md
@@ -1,0 +1,50 @@
+# Postprocessing Skill-Metrics & Ensemble Correctness — Campaign Design
+
+**Vision:** correct, internally-consistent postprocessing of forecasts — fix the confirmed
+problems without introducing new errors.
+
+**Base:** `maxat_sapphire_2` @ `502ac63c` (post PR #411 min-n/stale merge).
+**Branch:** `develop_postprocessing_skill_correctness`.
+**Spine:** vision WF1 (decompose) → WF2 (build), TDD, cross-vendor quality gate → PR → `run_tests.sh`.
+**Source:** read-only Claude+Codex audit (2026-07-08), re-verified on this base. All 16 findings
+present; the merged min-n gate is defeated by finding #1.
+
+## Ratified design decisions (Phase-0 brainstorming, 2026-07-08)
+- **D1** — short-term skilled gate is INCLUSIVE (`NSE≥0.8`, `accuracy≥0.80`, `sdivsigma≤thr`);
+  long-term stays strict `NSE>0`. (Matches Central-Asia hydromet acceptance convention.)
+- **D2** — the long-term NSE gate must NOT be silently disable-able: reject disable tokens for its
+  env var and add an `isfinite` guard (also closes the nan-threshold hole). sdivsigma/accuracy
+  remain disable-able for long-term (intended).
+- **D3** — ONE canonical CRPS: both apps use the textbook `crps_from_quantiles` (factor-2 + flat
+  tails) via a shared helper; fix NaN-quantile poisoning in the same change.
+- **D4** — eval `short_term_dedup_one_per_target` defaults ON (one pair per target, matching the
+  operational side; closes the operational-vs-eval divergence).
+- **D5** — `fdc_flv` adopts Yilmaz et al. (2008) Eq.4 (leading negative sign + min-deviation
+  normalization). Lowest priority.
+
+## Mandatory (not a decision)
+- **#1** — long-term monthly & seasonal skill count each stored issue-date row as a separate
+  obs↔sim pair (`read_monthly_forecasts` has no dedup; `_deduplicate_seasonal_forecasts` keeps
+  `date`). This inflates `n_pairs` and **defeats the just-merged min-n gate** (Codex reproduced:
+  2 target seasons → n_pairs=5 → passes SEASON≥5). Fix = per-target dedup (keep latest issue)
+  BEFORE the `n_pairs` count, for the raw-model/skill grouping; keep per-issue grouping only for
+  EM composition. Quarterly is already safe (reader dedups).
+
+## Milestones (WF1 will adversarially refine ordering/deps; this is the seed)
+| ID | Findings | Scope (functions) | Acceptance |
+|----|----------|-------------------|------------|
+| **M1** (HIGH) | #1 (+re-baseline min-n) | `skill_metrics.calculate_monthly_skill_metrics`, `_calculate_aggregated_skill_metrics` | Reissued target contributes exactly 1 pair; seasonal repro (2 targets → n_pairs=2) locked; min-n gate no longer foolable |
+| **M2** | D1/#3, D2/#4, #12, #11 | `filter_for_highly_skilled_forecasts`, `_parse_threshold_env`, `_long_term_threshold_overrides` | Boundary models (0.80) kept short-term; LT NSE gate un-disable-able; nan/invalid tokens raise; disable tokens robust |
+| **M3** | #2 | `calculate_all_skill_metrics` | NSE/MAE/pbias/kgelf/nse_log use obs/sim mask only; delta mask applies to accuracy only; matches standalone fns |
+| **M4** | D3/#5, #6 | shared `crps_from_quantiles`; both apps' CRPS callers | Both apps return identical textbook CRPS; NaN quantile row doesn't poison the group |
+| **M5** | D4/#7 | `forecast_skill_eval/config.py` (+ callers) | Default run dedups short-term re-issues; documented; opt-out still available |
+| **M6** | #8 | `forecast_skill_eval/orchestrator.py` | Requested `rp5` events produce contingency rows (or are rejected at config validation) |
+| M7 (DEFERRED → issues) | D5/#14, #15, #16 | `fdc_flv`, `binary_contingency`, `calculate_sharpness` | Filed as gi_draft issues, not built this campaign |
+| Coordination (not ours) | #9, #10 | `sapphire/services/` (colleague-owned) | Raised as discussion/issue; no code by us |
+
+## No-new-errors guardrails
+Per milestone: locked regression test authored before the fix (must fail→pass), Codex implements,
+cross-vendor quality gate (strong Claude + `codex exec review` read the diff), then
+`SAPPHIRE_TEST_ENV=True bash run_tests.sh <module>` (zero failures / zero unexpected skips) and
+changed-line coverage before PR. EM output must stay byte-identical where a fix is not meant to
+change it (M1's dedup changes n_pairs/NSE by design — re-baseline those tests explicitly).

--- a/doc/plans/postprocessing_skill_correctness_design.md
+++ b/doc/plans/postprocessing_skill_correctness_design.md
@@ -48,3 +48,32 @@ cross-vendor quality gate (strong Claude + `codex exec review` read the diff), t
 `SAPPHIRE_TEST_ENV=True bash run_tests.sh <module>` (zero failures / zero unexpected skips) and
 changed-line coverage before PR. EM output must stay byte-identical where a fix is not meant to
 change it (M1's dedup changes n_pairs/NSE by design — re-baseline those tests explicitly).
+
+---
+
+## Review update (2026-07-08) — WF1 output + critical milestone review
+
+**WF1 (vision-decompose) result:** 6 milestones, all 4 adversarial reviewers approved. Applied
+advisories: M6 scoped to PRODUCE rp5 rows only (the "reject at config validation" branch would
+break the locked test_events.py:585-590 contract that rp5/rp10/rp30/rp100 are accepted); deps
+relaxed to two tracks (skill_metrics M1→M2→M3→M4 serial for same-file churn; forecast_skill_eval
+M5 ∥ M6 independent); "byte-identical" reworded to "numerically unchanged for unmodified paths".
+
+**Confirmed domain facts (user, 2026-07-08):** ONE target season (irrigation, months 4–9);
+`season_in_year` = the ISSUE LEAD, not a distinct season; skill + ensembles are wanted PER LEAD;
+min-n floors (MONTH≥4/QUARTER≥5/SEASON≥5) = minimum number of YEARS of paired history.
+
+**M1 INVERTED — now BLOCKED pending design.** The user confirmed day-10 vs day-25 issues within
+the same issue-month are DIFFERENT leads that must each get their own skill metric + ensemble.
+Current `horizon_value` is a COARSE month-level lead (0–3) that collapses them; the issue day is
+stored (`LongForecast.date`) but is not a grouping key. So the original M1 plan (dedup re-issues,
+keep latest) is WRONG — it would delete a forecast the user wants to keep. Correct direction:
+STRATIFY skill/ensembles by a finer lead, not collapse. This is a lead-taxonomy redesign, overlaps
+the parked lead-aware project (`SAPPHIRE_SKILL_LEAD_AWARE`, not on this base), and may touch the
+colleague-owned skill_metrics/long_forecasts key. OPEN DECISION (awaiting user): (a) define what a
+lead is (issue day-of-month / issue-date / lead-days bucket); (b) how it's keyed/stored (re-encode
+horizon_value vs add a field → service coordination); (c) campaign path — design-first / fold-in /
+park M1 & ship M2–M6.
+
+**M2–M6:** independent of the lead question; not yet critically reviewed with the user (pending).
+NOT fed to WF2 yet — no build until the user approves the path.


### PR DESCRIPTION
## Summary
Implements **M2–M5** of the postprocessing skill-metrics/ensemble **correctness campaign** (from the
read-only audit + owner-ratified design in `doc/plans/postprocessing_skill_correctness_design.md`).
Apps-only; **`sapphire/services/` untouched**.

| Milestone | Fix |
|---|---|
| **M2** | Inclusive `>=`/`<=` skill gates (keeps models exactly on the boundary, e.g. accuracy=0.80); long-term NSE epsilon so NSE=0 stays excluded + gate un-disable-able; `isfinite` guard; env **and** override threshold paths unified (`skill_metrics.py`) |
| **M3** | Per-metric NaN masks in `calculate_all_skill_metrics` — NSE/MAE/pbias/kgelf/nse_log use obs/sim-only; delta mask for accuracy only; `n_pairs` = obs/sim count |
| **M4** | One canonical CRPS in `iEasyHydroForecast/probabilistic_metrics.py` (textbook factor-2 + tails); `postprocessing_forecasts` and `forecast_skill_eval` both delegate → identical values; NaN-quantile no longer poisons the group |
| **M5** | Default short-term re-issue dedup ON in `forecast_skill_eval` (config **and** CLI `BooleanOptionalAction`), opt-out preserved |

## Review evidence
Each milestone: TDD (RED-verified locked tests) → orchestrator deliberation → out-of-loop `codex exec`
verifier → commit. The loop caught 3 pre-commit gaps (M5 operational-CLI no-op, M2 override bypass,
M4 would-be reverse-dependency), all fixed. An open-ended `codex exec` adversarial review of the full
diff found **no code defects** (1 false positive from a stale local base-ref, dismissed; 1 design
nuance — the LT-NSE epsilon — **reviewed and accepted by the owner**).

## Tests
Full local `run_tests.sh`: **9 modules pass** — the 3 changed (`iEasyHydroForecast`,
`postprocessing_forecasts`, `forecast_skill_eval`) + iEHF-importers (`preprocessing_runoff`,
`preprocessing_gateway`, `linear_regression`, `pipeline`) + `service:postprocessing`/`preprocessing`.
Deferred to CI: `machine_learning` (torch), `forecast_dashboard` (chromium gate), `validate_pipeline`.

## Behavior notes
- Stored `crps` values shift (~2x toward correct scale) — informational (no gate uses it); corrects at
  next recalc, no migration.
- Boundary models exactly on a threshold are now KEPT short-term (inclusive gate); this can change EM /
  Skilled-Mean membership at the boundary (intended). Tests re-baselined accordingly.

## Not in this PR (deliberate)
- **M1** (config-driven per-lead skill/ensembles) — planned separately (lead-aware resumption).
- **M6/M7** (rp-events, FLV/contingency/sharpness) — deferred backlog.
- **#9/#10** — `sapphire/services/` items → colleague coordination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
