### PR TITLE
Agent workflow: mandatory multi-model + out-of-loop adversarial review, tests-as-done

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,11 +74,15 @@ vocabulary is owned by** [`doc/plans/README.md`](doc/plans/README.md) — do not
    tool/model where possible. Default out-of-loop verifier = `codex exec`; fall back to a
    general-purpose Claude subagent with no prior session context if Codex is unavailable.
    Post-implementation review is a required gate before PR approval — never approve on the
-   implementer's claim alone.
+   implementer's claim alone. **Work is not "done", review-eligible, or PR-eligible until the full
+   affected-scope tests pass** (`run_tests.sh`, zero fail / zero unexpected skip) — a standing
+   precondition, not a pre-PR afterthought.
 
-2. **Out-of-loop verifier for high-claim-density artifacts** (plans, designs, audits, multi-file
-   patches). Pass the artifact *in the prompt before committing it*; the verifier checks every
-   falsifiable claim against code, tests, docs, and DB/API contracts. Verifier-found **factual
+2. **Out-of-loop review for high-claim-density artifacts** (plans, designs, audits, multi-file
+   patches). Pass the artifact *in the prompt before committing it*; the reviewer must run an
+   **OPEN-ENDED adversarial pass — find any defect / missing step / edge case, not merely confirm a
+   claim checklist** — against code, tests, docs, and DB/API contracts (claim-verification alone is
+   necessary but not sufficient). Applies to plans as well as implementation diffs. Verifier-found **factual
    errors** may be applied directly; **scope/design/semantics/security/API-contract** changes
    **escalate to the human owner**; related bugs found while mapping become `gi_draft_*` plan files
    under `doc/plans/issues/` (indexed in `doc/plans/module_issues.md`), never inline fixes. After

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,38 @@ End the plan with a dependency graph:
 }
 ```
 
+### Multi-Model Review & Verification
+
+Additive to the Orchestration Protocol. The human owner is the terminal authority; an
+implementation agent's "done"/"complete" is **evidence, not approval**. Full procedure, prompt
+templates, and the repo's high-risk coupling points live in
+[`doc/dev/agent_review_workflow.md`](doc/dev/agent_review_workflow.md). Plan/issue **status
+vocabulary is owned by** [`doc/plans/README.md`](doc/plans/README.md) — do not restate it elsewhere.
+
+1. **Mandatory multi-model review.** Any non-trivial plan or patch needs at least two independent
+   perspectives, and at least one must be **out-of-loop**: fresh context, read-only, different
+   tool/model where possible. Default out-of-loop verifier = `codex exec`; fall back to a
+   general-purpose Claude subagent with no prior session context if Codex is unavailable.
+   Post-implementation review is a required gate before PR approval — never approve on the
+   implementer's claim alone.
+
+2. **Out-of-loop verifier for high-claim-density artifacts** (plans, designs, audits, multi-file
+   patches). Pass the artifact *in the prompt before committing it*; the verifier checks every
+   falsifiable claim against code, tests, docs, and DB/API contracts. Verifier-found **factual
+   errors** may be applied directly; **scope/design/semantics/security/API-contract** changes
+   **escalate to the human owner**; related bugs found while mapping become `gi_draft_*` plan files
+   under `doc/plans/issues/` (indexed in `doc/plans/module_issues.md`), never inline fixes. After
+   corrections, run one lightweight **confirm-fixes pass**.
+
+3. **Every high-claim-density prompt carries the fitness line** (verbatim): "Every bullet must help
+   an agent know what to inspect, what contract not to break, or what verification proves safety —
+   otherwise cut it." Apply a standing **proportionality lens** that argues for cuts, and **separate
+   implemented vs documented vs drift** — never present aspiration as current behavior.
+
+A cross-vendor orchestration workflow that provides an independent review panel plus a quality gate
+satisfies 1–2 for work run through it; such outputs need no second verifier pass. See
+[`doc/dev/agent_review_workflow.md`](doc/dev/agent_review_workflow.md) for which workflows qualify.
+
 ---
 
 ## Project Architecture

--- a/doc/dev/agent_review_workflow.md
+++ b/doc/dev/agent_review_workflow.md
@@ -10,6 +10,15 @@ Procedure and templates for the multi-model review rules in
 > Every bullet must help an agent know what to inspect, what contract not to break, or what
 > verification proves safety — otherwise cut it.
 
+## Definition of done: tests are non-negotiable
+
+Nothing is "done", review-eligible, or PR-eligible until the full affected-scope tests pass —
+`run_tests.sh` for every touched module AND every module that imports the changed code, with **zero
+failures and zero unexpected skips**. Run them before calling a milestone complete or handing an
+artifact for review; this is a standing precondition, not a pre-PR afterthought (see CLAUDE.md
+Testing Requirements). If the local worktree lacks a module's venv, either `uv sync --all-extras` it
+and run it, or explicitly record it as deferred-to-CI **with the reason** — never silently skip.
+
 ## When mandatory multi-model review applies
 
 Required for: implementation plans (`gi_*.md`), design docs, audit/investigation reports, and
@@ -36,16 +45,36 @@ The repo-native path (`codex exec` verifier + `code-review` + human owner) satis
 a repo-native equivalent as a **separate `gi_draft` initiative** — do not couple the review rule to
 undocumented external tooling.
 
+## Adversarial review is REQUIRED — not just claim verification
+
+There are two different out-of-loop passes; a high-claim artifact (plan, design, audit, or
+multi-file / high-risk patch) needs the **adversarial** one, and it is the primary gate:
+
+- **Claim verification** — you hand the reviewer a checklist of falsifiable claims; it confirms/refutes
+  each. Catches "does the code do what I said" — but only checks what you thought to ask. Necessary,
+  **not sufficient**; never treat a passing claim-verifier as review-complete.
+- **Open-ended adversarial review** — you hand the reviewer the artifact/diff with **no checklist** and
+  instruct it to find ANY defect, missing step, wrong assumption, edge case, or regression. Applies to
+  **implementations (the diff) AND plans**. This is what catches what you didn't think to ask. Run it
+  via read-only `codex exec` with an open-ended prompt; a fresh Claude subagent (no prior context) is
+  the fallback — also open-ended.
+
+Note: the dedicated `codex exec review` subcommand cannot run sandboxed (it requires
+`--dangerously-bypass-approvals-and-sandbox`), so prefer the **read-only `codex exec`** form with the
+artifact/diff pasted in the prompt.
+
 ## Out-of-loop verifier requirements
 
 - Different tool/model where possible — default `codex exec`; fallback = a fresh Claude
   general-purpose subagent with **no prior session context**.
 - **Read-only.** The verifier must not edit repo files.
 - The artifact is passed **in the prompt, before it is committed**.
-- Run against the patch's **target branch in a clean checkout** (e.g. a worktree off
-  `origin/maxat_sapphire_2`), NOT the current working tree — a dirty or wrong-branch tree yields
-  false refutations. (Learned the hard way: a verifier run against the wrong branch falsely refuted
-  `round_3sf` usage and dashboard tombstone suppression that are present on the target.)
+- Run against the patch's **target branch in a clean checkout**, and **diff against `origin/<target>`
+  (e.g. `origin/maxat_sapphire_2`), never a stale LOCAL branch ref or the working tree.** A
+  dirty/wrong-branch tree or a stale local ref produces false verdicts. (Seen twice: a wrong-branch
+  run falsely refuted `round_3sf`/tombstone code that is present on the target; a run diffing against a
+  stale local `maxat_sapphire_2` falsely reported an upstream `sapphire/services/` file as added by
+  the change.)
 - Output = per-claim verdict: `confirmed` / `refuted` / `unverifiable`, each with concrete evidence
   (path, symbol, test, or contract). No prose approval.
 
@@ -110,7 +139,8 @@ transcription drift introduced while applying fixes.
 
 No PR is approved on the implementer's `done` alone. Standard patches: in-loop `code-review`
 (correctness) + human owner. Patches touching a high-risk coupling point (below): additionally one
-**out-of-loop** reviewer (`codex exec review` on the diff, or the fresh-Claude fallback).
+**out-of-loop** reviewer running an OPEN-ENDED adversarial review of the diff (read-only `codex exec`,
+or the fresh-Claude fallback — not merely a claim-checklist).
 PASS = `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh` zero-fail / zero-unexpected-skip
 **and** both reviewers' Critical/Important items resolved or reasoned-rebutted **and** no
 unescalated design/contract fork. Live-DB behavior changes additionally require the operational

--- a/doc/dev/agent_review_workflow.md
+++ b/doc/dev/agent_review_workflow.md
@@ -1,0 +1,144 @@
+# Agent Review & Verification Workflow
+
+Procedure and templates for the multi-model review rules in
+[`CLAUDE.md`](../../CLAUDE.md) (§ Multi-Model Review & Verification). This document is the
+"how"; CLAUDE.md is the "must". Status vocabulary is owned by
+[`../plans/README.md`](../plans/README.md); this doc does not restate it.
+
+## Fitness statement (required in every high-claim-density prompt, verbatim)
+
+> Every bullet must help an agent know what to inspect, what contract not to break, or what
+> verification proves safety — otherwise cut it.
+
+## When mandatory multi-model review applies
+
+Required for: implementation plans (`gi_*.md`), design docs, audit/investigation reports, and
+multi-file patches — anything with many falsifiable claims about code or contracts, OR any patch
+touching a high-risk coupling point (below).
+
+Optional for: single-file mechanical patches, docs-only edits with no code claims, and artifacts
+produced by a qualifying cross-vendor workflow (see "Cross-vendor workflow accelerators" below).
+
+## Cross-vendor workflow accelerators (optional)
+
+A multi-agent orchestration workflow that provides an independent review panel **plus** a quality
+gate satisfies the mandatory-review + out-of-loop requirements for work run through it. Today the
+`vision-decompose` (WF1) and `vision-build` (WF2) skills provide this (Codex planner/implementer +
+Claude adversarial panel / quality gate).
+
+Caveats — do not treat them as a dependency:
+- They are **external plugin skills, not versioned in this repo**, so they can change or be
+  unavailable to a teammate without the plugin.
+- WF2 requires `<repo>/.claude/workflow-capabilities.json`, which is **absent by default**.
+
+The repo-native path (`codex exec` verifier + `code-review` + human owner) satisfies the rule
+**without** them. If the team wants this capability reliable, portable, and editable in-repo, vendor
+a repo-native equivalent as a **separate `gi_draft` initiative** — do not couple the review rule to
+undocumented external tooling.
+
+## Out-of-loop verifier requirements
+
+- Different tool/model where possible — default `codex exec`; fallback = a fresh Claude
+  general-purpose subagent with **no prior session context**.
+- **Read-only.** The verifier must not edit repo files.
+- The artifact is passed **in the prompt, before it is committed**.
+- Run against the patch's **target branch in a clean checkout** (e.g. a worktree off
+  `origin/maxat_sapphire_2`), NOT the current working tree — a dirty or wrong-branch tree yields
+  false refutations. (Learned the hard way: a verifier run against the wrong branch falsely refuted
+  `round_3sf` usage and dashboard tombstone suppression that are present on the target.)
+- Output = per-claim verdict: `confirmed` / `refuted` / `unverifiable`, each with concrete evidence
+  (path, symbol, test, or contract). No prose approval.
+
+### `codex exec` verifier prompt template
+
+```
+codex exec -s read-only -C <clean_target_checkout> --color never -o <out.json> "$(cat <<'PROMPT'
+READ-ONLY verification. Do NOT edit any file. You are a fresh, out-of-loop reviewer; assume nothing
+from prior context.
+
+ARTIFACT UNDER REVIEW (verify, do not trust):
+<paste the full artifact text here>
+
+TASK: For each falsifiable claim in the artifact — file paths, symbol names, described behavior,
+conventions, DB/API contracts — verify it against the repo at the working directory. Return a JSON
+array: [{claim, verdict: confirmed|refuted|unverifiable, evidence: "path/symbol/test or why
+unverifiable"}]. Flag any claim that contradicts CLAUDE.md, doc/plans/README.md, or
+doc/dev/testing_workflow.md. Do not propose design changes; only check factual accuracy.
+PROMPT
+)"
+```
+
+### Fresh-Claude fallback verifier prompt (Agent tool, general-purpose, no prior context)
+
+```
+READ-ONLY verification, fresh context. Work only in <clean_target_checkout>; do not edit any file.
+Here is an artifact (verify, do not trust): <paste artifact>.
+For each falsifiable claim (paths, symbols, behavior, conventions, contracts), check it against the
+repo and return {claim, verdict: confirmed|refuted|unverifiable, evidence}. Flag contradictions with
+CLAUDE.md / doc/plans/README.md / doc/dev/testing_workflow.md. Factual accuracy only — no design
+opinions.
+```
+
+## Proportionality lens checklist (argue for cuts)
+
+- [ ] Present-but-unnecessary content that doesn't change what an agent does.
+- [ ] Over-specific line-number references likely to drift — prefer file + symbol.
+- [ ] Duplicated docs — point to the one owner instead.
+- [ ] Content that teaches how the code works instead of routing an agent to where to inspect.
+- [ ] Restated status vocabulary (owned by [`../plans/README.md`](../plans/README.md)).
+
+## Implemented vs documented separation
+
+Every artifact must label: **implemented** (current behavior in code), **documented**
+(aspirational / spec), and **drift** (where they disagree). Never present aspiration as current.
+
+## Accuracy fixes vs design forks
+
+- **Factual errors** the verifier finds may be applied directly.
+- **Scope, design, semantics, security, or API-contract** changes **escalate to the human owner** —
+  the verifier does not decide them.
+- **Related bugs found while mapping** become `gi_draft_*` plan files under
+  [`../plans/issues/`](../plans/issues/) (indexed in
+  [`../plans/module_issues.md`](../plans/module_issues.md)), never inline fixes.
+
+## Final confirm-fixes pass
+
+After corrections are applied, run one lightweight pass re-reading the corrected artifact to catch
+transcription drift introduced while applying fixes.
+
+## Post-implementation review gate
+
+No PR is approved on the implementer's `done` alone. Standard patches: in-loop `code-review`
+(correctness) + human owner. Patches touching a high-risk coupling point (below): additionally one
+**out-of-loop** reviewer (`codex exec review` on the diff, or the fresh-Claude fallback).
+PASS = `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh` zero-fail / zero-unexpected-skip
+**and** both reviewers' Critical/Important items resolved or reasoned-rebutted **and** no
+unescalated design/contract fork. Live-DB behavior changes additionally require the operational
+checklist (local-only; see `doc/dev/review_checklist_local_template.md`).
+
+## High-risk coupling points (name these explicitly in the review prompt)
+
+- **`skill_metrics` / `long_forecasts` upsert keys + `horizon_value`** — long-term rows are keyed on
+  a tuple including `date` and `horizon_value`, and **the per-horizon meaning of both fields is subtle
+  and has changed over time** (`date` is an issue date for some horizons, a period-derived date for
+  others; `horizon_value` is a configured lead for some horizons, a sentinel for others). **Verify the
+  current semantics in `sapphire/services/postprocessing/app/models.py` and
+  `apps/postprocessing_forecasts/src/api_writer.py` before changing any key** — mis-keying causes
+  duplicate rows, stale survivors, or dropped leads.
+- **`sapphire_api_client` ↔ `sapphire/services` enum label/value contract** — PostgreSQL stores the
+  enum NAME while the API passes/returns the VALUE (e.g. `NAIVE_MEAN` vs `"Naive Mean"`); a mismatch
+  surfaces as a 422. Verify model-name mapping on both write and read.
+- **Dashboard readers + tombstone / `horizon_value`** — the dashboard read paths
+  (`apps/forecast_dashboard/src/db.py`) and the postprocessing `data_reader` handle `horizon_value`
+  and tombstone (`n_pairs == 0`) rows **differently per horizon and per reader** (some keep
+  `horizon_value`, some drop it; some suppress tombstones). **Verify the specific reader before
+  changing skill/lead keying** — a mismatch makes dashboard tiles silently break.
+- **Hydrograph `round_3sf` actuals** — observed monthly/quarter/season actuals use the shared
+  3-significant-figure discharge rounding (round-of-rounded cascade is deliberate). Do not apply that
+  rounding to forecast outputs, and do not change the cascade. The helper name may differ by branch —
+  verify the current symbol before relying on it.
+- **Live DB / operational verification** — never commit station codes or discharge values; operational
+  DB behavior changes require the local-only verification checklist.
+- **`sapphire/services/` ownership boundary** — colleague-managed. Read and audit, but do not edit;
+  any API-contract change (new endpoint, changed request/response schema) is a discussion first, not
+  a code change.

--- a/doc/plans/README.md
+++ b/doc/plans/README.md
@@ -108,6 +108,7 @@ Use these Claude Code skills to guide the planning process:
 | Implementation | executing-issues | `/executing-issues` | Execute discrete issues with plans |
 | Large Plans | executing-plans | `/executing-plans` | Execute multi-issue architecture work |
 | Deployment | pre-deploy-validation | `/pre-deploy-validation` | Verify before pushing to production |
+| Review | multi-model review + out-of-loop verifier | see [`../dev/agent_review_workflow.md`](../dev/agent_review_workflow.md) | Independent review gates for plans, patches, and high-claim artifacts |
 
 **Start with `/use-skills`** if unsure which skill applies — it includes a workflow decision tree.
 


### PR DESCRIPTION
## Summary
Adds a repo-native **multi-model review + out-of-loop verification** workflow, incorporating
agent-harness learnings and hardened by dogfooding it on the skill-metrics campaign.

- **CLAUDE.md** — new lean `### Multi-Model Review & Verification` subsection: ≥2 independent
  perspectives with ≥1 out-of-loop; implementer "done" = evidence, not approval;
  **open-ended adversarial review is required and distinct from claim-verification** (for plans AND
  diffs); **tests are the definition of done** (full affected-scope `run_tests`, zero fail / zero
  unexpected skip); fitness line + proportionality lens; escalate design forks; related bugs → `gi_draft`.
- **doc/dev/agent_review_workflow.md** (new) — the procedure: adversarial-vs-claim-verification,
  `codex exec` + fresh-Claude prompt templates, verify against `origin/<target>` (not a stale local
  ref), proportionality checklist, implemented-vs-documented, accuracy-vs-fork rule, confirm-fixes
  pass, post-implementation gate, and the repo's high-risk coupling points.
- **doc/plans/README.md** — one Review pointer row (status vocabulary stays owned by README).

Owner decisions baked in: default out-of-loop verifier = `codex exec` (fresh-Claude fallback);
external vision workflows kept as optional accelerators (rule stays repo-native); `requesting-code-review`
skill left as-is for now.

Docs-only; no code paths touched. The workflow validated itself — two verifier rounds on its own draft
caught 4 real errors + a procedure gap (verify against the target branch), all fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
