### PR TITLE
run_tests.sh: fail loudly instead of reporting success over zero tests

### DIFF
--- a/apps/run_tests.sh
+++ b/apps/run_tests.sh
@@ -48,7 +48,15 @@ cd "$SCRIPT_DIR"
 # Track results
 PASSED=()
 FAILED=()
-SKIPPED=()
+# ERRORED holds modules that could NOT be verified at all: missing/broken
+# venv (no pytest), missing test directory, or a pytest run that collected
+# zero tests. This is distinct from FAILED (tests actually ran and some
+# failed assertions) and, unlike the old SKIPPED array, is NEVER treated as
+# a passing/neutral outcome by the summary at the bottom of this script.
+# This is the fix for the "silent success over zero tests" bug: previously
+# these conditions were recorded in a SKIPPED array that the final success
+# banner and exit code completely ignored.
+ERRORED=()
 
 run_module_tests() {
     local module=$1
@@ -59,10 +67,11 @@ run_module_tests() {
     echo -e "${YELLOW}Testing: ${module}${NC}"
     echo "========================================"
 
-    # Check if venv exists
+    # Check if venv exists and has pytest installed
     if [ ! -f "$venv_path" ]; then
-        echo -e "${YELLOW}⚠ Skipping ${module}: No .venv found. Run 'cd ${module} && uv sync' first.${NC}"
-        SKIPPED+=("$module")
+        echo -e "${RED}✗ ERROR ${module}: cannot run tests — no pytest found at ${venv_path}.${NC}"
+        echo -e "${RED}  Fix: cd ${module} && uv sync --all-extras${NC}"
+        ERRORED+=("$module")
         return 0
     fi
 
@@ -73,15 +82,26 @@ run_module_tests() {
     elif [ -d "${module}/test" ]; then
         test_dir="${module}/test"
     else
-        echo -e "${YELLOW}⚠ Skipping ${module}: No test directory found (looked for 'tests' and 'test')${NC}"
-        SKIPPED+=("$module")
+        echo -e "${RED}✗ ERROR ${module}: no test directory found (looked for 'tests' and 'test').${NC}"
+        echo -e "${RED}  Module is listed in run_tests.sh but has no test suite to run.${NC}"
+        ERRORED+=("$module")
         return 0
     fi
 
-    # Run tests
-    if SAPPHIRE_TEST_ENV=True "$venv_path" "$test_dir" -v; then
+    # Run tests. Capture the real exit code (instead of branching directly in
+    # the if-condition) so a "collected zero tests" run (pytest exit code 5)
+    # can be told apart from a genuine test failure and reported as an error
+    # rather than silently accepted or lumped in with real failures.
+    local rc=0
+    SAPPHIRE_TEST_ENV=True "$venv_path" "$test_dir" -v || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
         echo -e "${GREEN}✓ ${module} tests passed${NC}"
         PASSED+=("$module")
+    elif [ "$rc" -eq 5 ]; then
+        echo -e "${RED}✗ ERROR ${module}: pytest collected zero tests (exit code 5).${NC}"
+        echo -e "${RED}  A run that verifies nothing is not a pass. Check the test path/markers.${NC}"
+        ERRORED+=("$module")
     else
         echo -e "${RED}✗ ${module} tests failed${NC}"
         FAILED+=("$module")
@@ -99,10 +119,11 @@ run_service_tests() {
     echo -e "${YELLOW}Testing: ${display_name}${NC}"
     echo "========================================"
 
-    # Check if venv exists
+    # Check if venv exists and has pytest installed
     if [ ! -f "$venv_path" ]; then
-        echo -e "${YELLOW}⚠ Skipping ${display_name}: No .venv found. Run 'cd sapphire/services/${service} && uv sync --all-extras' first.${NC}"
-        SKIPPED+=("$display_name")
+        echo -e "${RED}✗ ERROR ${display_name}: cannot run tests — no pytest found at ${venv_path}.${NC}"
+        echo -e "${RED}  Fix: cd sapphire/services/${service} && uv sync --all-extras${NC}"
+        ERRORED+=("$display_name")
         return 0
     fi
 
@@ -113,15 +134,25 @@ run_service_tests() {
     elif [ -d "${service_dir}/test" ]; then
         test_dir="${service_dir}/test"
     else
-        echo -e "${YELLOW}⚠ Skipping ${display_name}: No test directory found${NC}"
-        SKIPPED+=("$display_name")
+        echo -e "${RED}✗ ERROR ${display_name}: no test directory found (looked for 'tests' and 'test').${NC}"
+        echo -e "${RED}  Service is listed in run_tests.sh but has no test suite to run.${NC}"
+        ERRORED+=("$display_name")
         return 0
     fi
 
-    # Run tests (services don't need SAPPHIRE_TEST_ENV)
-    if "$venv_path" "$test_dir" -v; then
+    # Run tests (services don't need SAPPHIRE_TEST_ENV). Capture the real
+    # exit code so "collected zero tests" (pytest exit code 5) is reported
+    # as an error rather than silently accepted or lumped in with failures.
+    local rc=0
+    "$venv_path" "$test_dir" -v || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
         echo -e "${GREEN}✓ ${display_name} tests passed${NC}"
         PASSED+=("$display_name")
+    elif [ "$rc" -eq 5 ]; then
+        echo -e "${RED}✗ ERROR ${display_name}: pytest collected zero tests (exit code 5).${NC}"
+        echo -e "${RED}  A run that verifies nothing is not a pass. Check the test path/markers.${NC}"
+        ERRORED+=("$display_name")
     else
         echo -e "${RED}✗ ${display_name} tests failed${NC}"
         FAILED+=("$display_name")
@@ -152,6 +183,15 @@ SERVICE_MODULES=(
     "auth"
 )
 
+# main() wraps arg dispatch + run + summary so this file can be sourced by
+# a test harness (test_run_tests.sh, in this same directory) without
+# executing a real test run: sourcing re-uses the exact
+# run_module_tests/run_service_tests logic
+# above against synthetic fixtures. The guard at the bottom of this file
+# calls main "$@" only when the script is executed directly, which is the
+# only way it is invoked today (`bash run_tests.sh ...`), so normal usage
+# is unaffected.
+main() {
 # If a specific module is provided as argument, only run that one
 if [ -n "$1" ]; then
     # Check for service:name syntax
@@ -222,15 +262,29 @@ if [ ${#PASSED[@]} -gt 0 ]; then
     echo -e "${GREEN}Passed (${#PASSED[@]}):${NC} ${PASSED[*]}"
 fi
 
-if [ ${#SKIPPED[@]} -gt 0 ]; then
-    echo -e "${YELLOW}Skipped (${#SKIPPED[@]}):${NC} ${SKIPPED[*]}"
-fi
-
 if [ ${#FAILED[@]} -gt 0 ]; then
     echo -e "${RED}Failed (${#FAILED[@]}):${NC} ${FAILED[*]}"
+fi
+
+if [ ${#ERRORED[@]} -gt 0 ]; then
+    echo -e "${RED}Errored — could not be verified (${#ERRORED[@]}):${NC} ${ERRORED[*]}"
+    echo -e "${RED}These modules were NOT tested. Zero tests running is not success.${NC}"
+fi
+
+# A module that could not be verified (broken/missing venv, no test
+# directory, or a run that collected zero tests) is exactly as bad as a
+# module with failing tests: neither means the code was checked. The
+# success banner below must never print, and the exit code must never be 0,
+# when either array is non-empty.
+if [ ${#FAILED[@]} -gt 0 ] || [ ${#ERRORED[@]} -gt 0 ]; then
     echo ""
     exit 1
 fi
 
 echo ""
 echo -e "${GREEN}All tests completed successfully!${NC}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/apps/test_run_tests.sh
+++ b/apps/test_run_tests.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# Regression test for run_tests.sh's result accounting.
+#
+# Context: run_tests.sh used to have a "silent success over zero tests" bug.
+# When a module's venv was missing/broken (no pytest), or had no test
+# directory, the module was recorded in a SKIPPED array that the final
+# summary completely ignored -- the script still printed "All tests
+# completed successfully!" and exited 0, even though zero tests ran for
+# that module. This test locks in the fix: such conditions must now be
+# recorded as errors (ERRORED array) that make the overall run fail loudly
+# (non-zero exit, no unqualified success banner), while a genuine passing
+# run (including one containing pytest-level skips, e.g. the
+# SAPPHIRE_API_AVAILABLE-gated skip pattern documented in CLAUDE.md) must
+# still succeed.
+#
+# There is no existing shell-test framework/precedent in this repo (no
+# bats, no shunit2), so this is a small dependency-free bash harness. It
+# sources run_tests.sh (which guards its own "main" dispatch/summary logic
+# behind a `[[ "${BASH_SOURCE[0]}" == "${0}" ]]` check, so sourcing it only
+# defines functions/arrays and does not run a real test sweep) and drives
+# it against synthetic fixture "modules" -- fake .venv/bin/pytest
+# executables under a temp directory that deterministically exit with a
+# chosen code, standing in for: missing pytest, a broken pytest, a run
+# that collects zero tests (pytest exit code 5), a passing run, and a
+# failing run.
+#
+# Usage: bash test_run_tests.sh
+# Exits 0 if all cases behave as expected, non-zero (with a diagnostic) if
+# any regress.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXROOT="$(mktemp -d)"
+trap 'rm -rf "$FIXROOT"' EXIT
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+FAILURES=0
+
+# make_fake_pytest DIR EXIT_CODE [OUTPUT_LINE]
+# Creates DIR/.venv/bin/pytest as an executable stub that ignores its
+# arguments and exits with EXIT_CODE. Used to deterministically drive
+# run_module_tests through each branch without depending on a real
+# Python venv or real pytest behavior.
+make_fake_pytest() {
+    local dir="$1" code="$2" msg="${3:-}"
+    mkdir -p "${dir}/.venv/bin"
+    cat > "${dir}/.venv/bin/pytest" <<EOF
+#!/usr/bin/env bash
+echo "${msg}"
+exit ${code}
+EOF
+    chmod +x "${dir}/.venv/bin/pytest"
+}
+
+# assert_case DESC MODULE_PATH EXPECT_EXIT EXPECT_BANNER(yes/no) EXPECT_NEEDLE
+#
+# Drives the *real*, unmodified main() (arg validation, dispatch,
+# run_module_tests, summary, exit code) end to end. MODULES is overridden
+# post-source to point at the synthetic fixture module -- MODULES is plain
+# configuration data, not logic, so this exercises production code paths.
+assert_case() {
+    local desc="$1" module="$2" expect_exit="$3" expect_banner="$4" expect_needle="$5"
+    local out rc
+
+    out=$(cd "$SCRIPT_DIR" && bash -c '
+        source ./run_tests.sh
+        MODULES=("$1")
+        main "$1"
+    ' _ "$module" 2>&1)
+    rc=$?
+
+    local ok=1
+
+    if [ "$rc" -ne "$expect_exit" ]; then
+        echo -e "${RED}FAIL${NC} [$desc]: expected exit code $expect_exit, got $rc"
+        ok=0
+    fi
+
+    if [ "$expect_banner" = "yes" ]; then
+        if ! grep -q "All tests completed successfully" <<<"$out"; then
+            echo -e "${RED}FAIL${NC} [$desc]: expected success banner, none printed"
+            ok=0
+        fi
+    else
+        if grep -q "All tests completed successfully" <<<"$out"; then
+            echo -e "${RED}FAIL${NC} [$desc]: success banner printed but must not be (zero-verification condition)"
+            ok=0
+        fi
+    fi
+
+    if [ -n "$expect_needle" ] && ! grep -qF "$expect_needle" <<<"$out"; then
+        echo -e "${RED}FAIL${NC} [$desc]: expected output to contain: $expect_needle"
+        echo "--- actual output ---"
+        echo "$out"
+        echo "----------------------"
+        ok=0
+    fi
+
+    if [ "$ok" -eq 1 ]; then
+        echo -e "${GREEN}PASS${NC} [$desc]"
+    else
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# --- Fixture 1: module directory exists but has no .venv at all -------
+# This is the exact bug reproduction: previously this yielded an
+# unqualified "All tests completed successfully!" over zero tests run.
+NO_VENV_MODULE="${FIXROOT}/no_venv_module"
+mkdir -p "${NO_VENV_MODULE}/tests"
+touch "${NO_VENV_MODULE}/tests/test_dummy.py"
+
+assert_case \
+    "missing venv (no pytest) must ERROR, not silently pass" \
+    "$NO_VENV_MODULE" 1 no "ERROR"
+
+# --- Fixture 2: venv/pytest present, but no tests/ or test/ directory --
+NO_TESTDIR_MODULE="${FIXROOT}/no_testdir_module"
+make_fake_pytest "$NO_TESTDIR_MODULE" 0
+
+assert_case \
+    "missing test directory must ERROR, not silently pass" \
+    "$NO_TESTDIR_MODULE" 1 no "ERROR"
+
+# --- Fixture 3: pytest runs but collects zero tests (exit code 5) -----
+ZERO_COLLECT_MODULE="${FIXROOT}/zero_collect_module"
+mkdir -p "${ZERO_COLLECT_MODULE}/tests"
+make_fake_pytest "$ZERO_COLLECT_MODULE" 5 "collected 0 items"
+
+assert_case \
+    "pytest collecting zero tests must ERROR, not silently pass" \
+    "$ZERO_COLLECT_MODULE" 1 no "collected zero tests"
+
+# --- Fixture 4: a real passing run (including pytest-level skips) -----
+# Standing in for the ONE approved skip pattern (SAPPHIRE_API_AVAILABLE
+# dependency-gated skips): pytest itself exits 0 even though some
+# individual tests were skipped inside a run that DID happen. This must
+# still be treated as a pass.
+PASS_MODULE="${FIXROOT}/pass_module"
+mkdir -p "${PASS_MODULE}/tests"
+make_fake_pytest "$PASS_MODULE" 0 "12 passed, 2 skipped"
+
+assert_case \
+    "a real passing run (with internal pytest skips) must still pass" \
+    "$PASS_MODULE" 0 yes "tests passed"
+
+# --- Fixture 5: pytest runs and reports real test failures ------------
+FAIL_MODULE="${FIXROOT}/fail_module"
+mkdir -p "${FAIL_MODULE}/tests"
+make_fake_pytest "$FAIL_MODULE" 1 "3 passed, 1 failed"
+
+assert_case \
+    "genuine test failures must FAIL (distinct from ERROR), not silently pass" \
+    "$FAIL_MODULE" 1 no "tests failed"
+
+# --- Fixture 6: run_service_tests shares the same missing-venv bug class
+# Called directly (not through main()) so this never touches the real
+# sapphire/services/ directory tree. Confirms the service-side function
+# was fixed identically to the module-side one.
+service_out=$(cd "$SCRIPT_DIR" && bash -c '
+    source ./run_tests.sh
+    run_service_tests "no-such-service-fixture-zzz"
+    echo "ERRORED_COUNT=${#ERRORED[@]}"
+    echo "PASSED_COUNT=${#PASSED[@]}"
+    echo "FAILED_COUNT=${#FAILED[@]}"
+' 2>&1)
+
+if grep -q "ERRORED_COUNT=1" <<<"$service_out" \
+    && grep -q "PASSED_COUNT=0" <<<"$service_out" \
+    && grep -q "FAILED_COUNT=0" <<<"$service_out" \
+    && grep -qF "ERROR" <<<"$service_out"; then
+    echo -e "${GREEN}PASS${NC} [run_service_tests: missing venv must ERROR, not silently pass]"
+else
+    echo -e "${RED}FAIL${NC} [run_service_tests: missing venv must ERROR, not silently pass]"
+    echo "--- actual output ---"
+    echo "$service_out"
+    echo "----------------------"
+    FAILURES=$((FAILURES + 1))
+fi
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+    echo -e "${GREEN}All test_run_tests.sh cases passed.${NC}"
+    exit 0
+else
+    echo -e "${RED}${FAILURES} test_run_tests.sh case(s) failed.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## The bug: a green banner over zero tests

`apps/run_tests.sh` is the single entry point this project uses to verify every change — CLAUDE.md
mandates it before every commit and enforces a zero-skips policy.

It had a **silent-success** failure mode. In `run_module_tests()` (and identically in
`run_service_tests()`), a missing `<module>/.venv/bin/pytest` pushed the module onto a `SKIPPED`
array and **returned 0**. The summary block built its exit code and its success banner from the
`FAILED` array **only** — it never looked at `SKIPPED`. A module that ran **zero tests** was
indistinguishable from a healthy pass.

**Reproduced at full scale:** in a fresh worktree with no venvs synced, all 11 app modules and all
5 services were skipped — and the script printed `All tests completed successfully!` and exited **0**.

```
$ SAPPHIRE_TEST_ENV=True bash run_tests.sh iEasyHydroForecast
⚠ Skipping iEasyHydroForecast: No .venv found. Run 'cd iEasyHydroForecast && uv sync' first.
...
All tests completed successfully!
EXIT CODE: 0
```

This is the worst class of test-infrastructure bug: it does not fail loudly, it fails
**reassuringly**. Every "green" from a fresh worktree may have been vacuous — including green
reported by CI-adjacent tooling and by AI agents verifying their own work.

## The fix

- `SKIPPED` → `ERRORED`. A missing/broken venv, a missing test directory, and **pytest exit code 5
  ("collected zero tests")** are each now an explicit, module-named ERROR carrying an actionable
  `uv sync --all-extras` remedy.
- The summary exits **non-zero** and suppresses the success banner whenever `FAILED` **or**
  `ERRORED` is non-empty.
- The one legitimate skip pattern is preserved: pytest-level skips *inside a run that actually
  happened* — the documented `SAPPHIRE_API_AVAILABLE` dependency gate — still count as PASSED.
- Existing invocations are unchanged: `bash run_tests.sh`, `bash run_tests.sh <module>`,
  `bash run_tests.sh service:<service>`. The dispatch/summary logic moved into `main()` behind a
  `[[ "${BASH_SOURCE[0]}" == "${0}" ]]` guard so the script stays sourceable for testing.

## Tests for the test script

New `apps/test_run_tests.sh` — a dependency-free bash harness (no shell-test precedent existed in
this repo) that sources the real `run_tests.sh` and drives it against synthetic fixtures with fake
`pytest` stubs returning controlled exit codes: missing venv, missing test dir, zero-collected
(exit 5), a real pass (with internal skips), a real failure, and the service-side missing-venv path
— asserting exit codes and banner presence/absence through the real `main()`.

The harness was itself mutation-tested: reverting the fix makes it fail with exactly the original
bug's signature. `shellcheck` is clean on both files.

## Verification

| Run | Result |
|---|---|
| `iEasyHydroForecast` (healthy module) | 853 passed, 1 xfailed, **exit 0** |
| Full suite, fresh worktree *before* syncing venvs | **exit 1** — 1 passed / **15 errored**, each named |
| Full suite *after* `uv sync --all-extras` | **exit 0** — all 16 modules/services pass |

The 15 errors were pure local venv rot, not real breakage — every module and service synced cleanly
and passed. That is precisely the scenario the old script reported as success.

`forecast_dashboard`'s "531 passed, 6 skipped" is the documented chromium/live-integration operator
gate, correctly preserved as a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
