### PR TITLE
pp lead-aware: guard empty operational schedules (finding #2 robustness)

### DIFF
--- a/apps/postprocessing_forecasts/recalculate_skill_metrics.py
+++ b/apps/postprocessing_forecasts/recalculate_skill_metrics.py
@@ -38,6 +38,7 @@ from long_term_horizon_resolver import (
     seasonal_horizon_value,
     supported_long_term_modes,
 )
+from skill_lead_aware_flag import skill_lead_aware_enabled
 from src import data_reader, file_writer, skill_metrics
 from src import postprocessing_tools as pt
 from src.horizon_config import ShortTermHorizonConfig
@@ -112,6 +113,48 @@ def _supported_seasonal_issue_leads() -> list[int]:
             if lead not in leads:
                 leads.append(lead)
     return leads
+
+
+def _long_term_horizon_supported(horizon_type: str) -> bool:
+    """Whether this long-term horizon ("month"|"quarter"|"season") should be
+    recalculated for this deployment under the lead-aware flag.
+
+    Flag OFF -> always True (preserve legacy behavior, byte-identical).
+    Flag ON  -> True iff the deployment configures >=1 operational mode for the
+    horizon. When ON and no mode is configured, log a warning and return False so
+    the caller SKIPS the block (avoids computing empty skill that would tombstone
+    all stored skill for the horizon). Propagates LongTermHorizonResolverError
+    (fail-loud) when a configured mode's config is incomplete (missing
+    operational_issue_day) -- do NOT swallow it.
+
+    Season note: "supported" for the season horizon is derived from
+    ``_supported_seasonal_issue_leads()`` -- the SAME source the seasonal recalc
+    block reads its leads from (which enumerates only the 4 canonical modes
+    seasonal_january..april) -- rather than the reader's looser ``seasonal_*``
+    match. This keeps the gate consistent with the block's actual reads, so a
+    mis-named seasonal mode cannot open the gate on a horizon the block will read
+    nothing for (which would tombstone all stored season skill). Fail-loud on an
+    incomplete configured mode is still enforced by the reader when a valid lead
+    is read. Month/quarter continue to use the reader's operational schedules.
+    """
+    if not skill_lead_aware_enabled():
+        return True
+    if horizon_type == "season":
+        supported = bool(_supported_seasonal_issue_leads())
+    else:
+        supported = bool(data_reader._operational_schedules_for_horizon_type(horizon_type))
+    if supported:
+        return True
+    logger.warning(
+        "Skipping %s long-term skill recalc under SAPPHIRE_SKILL_LEAD_AWARE: no "
+        "operational '%s' mode configured (check "
+        "ieasyhydroforecast_ml_long_term_supported_modes); existing stored %s "
+        "skill is left intact.",
+        horizon_type,
+        horizon_type,
+        horizon_type,
+    )
+    return False
 
 
 def _read_station_codes(config):
@@ -255,7 +298,7 @@ def recalculate_skill_metrics():
                 codes=codes,
             )
 
-        if prediction_mode in ["MONTHLY", "ALL"]:
+        if prediction_mode in ["MONTHLY", "ALL"] and _long_term_horizon_supported("month"):
             current_year = dt.date.today().year
             start_year = int(
                 os.getenv(
@@ -324,7 +367,7 @@ def recalculate_skill_metrics():
 
             pt.log_most_recent_forecasts_monthly(monthly_joint)
 
-        if prediction_mode in ["QUARTERLY", "ALL"]:
+        if prediction_mode in ["QUARTERLY", "ALL"] and _long_term_horizon_supported("quarter"):
             current_year = dt.date.today().year
             start_year = int(
                 os.getenv(
@@ -393,7 +436,7 @@ def recalculate_skill_metrics():
                     logger.error(f"Error saving quarterly skill metrics: {ret}")
                     errors.append(f"Quarterly skill metrics save failed: {ret}")
 
-        if prediction_mode in ["SEASONAL", "ALL"]:
+        if prediction_mode in ["SEASONAL", "ALL"] and _long_term_horizon_supported("season"):
             current_year = dt.date.today().year
             start_year = int(
                 os.getenv(

--- a/apps/postprocessing_forecasts/src/data_reader.py
+++ b/apps/postprocessing_forecasts/src/data_reader.py
@@ -1371,6 +1371,14 @@ def read_monthly_forecasts(
         # month_N mode missing operational_issue_day) must NOT silently
         # fall back to an unfiltered read that retains backfill rows.
         month_schedules = _operational_schedules_for_horizon_type("month")
+        if lead_aware and not month_schedules:
+            logger.warning(
+                "SAPPHIRE_SKILL_LEAD_AWARE is enabled but no operational month "
+                "schedules are configured (check "
+                "ieasyhydroforecast_ml_long_term_supported_modes); returning no "
+                "operational forecasts."
+            )
+            return empty
         max_lead = max((s.lead_time for s in month_schedules.values()), default=0)
         read_start_year = start_year - _read_window_expansion_years(max_lead)
 
@@ -1543,6 +1551,14 @@ def read_latest_monthly_forecasts(
     if lead_aware:
         # Fail LOUD under flag-ON (no silent fallback to an unfiltered read).
         month_schedules = _operational_schedules_for_horizon_type("month")
+        if lead_aware and not month_schedules:
+            logger.warning(
+                "SAPPHIRE_SKILL_LEAD_AWARE is enabled but no operational month "
+                "schedules are configured (check "
+                "ieasyhydroforecast_ml_long_term_supported_modes); returning no "
+                "operational forecasts."
+            )
+            return pd.DataFrame()
         max_lead = max((s.lead_time for s in month_schedules.values()), default=0)
         read_start_year = start_year - _read_window_expansion_years(max_lead)
 
@@ -3083,6 +3099,14 @@ def read_quarterly_forecasts(
     if lead_aware:
         # Fail LOUD under flag-ON (no silent fallback to an unfiltered read).
         quarter_schedules = _operational_schedules_for_horizon_type("quarter")
+        if lead_aware and not quarter_schedules:
+            logger.warning(
+                "SAPPHIRE_SKILL_LEAD_AWARE is enabled but no operational quarter "
+                "schedules are configured (check "
+                "ieasyhydroforecast_ml_long_term_supported_modes); returning no "
+                "operational forecasts."
+            )
+            return pd.DataFrame(columns=empty_cols)
         max_lead = max((s.lead_time for s in quarter_schedules.values()), default=0)
         q_start_year = start_year - _read_window_expansion_years(max_lead)
 
@@ -3210,11 +3234,20 @@ def read_seasonal_forecasts(
         else:
             candidate_schedules = all_season_schedules
 
-        if candidate_schedules:
-            season_schedules = candidate_schedules
-            max_lead = max(s.lead_time for s in season_schedules.values())
-            read_start_year = start_year - _read_window_expansion_years(max_lead)
-            read_horizon_value = None
+        if not candidate_schedules:
+            logger.warning(
+                "SAPPHIRE_SKILL_LEAD_AWARE is enabled but no operational season "
+                "schedules are configured for this read (no seasonal modes "
+                "configured, or no seasonal mode at the requested lead; check "
+                "ieasyhydroforecast_ml_long_term_supported_modes); returning no "
+                "operational forecasts."
+            )
+            return empty
+
+        season_schedules = candidate_schedules
+        max_lead = max(s.lead_time for s in season_schedules.values())
+        read_start_year = start_year - _read_window_expansion_years(max_lead)
+        read_horizon_value = None
 
     raw = _read_long_forecasts_api(
         codes,
@@ -3342,6 +3375,14 @@ def read_latest_quarterly_forecasts(
     if lead_aware:
         # Fail LOUD under flag-ON (no silent fallback to an unfiltered read).
         quarter_schedules = _operational_schedules_for_horizon_type("quarter")
+        if lead_aware and not quarter_schedules:
+            logger.warning(
+                "SAPPHIRE_SKILL_LEAD_AWARE is enabled but no operational quarter "
+                "schedules are configured (check "
+                "ieasyhydroforecast_ml_long_term_supported_modes); returning no "
+                "operational forecasts."
+            )
+            return pd.DataFrame(columns=_QUARTERLY_FC_COLS)
         max_lead = max((s.lead_time for s in quarter_schedules.values()), default=0)
         q_start_year = start_year - _read_window_expansion_years(max_lead)
 
@@ -3472,11 +3513,20 @@ def read_latest_seasonal_forecasts(
         else:
             candidate_schedules = all_season_schedules
 
-        if candidate_schedules:
-            season_schedules = candidate_schedules
-            max_lead = max(s.lead_time for s in season_schedules.values())
-            read_start_year = start_year - _read_window_expansion_years(max_lead)
-            read_horizon_value = None
+        if not candidate_schedules:
+            logger.warning(
+                "SAPPHIRE_SKILL_LEAD_AWARE is enabled but no operational season "
+                "schedules are configured for this read (no seasonal modes "
+                "configured, or no seasonal mode at the requested lead; check "
+                "ieasyhydroforecast_ml_long_term_supported_modes); returning no "
+                "operational forecasts."
+            )
+            return pd.DataFrame(columns=_SEASONAL_FC_COLS)
+
+        season_schedules = candidate_schedules
+        max_lead = max(s.lead_time for s in season_schedules.values())
+        read_start_year = start_year - _read_window_expansion_years(max_lead)
+        read_horizon_value = None
 
     raw = _read_long_forecasts_api(
         codes,

--- a/apps/postprocessing_forecasts/src/file_writer.py
+++ b/apps/postprocessing_forecasts/src/file_writer.py
@@ -356,6 +356,10 @@ def save_monthly_skill_metrics(data: pd.DataFrame, year: int = None):
     Returns:
         None
     """
+    if data is None or data.empty:
+        logger.info("No monthly skill metrics to save")
+        return None
+
     data = data.round(4)
 
     if "code" in data.columns:

--- a/apps/postprocessing_forecasts/tests/test_file_writer.py
+++ b/apps/postprocessing_forecasts/tests/test_file_writer.py
@@ -286,11 +286,12 @@ class TestSaveMonthlySkillMetrics:
         em_row = saved[saved["model_short"] == "EM"].iloc[0]
         assert em_row["composition"] == "GBT, LR_Base"
 
-    def test_empty_dataframe_handled(self):
-        """Empty DataFrame doesn't crash save_monthly_skill_metrics.
+    def test_empty_dataframe_guarded_no_write(self):
+        """Empty DataFrame is guarded: returns None and does NOT touch the CSV.
 
-        An empty DataFrame with correct columns should produce a valid
-        (empty) CSV file without raising on .astype(int).
+        Mirrors save_quarterly/seasonal_skill_metrics. A transient empty read
+        must not overwrite an existing monthly skill CSV empty (data loss).
+        The guard returns before any CSV or API write is attempted.
         """
         data = pd.DataFrame(
             {
@@ -306,13 +307,83 @@ class TestSaveMonthlySkillMetrics:
                 "crps": pd.Series([], dtype=float),
             }
         )
+        csv_path = os.path.join(str(self.tmp_path), "skill_monthly.csv")
+        with (
+            patch.object(api_writer, "SAPPHIRE_API_AVAILABLE", False),
+            patch("src.file_writer.atomic_write_csv") as mock_write,
+        ):
+            result = file_writer.save_monthly_skill_metrics(data)
+
+        assert result is None
+        mock_write.assert_not_called()
+        # No CSV created by the guarded call.
+        assert not os.path.exists(csv_path)
+
+    def test_empty_dataframe_preserves_existing_csv(self):
+        """A transient empty frame leaves a previously-written CSV intact."""
+        csv_path = os.path.join(str(self.tmp_path), "skill_monthly.csv")
+        # Pre-existing good CSV on disk.
+        good = pd.DataFrame(
+            {
+                "month_in_year": [6],
+                "code": ["19999"],
+                "model_short": ["GBT"],
+                "sdivsigma": [0.3],
+                "nse": [0.9],
+                "delta": [5.0],
+                "accuracy": [0.9],
+                "mae": [2.0],
+                "n_pairs": [10],
+                "crps": [12.0],
+            }
+        )
+        good.to_csv(csv_path, index=False)
+
+        empty = pd.DataFrame(
+            {
+                "month_in_year": pd.Series([], dtype=float),
+                "code": pd.Series([], dtype=str),
+                "model_short": pd.Series([], dtype=str),
+                "sdivsigma": pd.Series([], dtype=float),
+                "nse": pd.Series([], dtype=float),
+                "delta": pd.Series([], dtype=float),
+                "accuracy": pd.Series([], dtype=float),
+                "mae": pd.Series([], dtype=float),
+                "n_pairs": pd.Series([], dtype=float),
+                "crps": pd.Series([], dtype=float),
+            }
+        )
+        with patch.object(api_writer, "SAPPHIRE_API_AVAILABLE", False):
+            file_writer.save_monthly_skill_metrics(empty)
+
+        saved = pd.read_csv(csv_path, dtype={"code": str})
+        assert len(saved) == 1
+        assert saved.iloc[0]["code"] == "19999"
+
+    def test_nonempty_dataframe_still_writes(self):
+        """Non-empty frame still writes the CSV (guard does not regress the
+        happy path)."""
+        data = pd.DataFrame(
+            {
+                "month_in_year": [1],
+                "code": ["19999"],
+                "model_short": ["GBT"],
+                "sdivsigma": [0.3],
+                "nse": [0.9],
+                "delta": [5.0],
+                "accuracy": [0.9],
+                "mae": [2.0],
+                "n_pairs": [10],
+                "crps": [12.0],
+            }
+        )
         with patch.object(api_writer, "SAPPHIRE_API_AVAILABLE", False):
             file_writer.save_monthly_skill_metrics(data)
 
         csv_path = os.path.join(str(self.tmp_path), "skill_monthly.csv")
         assert os.path.exists(csv_path)
-        saved = pd.read_csv(csv_path)
-        assert len(saved) == 0
+        saved = pd.read_csv(csv_path, dtype={"code": str})
+        assert len(saved) == 1
 
     def test_crps_nan_written_to_csv(self, monthly_skill_data):
         """NaN CRPS values (from EM/Naive Mean) are written to CSV.

--- a/apps/postprocessing_forecasts/tests/test_lead_aware_empty_schedules.py
+++ b/apps/postprocessing_forecasts/tests/test_lead_aware_empty_schedules.py
@@ -1,0 +1,421 @@
+"""Tests for the flag-ON empty-operational-schedules robustness guard
+(finding #2).
+
+The long-term readers resolve per-horizon operational schedules via
+`_operational_schedules_for_horizon_type(htype)`, which returns an EMPTY
+dict when the deployment's ``ieasyhydroforecast_ml_long_term_supported_modes``
+contains NO mode for that horizon (a typo, or only a legacy/other-horizon
+mode). Previously the readers guarded selection with
+``if lead_aware and <schedules>:`` -- an empty dict is falsy, so under
+flag-ON the operational-issuance selector was SILENTLY SKIPPED and the
+reader returned UNFILTERED rows (non-operational re-issues / backfills
+leaking in), or -- for the quarterly readers -- crashed on
+``quarter_horizon_value()``.
+
+These tests lock the fix: under flag-ON, if a horizon's resolved
+operational-schedules dict is EMPTY, the reader logs a clear WARNING and
+returns its own established empty shape (no unfiltered rows, no crash).
+Flag-OFF behavior is unchanged (schedules are never resolved, rows are
+returned unfiltered as before).
+
+NOTE: this is distinct from the "fail loud" contract (a mode config
+missing ``operational_issue_day`` still RAISES during resolution, BEFORE
+the empty guard is reached -- see
+``test_lead_aware_operational_issuance_wiring.py`` /
+``test_lead_aware_latest_readers.py``). "No schedules configured" is a
+legitimate deployment state (a deployment may not run a given horizon);
+"schedule present but malformed" is a misconfiguration that must crash.
+"""
+
+import datetime as dt
+import json
+import logging
+import os
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "iEasyHydroForecast"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src import data_reader
+
+CODE = "19999"
+LOGGER_NAME = "src.data_reader"
+
+
+def _write_mode_config(config_dir, mode, lead, issue_day=None):
+    payload = {"operational_month_lead_time": lead}
+    if issue_day is not None:
+        payload["operational_issue_day"] = issue_day
+    (config_dir / f"{mode}.json").write_text(json.dumps(payload))
+
+
+def _set_long_term_env(monkeypatch, tmp_path, modes):
+    monkeypatch.setenv("ieasyforecast_configuration_path", str(tmp_path))
+    monkeypatch.setenv("ieasyhydroforecast_ml_long_term_configuration", "long_term")
+    monkeypatch.setenv("ieasyhydroforecast_ml_long_term_supported_modes", ",".join(modes))
+
+
+def _month_row(code, year, month, issue_date, model="LR_Base", horizon_value=99, q50=100.0):
+    valid_from = f"{year}-{month:02d}-01"
+    return {
+        "horizon_type": "month",
+        "horizon_value": horizon_value,
+        "code": code,
+        "date": issue_date,
+        "model_type": model,
+        "valid_from": valid_from,
+        "valid_to": valid_from,
+        "q50": q50,
+        "q05": q50 - 30.0,
+        "q10": q50 - 25.0,
+        "q25": q50 - 15.0,
+        "q75": q50 + 15.0,
+        "q90": q50 + 25.0,
+        "q95": q50 + 30.0,
+        "id": 1,
+        "model_type_description": model,
+    }
+
+
+def _season_row(code, valid_from, issue_date, model="LR_Base", horizon_value=0, q50=100.0):
+    return {
+        "horizon_type": "season",
+        "horizon_value": horizon_value,
+        "code": code,
+        "date": issue_date,
+        "model_type": model,
+        "valid_from": valid_from,
+        "valid_to": valid_from,
+        "q50": q50,
+        "q05": q50 - 30.0,
+        "q10": q50 - 25.0,
+        "q25": q50 - 15.0,
+        "q75": q50 + 15.0,
+        "q90": q50 + 25.0,
+        "q95": q50 + 30.0,
+        "id": 1,
+        "model_type_description": model,
+    }
+
+
+def _has_empty_schedules_warning(caplog):
+    return any(
+        "no operational" in r.getMessage().lower()
+        and "ieasyhydroforecast_ml_long_term_supported_modes" in r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
+
+# ---------------------------------------------------------------------------
+# Site 1 -- read_monthly_forecasts
+# ---------------------------------------------------------------------------
+
+
+class TestMonthlyEmptySchedulesFlagOn:
+    """Flag ON, no month mode configured (only 'quarter'): the month
+    schedules dict is empty -> warn + return empty, never an unfiltered read.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _config(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "long_term"
+        config_dir.mkdir()
+        # Only a quarter mode -> NO month_N mode -> month schedules empty.
+        _set_long_term_env(monkeypatch, tmp_path, ["quarter"])
+        _write_mode_config(config_dir, "quarter", lead=1, issue_day=25)
+        monkeypatch.setenv("SAPPHIRE_SKILL_LEAD_AWARE", "true")
+
+    def test_warns_returns_empty_and_does_not_read_api(self, caplog):
+        rows = [
+            _month_row(CODE, 2024, 6, "2024-05-25", q50=111.0),
+            _month_row(CODE, 2024, 6, "2024-05-10", q50=999.0),  # would leak pre-fix
+        ]
+
+        def fake_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
+            return pd.DataFrame(rows)
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            with patch(
+                "src.data_reader._read_long_forecasts_api", side_effect=fake_api
+            ) as mock_api:
+                result = data_reader.read_monthly_forecasts([CODE], 2024, 2024)
+
+        assert result.empty
+        assert 999.0 not in set(result.get("q50", pd.Series(dtype=float)).astype(float))
+        mock_api.assert_not_called()
+        assert _has_empty_schedules_warning(caplog)
+
+
+# ---------------------------------------------------------------------------
+# Site 2 -- read_latest_monthly_forecasts
+# ---------------------------------------------------------------------------
+
+
+class TestLatestMonthlyEmptySchedulesFlagOn:
+    @pytest.fixture(autouse=True)
+    def _config(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "long_term"
+        config_dir.mkdir()
+        _set_long_term_env(monkeypatch, tmp_path, ["quarter"])
+        _write_mode_config(config_dir, "quarter", lead=1, issue_day=25)
+        monkeypatch.setenv("SAPPHIRE_SKILL_LEAD_AWARE", "true")
+
+    def test_warns_returns_empty_and_does_not_read_api(self, caplog):
+        rows = [
+            _month_row(CODE, 2024, 6, "2024-05-25", q50=111.0),
+            _month_row(CODE, 2024, 6, "2024-05-10", q50=999.0),
+        ]
+
+        def fake_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
+            return pd.DataFrame(rows)
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            with patch(
+                "src.data_reader._read_long_forecasts_api", side_effect=fake_api
+            ) as mock_api:
+                result = data_reader.read_latest_monthly_forecasts(
+                    [CODE], forecast_date=dt.date(2024, 6, 30)
+                )
+
+        assert result.empty
+        mock_api.assert_not_called()
+        assert _has_empty_schedules_warning(caplog)
+
+
+# ---------------------------------------------------------------------------
+# Site 3 -- read_quarterly_forecasts
+# (pre-fix: quarter_horizon_value() RAISES for an unsupported mode; fixed:
+#  warn + empty)
+# ---------------------------------------------------------------------------
+
+
+class TestQuarterlyEmptySchedulesFlagOn:
+    @pytest.fixture(autouse=True)
+    def _config(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "long_term"
+        config_dir.mkdir()
+        # A month mode (so Source-1 monthly resolves fine) but NO quarter mode.
+        _set_long_term_env(monkeypatch, tmp_path, ["month_0"])
+        _write_mode_config(config_dir, "month_0", lead=0, issue_day=25)
+        monkeypatch.setenv("SAPPHIRE_SKILL_LEAD_AWARE", "true")
+
+    def test_warns_returns_empty_no_crash(self, caplog):
+        # Source-1 monthly returns data; the quarter guard must still discard
+        # everything (no quarter schedule => no operational quarterly output).
+        month_rows = [_month_row(CODE, 2024, 6, "2024-06-25", q50=111.0)]
+
+        def fake_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
+            if horizon_type == "month":
+                return pd.DataFrame(month_rows)
+            return pd.DataFrame()
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            with patch("src.data_reader._read_long_forecasts_api", side_effect=fake_api):
+                result = data_reader.read_quarterly_forecasts([CODE], 2024, 2024)
+
+        assert result.empty
+        assert _has_empty_schedules_warning(caplog)
+
+
+# ---------------------------------------------------------------------------
+# Site 4 -- read_latest_quarterly_forecasts
+# ---------------------------------------------------------------------------
+
+
+class TestLatestQuarterlyEmptySchedulesFlagOn:
+    @pytest.fixture(autouse=True)
+    def _config(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "long_term"
+        config_dir.mkdir()
+        _set_long_term_env(monkeypatch, tmp_path, ["month_0"])
+        _write_mode_config(config_dir, "month_0", lead=0, issue_day=25)
+        monkeypatch.setenv("SAPPHIRE_SKILL_LEAD_AWARE", "true")
+
+    def test_warns_returns_empty_no_crash(self, caplog):
+        month_rows = [_month_row(CODE, 2024, 6, "2024-06-25", q50=111.0)]
+
+        def fake_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
+            if horizon_type == "month":
+                return pd.DataFrame(month_rows)
+            return pd.DataFrame()
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            with patch("src.data_reader._read_long_forecasts_api", side_effect=fake_api):
+                result = data_reader.read_latest_quarterly_forecasts(
+                    [CODE], forecast_date=dt.date(2024, 6, 30)
+                )
+
+        assert result.empty
+        assert _has_empty_schedules_warning(caplog)
+
+
+# ---------------------------------------------------------------------------
+# Site 5 -- read_seasonal_forecasts
+# ---------------------------------------------------------------------------
+
+
+class TestSeasonalNoSeasonModeFlagOn:
+    """Flag ON, no seasonal mode configured at all -> warn + empty."""
+
+    @pytest.fixture(autouse=True)
+    def _config(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "long_term"
+        config_dir.mkdir()
+        _set_long_term_env(monkeypatch, tmp_path, ["quarter"])
+        _write_mode_config(config_dir, "quarter", lead=1, issue_day=25)
+        monkeypatch.setenv("SAPPHIRE_SKILL_LEAD_AWARE", "true")
+
+    def test_warns_returns_empty_no_unfiltered_leak(self, caplog):
+        rows = [
+            _season_row(CODE, "2024-04-01", "2024-04-25", q50=111.0),
+            _season_row(CODE, "2024-04-01", "2024-04-10", q50=999.0),  # would leak pre-fix
+        ]
+
+        def fake_api(codes, start_year, end_year, horizon_type="season", horizon_value=None):
+            return pd.DataFrame(rows)
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            with patch("src.data_reader._read_long_forecasts_api", side_effect=fake_api):
+                result = data_reader.read_seasonal_forecasts([CODE], 2024, 2024)
+
+        assert result.empty
+        assert 999.0 not in set(result.get("q50", pd.Series(dtype=float)).astype(float))
+        assert _has_empty_schedules_warning(caplog)
+
+
+class TestSeasonalNoModeAtRequestedLeadFlagOn:
+    """Flag ON, a seasonal mode exists but NOT at the requested lead ->
+    candidate schedules empty -> warn + empty (covers the horizon_value branch).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _config(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "long_term"
+        config_dir.mkdir()
+        _set_long_term_env(monkeypatch, tmp_path, ["seasonal_april"])
+        _write_mode_config(config_dir, "seasonal_april", lead=0, issue_day=25)
+        monkeypatch.setenv("SAPPHIRE_SKILL_LEAD_AWARE", "true")
+
+    def test_warns_returns_empty_for_absent_lead(self, caplog):
+        rows = [
+            _season_row(CODE, "2024-04-01", "2024-04-25", horizon_value=3, q50=111.0),
+            _season_row(CODE, "2024-04-01", "2024-04-10", horizon_value=3, q50=999.0),
+        ]
+
+        def fake_api(codes, start_year, end_year, horizon_type="season", horizon_value=None):
+            return pd.DataFrame(rows)
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            with patch("src.data_reader._read_long_forecasts_api", side_effect=fake_api):
+                # Requested lead 3, but only seasonal_april (lead 0) is configured.
+                result = data_reader.read_seasonal_forecasts([CODE], 2024, 2024, horizon_value=3)
+
+        assert result.empty
+        assert _has_empty_schedules_warning(caplog)
+
+
+# ---------------------------------------------------------------------------
+# Site 6 -- read_latest_seasonal_forecasts
+# ---------------------------------------------------------------------------
+
+
+class TestLatestSeasonalNoSeasonModeFlagOn:
+    @pytest.fixture(autouse=True)
+    def _config(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "long_term"
+        config_dir.mkdir()
+        _set_long_term_env(monkeypatch, tmp_path, ["quarter"])
+        _write_mode_config(config_dir, "quarter", lead=1, issue_day=25)
+        monkeypatch.setenv("SAPPHIRE_SKILL_LEAD_AWARE", "true")
+
+    def test_warns_returns_empty_no_unfiltered_leak(self, caplog):
+        rows = [
+            _season_row(CODE, "2024-04-01", "2024-04-25", q50=111.0),
+            _season_row(CODE, "2024-04-01", "2024-04-10", q50=999.0),
+        ]
+
+        def fake_api(codes, start_year, end_year, horizon_type="season", horizon_value=None):
+            return pd.DataFrame(rows)
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            with patch("src.data_reader._read_long_forecasts_api", side_effect=fake_api):
+                result = data_reader.read_latest_seasonal_forecasts(
+                    [CODE], forecast_date=dt.date(2024, 4, 30)
+                )
+
+        assert result.empty
+        assert 999.0 not in set(result.get("q50", pd.Series(dtype=float)).astype(float))
+        assert _has_empty_schedules_warning(caplog)
+
+
+# ---------------------------------------------------------------------------
+# Flag OFF byte-identity: no month mode configured, flag OFF -> schedules
+# are NEVER resolved and the rows are returned unfiltered exactly as before
+# (the new guard MUST NOT trigger under flag OFF).
+# ---------------------------------------------------------------------------
+
+
+class TestSeasonalEmptySchedulesFlagOffUnchanged:
+    @pytest.fixture(autouse=True)
+    def _config(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "long_term"
+        config_dir.mkdir()
+        # No seasonal mode configured -- but flag OFF must ignore this entirely.
+        _set_long_term_env(monkeypatch, tmp_path, ["quarter"])
+        _write_mode_config(config_dir, "quarter", lead=1, issue_day=25)
+        monkeypatch.delenv("SAPPHIRE_SKILL_LEAD_AWARE", raising=False)
+
+    def test_flag_off_returns_unfiltered_and_never_resolves_schedules(self):
+        rows = [
+            _season_row(CODE, "2024-04-01", "2024-04-25", q50=111.0),
+            _season_row(CODE, "2024-04-01", "2024-04-10", q50=999.0),
+        ]
+
+        def fake_api(codes, start_year, end_year, horizon_type="season", horizon_value=None):
+            return pd.DataFrame(rows)
+
+        with (
+            patch("src.data_reader._read_long_forecasts_api", side_effect=fake_api),
+            patch.object(data_reader, "_operational_schedules_for_horizon_type") as mock_resolve,
+        ):
+            result = data_reader.read_seasonal_forecasts([CODE], 2024, 2024)
+
+        # Flag OFF must never resolve schedules and must keep the unfiltered rows.
+        mock_resolve.assert_not_called()
+        assert not result.empty
+        assert 999.0 in set(result["q50"].astype(float))
+
+
+class TestMonthlyEmptySchedulesFlagOffUnchanged:
+    @pytest.fixture(autouse=True)
+    def _config(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "long_term"
+        config_dir.mkdir()
+        _set_long_term_env(monkeypatch, tmp_path, ["quarter"])
+        _write_mode_config(config_dir, "quarter", lead=1, issue_day=25)
+        monkeypatch.delenv("SAPPHIRE_SKILL_LEAD_AWARE", raising=False)
+
+    def test_flag_off_returns_unfiltered_and_never_resolves_schedules(self):
+        rows = [
+            _month_row(CODE, 2024, 6, "2024-05-25", horizon_value=1, q50=111.0),
+            _month_row(CODE, 2024, 6, "2024-05-10", horizon_value=1, q50=999.0),
+        ]
+
+        def fake_api(codes, start_year, end_year, horizon_type="month", horizon_value=None):
+            return pd.DataFrame(rows)
+
+        with (
+            patch("src.data_reader._read_long_forecasts_api", side_effect=fake_api) as mock_api,
+            patch.object(data_reader, "_operational_schedules_for_horizon_type") as mock_resolve,
+        ):
+            result = data_reader.read_monthly_forecasts([CODE], 2024, 2024)
+
+        mock_resolve.assert_not_called()
+        assert mock_api.call_args.args[1] == 2024  # read window not expanded
+        assert not result.empty
+        assert 999.0 in set(result["q50"].astype(float))

--- a/apps/postprocessing_forecasts/tests/test_recalc_supported_modes_gate.py
+++ b/apps/postprocessing_forecasts/tests/test_recalc_supported_modes_gate.py
@@ -1,0 +1,235 @@
+"""Tests for the supported-modes recalc gate (finding #2).
+
+`recalculate_skill_metrics.py` gates each long-term horizon block on
+`prediction_mode` AND, under SAPPHIRE_SKILL_LEAD_AWARE, on whether the
+deployment actually configures an operational mode for that horizon
+(`_long_term_horizon_supported`).
+
+Rationale: the long-term readers warn+return EMPTY when a horizon has no
+configured operational schedules under the flag. Without this gate, the
+block would still read (empty) -> compute empty skill ->
+`build_stale_tombstones(existing, empty, ...)` would tombstone (n_pairs=0)
+ALL of that horizon's stored skill, and `save_*_skill_metrics` would
+overwrite the skill CSV empty -> data loss on a misconfig.
+
+The gate:
+  * Flag OFF  -> always True (byte-identical legacy behavior).
+  * Flag ON + >=1 mode configured for the horizon -> True.
+  * Flag ON + no mode configured -> WARNING + False -> block skipped
+    (no read, no calc, no tombstone, no save).
+  * Flag ON + a configured mode's config is incomplete -> the underlying
+    LongTermHorizonResolverError PROPAGATES (fail-loud, not swallowed).
+
+Note: a SUPPORTED horizon whose groups all fall below min-n still emits
+empty and tombstones as before -- the gate only skips UNSUPPORTED horizons.
+"""
+
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+SCRIPT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "iEasyHydroForecast"))
+sys.path.insert(0, SCRIPT_DIR)
+
+import recalculate_skill_metrics as recalc  # noqa: E402  (path set above)
+from long_term_horizon_resolver import LongTermHorizonResolverError
+
+# Reuse the established recalc-driver mocks/harness from the sibling test file.
+from tests.test_recalc_workflow import (
+    _setup_mocks,
+    import_recalc_module,
+)
+
+WARNING_NEEDLE_A = "no operational"
+WARNING_NEEDLE_B = "ieasyhydroforecast_ml_long_term_supported_modes"
+
+
+def _has_skip_warning(caplog):
+    return any(
+        WARNING_NEEDLE_A in r.getMessage().lower() and WARNING_NEEDLE_B in r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _long_term_horizon_supported (direct)
+# ---------------------------------------------------------------------------
+
+
+class TestLongTermHorizonSupportedHelper:
+    def test_flag_off_true_even_when_schedules_empty(self, monkeypatch):
+        """Flag OFF -> always True; schedules resolver must not even be consulted."""
+        monkeypatch.setattr(recalc, "skill_lead_aware_enabled", lambda: False)
+        mock_dr = MagicMock()
+        monkeypatch.setattr(recalc, "data_reader", mock_dr)
+
+        assert recalc._long_term_horizon_supported("month") is True
+        # Flag OFF short-circuits before touching the resolver.
+        mock_dr._operational_schedules_for_horizon_type.assert_not_called()
+
+    def test_flag_on_nonempty_schedules_true(self, monkeypatch):
+        monkeypatch.setattr(recalc, "skill_lead_aware_enabled", lambda: True)
+        mock_dr = MagicMock()
+        mock_dr._operational_schedules_for_horizon_type.return_value = {"quarter": object()}
+        monkeypatch.setattr(recalc, "data_reader", mock_dr)
+
+        assert recalc._long_term_horizon_supported("quarter") is True
+        mock_dr._operational_schedules_for_horizon_type.assert_called_once_with("quarter")
+
+    def test_flag_on_empty_schedules_false_and_warns(self, monkeypatch, caplog):
+        # month/quarter branch: driven by the reader's operational schedules.
+        monkeypatch.setattr(recalc, "skill_lead_aware_enabled", lambda: True)
+        mock_dr = MagicMock()
+        mock_dr._operational_schedules_for_horizon_type.return_value = {}
+        monkeypatch.setattr(recalc, "data_reader", mock_dr)
+
+        with caplog.at_level(logging.WARNING):
+            result = recalc._long_term_horizon_supported("month")
+
+        assert result is False
+        assert _has_skip_warning(caplog)
+
+    def test_flag_on_resolver_error_propagates(self, monkeypatch):
+        """A configured-but-malformed mode raises during resolution; the
+        helper must NOT swallow it (fail-loud contract)."""
+        monkeypatch.setattr(recalc, "skill_lead_aware_enabled", lambda: True)
+        mock_dr = MagicMock()
+        mock_dr._operational_schedules_for_horizon_type.side_effect = LongTermHorizonResolverError(
+            "month_0 missing operational_issue_day"
+        )
+        monkeypatch.setattr(recalc, "data_reader", mock_dr)
+
+        with pytest.raises(LongTermHorizonResolverError, match="operational_issue_day"):
+            recalc._long_term_horizon_supported("month")
+
+
+class TestSeasonHorizonSupportedHelper:
+    """Season gate consistency (fix 5b): the season branch is driven by
+    ``_supported_seasonal_issue_leads()`` -- the SAME source the seasonal
+    recalc block reads -- NOT the reader's looser ``seasonal_*`` schedule
+    match. This prevents a mis-named seasonal mode from opening the gate on a
+    horizon the block reads nothing for (which would tombstone stored skill).
+    """
+
+    def test_season_flag_off_true(self, monkeypatch):
+        """Flag OFF -> always True, even with no seasonal issue leads."""
+        monkeypatch.setattr(recalc, "skill_lead_aware_enabled", lambda: False)
+        monkeypatch.setattr(recalc, "_supported_seasonal_issue_leads", lambda: [])
+        assert recalc._long_term_horizon_supported("season") is True
+
+    def test_season_flag_on_issue_leads_nonempty_true(self, monkeypatch):
+        """Flag ON + >=1 seasonal issue lead -> True. The reader's schedule
+        match is NOT consulted for season (gate relies on the issue-leads
+        helper, not the loose seasonal_* match)."""
+        monkeypatch.setattr(recalc, "skill_lead_aware_enabled", lambda: True)
+        monkeypatch.setattr(recalc, "_supported_seasonal_issue_leads", lambda: [3])
+        mock_dr = MagicMock()
+        # Deliberately empty: were the gate still using this, it would return False.
+        mock_dr._operational_schedules_for_horizon_type.return_value = {}
+        monkeypatch.setattr(recalc, "data_reader", mock_dr)
+
+        assert recalc._long_term_horizon_supported("season") is True
+        mock_dr._operational_schedules_for_horizon_type.assert_not_called()
+
+    def test_season_flag_on_issue_leads_empty_false_and_warns(self, monkeypatch, caplog):
+        """Flag ON + no seasonal issue lead -> False + WARNING, EVEN WHEN the
+        reader's loose seasonal_* schedule match WOULD have returned non-empty.
+        Proves the gate now relies on the issue-leads helper, not that match."""
+        monkeypatch.setattr(recalc, "skill_lead_aware_enabled", lambda: True)
+        monkeypatch.setattr(recalc, "_supported_seasonal_issue_leads", lambda: [])
+        mock_dr = MagicMock()
+        # Non-empty: a mis-named seasonal_* mode the block would read nothing for.
+        mock_dr._operational_schedules_for_horizon_type.return_value = {"season": object()}
+        monkeypatch.setattr(recalc, "data_reader", mock_dr)
+
+        with caplog.at_level(logging.WARNING):
+            result = recalc._long_term_horizon_supported("season")
+
+        assert result is False
+        assert _has_skip_warning(caplog)
+        mock_dr._operational_schedules_for_horizon_type.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Integration: the gate actually SKIPS / REACHES the quarterly block
+# (seam = data_reader.read_quarterly_forecasts + build_stale_tombstones)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _mock_data():
+    return pd.DataFrame(
+        {
+            "code": ["19999"],
+            "date": pd.to_datetime(["2024-01-05"]),
+            "forecasted_discharge": [100.0],
+        }
+    )
+
+
+@pytest.fixture
+def _mock_skill():
+    return pd.DataFrame({"pentad_in_year": [1], "code": ["19999"], "sdivsigma": [0.3]})
+
+
+def _run_quarterly(env, schedules_return, mock_data, mock_skill):
+    """Drive recalc in QUARTERLY mode with the given env + resolver return,
+    returning the data_reader/file_writer mocks and the imported module."""
+    with patch.dict(os.environ, {"SAPPHIRE_PREDICTION_MODE": "QUARTERLY", **env}):
+        with patch.dict(sys.modules, {}):
+            mocks = _setup_mocks(mock_data, mock_skill)
+            mocks[
+                "data_reader"
+            ]._operational_schedules_for_horizon_type.return_value = schedules_return
+
+            module, spec = import_recalc_module()
+            spec.loader.exec_module(module)
+            module._read_station_codes = MagicMock(return_value=["19999"])
+
+            with pytest.raises(SystemExit) as exc_info:
+                module.recalculate_skill_metrics()
+
+            return exc_info.value.code, mocks, module
+
+
+class TestQuarterlyBlockGate:
+    def test_flag_on_no_quarter_mode_skips_block(self, _mock_data, _mock_skill):
+        """Flag ON + empty quarter schedules -> block skipped: no read, no
+        tombstone (which would zero out stored quarterly skill)."""
+        code, mocks, module = _run_quarterly(
+            {"SAPPHIRE_SKILL_LEAD_AWARE": "true"}, {}, _mock_data, _mock_skill
+        )
+        assert code == 0
+        # Block skipped entirely: no read, no calc, no tombstone, no save.
+        # (read_quarterly_forecasts is the block's entry read; build_stale_tombstones
+        #  and save_quarterly_skill_metrics are only reachable after it.)
+        mocks["data_reader"].read_quarterly_forecasts.assert_not_called()
+        mocks["data_reader"].read_quarterly_observations.assert_not_called()
+        mocks["skill_metrics"].calculate_quarterly_skill_metrics.assert_not_called()
+        mocks["file_writer"].save_quarterly_skill_metrics.assert_not_called()
+
+    def test_flag_on_quarter_mode_reaches_block(self, _mock_data, _mock_skill):
+        """Flag ON + a configured quarter mode -> block runs (reads happen)."""
+        code, mocks, module = _run_quarterly(
+            {"SAPPHIRE_SKILL_LEAD_AWARE": "true"},
+            {"quarter": object()},
+            _mock_data,
+            _mock_skill,
+        )
+        assert code == 0
+        mocks["data_reader"].read_quarterly_forecasts.assert_called_once()
+
+    def test_flag_off_runs_block_unchanged(self, _mock_data, _mock_skill):
+        """Flag OFF -> gate is a no-op, block runs regardless of schedules
+        (byte-identical to legacy)."""
+        code, mocks, module = _run_quarterly({}, {}, _mock_data, _mock_skill)
+        assert code == 0
+        mocks["data_reader"].read_quarterly_forecasts.assert_called_once()
+        # Flag OFF must not even consult the resolver.
+        mocks["data_reader"]._operational_schedules_for_horizon_type.assert_not_called()


### PR DESCRIPTION
## Summary

Robustness follow-up to the lead-aware skill/ensemble feature (PR #414, `SAPPHIRE_SKILL_LEAD_AWARE`, default OFF). Closes an audit finding ("#2"): under flag-ON, if a deployment's `ieasyhydroforecast_ml_long_term_supported_modes` has **no modes for a horizon** (typo / stale migration), the long-term readers silently returned **unfiltered** rows and the recalc could then **tombstone all stored skill** for that horizon (n_pairs=0) — silent data loss. Flag stays default OFF, so trunk behavior is unchanged.

## What changed

**Part A — readers (`data_reader.py`):** the six long-term readers now WARN + return their empty shape when the horizon's operational schedules are empty under flag-ON (instead of silently returning unfiltered rows). Flag-OFF byte-identical (guards live inside the existing `if lead_aware:` blocks). Defense-in-depth that also covers the operational `read_latest_*` callers (empty merges harmlessly there).

**Part B — recalc gate (`recalculate_skill_metrics.py`) — the root fix:** the recalc ran each long-term block gated only on `prediction_mode`, not on whether the horizon is a supported mode. New helper `_long_term_horizon_supported(htype)` folded into each block condition:
- Flag OFF → `True` (resolver not consulted → byte-identical).
- Flag ON → skip the block (with a warning) when the horizon has no configured operational mode, so **nothing is read/computed/tombstoned/saved** for it.

This kills the misconfig blast radius at the root **while preserving** the deliberate empty-emitted → tombstone behavior for *supported* horizons (e.g. all groups below the min-n gate). Fail-loud on an incomplete configured mode (missing `operational_issue_day`) is preserved. The season branch derives "supported" from `_supported_seasonal_issue_leads()` — the same source the seasonal block reads — so a mis-named seasonal mode can't open the gate on a horizon that reads nothing.

**Also:** `save_monthly_skill_metrics` now guards an empty frame (quarter/season already did), so a transient empty read can't overwrite the monthly skill CSV empty.

## Review notes

Developed through an adversarial `codex` review cycle. A blanket empty-emitted guard in `build_stale_tombstones` was tried and **reverted** — it also suppressed *legitimate* invalidation (reversing a deliberate PR #414 behavior) and left the monthly-CSV hole; the recalc gate is the correct layer. Final review confirmed: misconfig neutralized (no read/calc/tombstone/save), legitimate invalidation preserved for supported horizons, flag-OFF byte-identical, fail-loud preserved, no residual data-loss.

## Testing

- `postprocessing_forecasts` **1720 passed, 1 xfailed** (pre-existing). Every change RED→GREEN mutation-verified; the recalc skip proven through the real `recalculate_skill_metrics()` entry point.
- Merges cleanly into current `maxat_sapphire_2` (`merge-tree` conflict-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)