### PR TITLE
Review workflow: add code-diff attack axes + adversarial-review skill

### DIFF
--- a/.claude/skills/adversarial-review/SKILL.md
+++ b/.claude/skills/adversarial-review/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: adversarial-review
+model: sonnet
+description: "Runs the out-of-loop adversarial diff review required by CLAUDE.md § Multi-Model Review & Verification and doc/dev/agent_review_workflow.md § Attack axes for code diffs, in one invocation. Use when: (1) a patch is about to be declared done and it touches a high-risk coupling point or is otherwise non-trivial, (2) before a PR is opened, (3) re-reviewing a round of fixes made in response to an earlier review. Computes the diff, runs a fresh out-of-loop reviewer (codex exec, or a fresh Claude subagent if codex is unavailable) against the diff-attack template, and returns findings for the caller to triage. Does not fix anything itself."
+---
+
+# Adversarial Review
+
+Single-command out-of-loop review of a **code diff** (not a plan or claim list) using the attack
+axes in [`doc/dev/agent_review_workflow.md`](../../../doc/dev/agent_review_workflow.md) § "Attack
+axes for code diffs". That doc owns the axes, the worked examples, and the process rules; this
+skill only owns *how to invoke the review in one step*. Read that section before using this skill
+if you have not already — it explains why claim-verification templates find nothing on a diff.
+
+**This skill finds and reports findings. It does not fix anything and it does not decide what's
+real.** Triage is the caller's job (see "Triage, not obey" below).
+
+## When to use
+
+- A patch is about to be declared "done" and either touches a high-risk coupling point (listed in
+  the doc) or is otherwise non-trivial (see "When mandatory multi-model review applies" in the doc).
+- Before opening a PR — this is the out-of-loop half of the "Post-implementation review gate".
+- **Re-reviewing a round of fixes.** A fix is new, unreviewed code; run this again on the new diff
+  after applying fixes from a prior round. Do not assume a fix is safe because the finding it
+  addresses was real.
+
+Not for reviewing plans, designs, or audit reports — those use the claim-verification template
+earlier in the same doc, not this one.
+
+## Procedure
+
+### 1. Compute the diff under review
+
+```bash
+BASE="${1:-origin/maxat_sapphire_2}"
+git fetch origin "${BASE#origin/}" 2>/dev/null || true
+git diff "${BASE}...HEAD" > /tmp/adversarial-review-diff.txt
+wc -l /tmp/adversarial-review-diff.txt   # sanity check it's non-empty
+```
+
+Run this from a clean checkout of the branch under review, diffing against `origin/<base>` — never
+a stale local branch ref or the dirty working tree (see "Out-of-loop verifier requirements" in the
+doc; a wrong-branch or stale-ref diff has produced false verdicts before).
+
+### 2. Fill in the template's three required inputs
+
+The diff alone is not enough context for a useful review — fill these in yourself before running
+anything (do not skip this and hand the reviewer just the diff):
+
+- **The bug being fixed** — one paragraph, what was broken and how it was observed.
+- **The contracts that must hold** — what the operator/caller must observe, stated as behavior, not
+  as "the diff should do X." Include any feature flag and its default if the diff is flag-gated.
+- **The suspicious seams to attack** — the specific lines/objects in *this* diff most likely to hide
+  a lifecycle, fallback, or invariant bug (see the axes in the doc for what counts).
+
+### 3. Run the out-of-loop reviewer
+
+Prefer `codex exec`. Write output straight to a file with `-o`; **do not pipe the run through
+`tail`/`head`** — that buffers the whole run and hides progress until it either finishes or hangs
+silently, which has already cost time on this project.
+
+```bash
+OUT=/tmp/adversarial-review-out.json
+codex exec --skip-git-repo-check --sandbox read-only -C <clean_target_checkout> --color never \
+  -o "$OUT" "$(cat <<'PROMPT'
+<fill in the code-diff template from doc/dev/agent_review_workflow.md § "Code-diff `codex exec`
+prompt template", substituting the diff and the three inputs from step 2>
+PROMPT
+)"
+```
+
+Let the command run to completion (use `run_in_background` if invoking from the Bash tool and you
+need to keep working, not a piped foreground tail); then read `$OUT` directly with the Read tool.
+
+**Fallback if `codex` is unavailable or errors out**: launch a fresh general-purpose Claude agent
+with **no prior session context** and the same filled-in template as its entire prompt. This
+mirrors the doc's fallback rule for the claim-verification path — different tool/model where
+possible, and always a reviewer that has not seen this session's assumptions.
+
+### 4. Triage, not obey
+
+The reviewer's output is evidence, not a verdict to execute mechanically:
+
+- For every returned finding, verify it against the **current** code before acting — file exists,
+  line matches, the described behavior is actually what the code does. Findings scoped from stale
+  context (an old diff, a moved line, a premise already fixed) do happen; reject those explicitly,
+  with a one-line reason, rather than silently fixing fiction or silently dropping a real one.
+- **Golden/kill-switch tests are supposed to pass with the flag off, both before and after the
+  change** — that is their entire job. If the reviewer flags one of those as "vacuous" or
+  "wouldn't catch a revert," that is a false positive on the vacuity axis, not a real finding;
+  don't act on it, and don't let it stand unchallenged if the finding is reused elsewhere.
+- Separate `introduced_by_diff: true` findings (fix now, in scope) from `false` (pre-existing —
+  file as a `gi_draft_*` issue per "Accuracy fixes vs design forks" in the doc, don't scope-creep
+  the current patch).
+- After fixes land for any Critical/Important finding, the fix is itself new code — go back to
+  step 1 with the new diff. Do not close the review on the strength of round one.
+
+## Output
+
+Report to the caller: the findings list (axis, file:line, severity, concrete failure scenario,
+introduced-by-diff or pre-existing), which findings were rejected as stale/incorrect and why, and
+which remain open for the human owner or a follow-up fix round.

--- a/.claude/skills/adversarial-review/SKILL.md
+++ b/.claude/skills/adversarial-review/SKILL.md
@@ -24,8 +24,11 @@ real.** Triage is the caller's job (see "Triage, not obey" below).
   after applying fixes from a prior round. Do not assume a fix is safe because the finding it
   addresses was real.
 
-Not for reviewing plans, designs, or audit reports — those use the claim-verification template
-earlier in the same doc, not this one.
+Not for reviewing plans, designs, or audit reports. Those still need the open-ended adversarial
+pass (see the doc § "Adversarial review is REQUIRED" — it applies to plans too, not just diffs),
+but this skill's mechanics (computing a `git diff`, the diff-shaped attack axes) only make sense
+for a diff; for a plan/design/audit, use the claim-verification template earlier in the same doc
+plus a general open-ended prompt over the prose, not this skill.
 
 ## Procedure
 
@@ -33,14 +36,22 @@ earlier in the same doc, not this one.
 
 ```bash
 BASE="${1:-origin/maxat_sapphire_2}"
-git fetch origin "${BASE#origin/}" 2>/dev/null || true
+if ! git fetch origin "${BASE#origin/}"; then
+  echo "FATAL: git fetch origin '${BASE#origin/}' failed — refusing to diff against a possibly" \
+       "stale copy of ${BASE}. Fix connectivity/the ref and retry; a review against a stale base" \
+       "is worse than no review (see 'Out-of-loop verifier requirements' in the doc)." >&2
+  exit 1
+fi
 git diff "${BASE}...HEAD" > /tmp/adversarial-review-diff.txt
 wc -l /tmp/adversarial-review-diff.txt   # sanity check it's non-empty
 ```
 
-Run this from a clean checkout of the branch under review, diffing against `origin/<base>` — never
-a stale local branch ref or the dirty working tree (see "Out-of-loop verifier requirements" in the
-doc; a wrong-branch or stale-ref diff has produced false verdicts before).
+`BASE` must always resolve to an `origin/<branch>` remote-tracking ref, never a bare local branch
+name — run this from a clean checkout of the branch under review, diffing against `origin/<target>`,
+never a stale local branch ref or the dirty working tree (see "Out-of-loop verifier requirements" in
+the doc; a wrong-branch or stale-ref diff has produced false verdicts before). The fetch above must
+succeed before the diff is trusted — do not silently fall back to whatever `origin/<target>` last
+pointed to.
 
 ### 2. Fill in the template's three required inputs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,10 @@ vocabulary is owned by** [`doc/plans/README.md`](doc/plans/README.md) — do not
    errors** may be applied directly; **scope/design/semantics/security/API-contract** changes
    **escalate to the human owner**; related bugs found while mapping become `gi_draft_*` plan files
    under `doc/plans/issues/` (indexed in `doc/plans/module_issues.md`), never inline fixes. After
-   corrections, run one lightweight **confirm-fixes pass**.
+   corrections, run one lightweight **confirm-fixes pass**. For diffs specifically, use the
+   diff-attack template in `doc/dev/agent_review_workflow.md` § "Attack axes for code diffs" (the
+   `adversarial-review` skill runs it in one step) — the artifact template above verifies claims, not
+   behavior.
 
 3. **Every high-claim-density prompt carries the fitness line** (verbatim): "Every bullet must help
    an agent know what to inspect, what contract not to break, or what verification proves safety —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,10 +86,12 @@ vocabulary is owned by** [`doc/plans/README.md`](doc/plans/README.md) — do not
    errors** may be applied directly; **scope/design/semantics/security/API-contract** changes
    **escalate to the human owner**; related bugs found while mapping become `gi_draft_*` plan files
    under `doc/plans/issues/` (indexed in `doc/plans/module_issues.md`), never inline fixes. After
-   corrections, run one lightweight **confirm-fixes pass**. For diffs specifically, use the
-   diff-attack template in `doc/dev/agent_review_workflow.md` § "Attack axes for code diffs" (the
-   `adversarial-review` skill runs it in one step) — the artifact template above verifies claims, not
-   behavior.
+   corrections, run one lightweight **confirm-fixes pass**. The open-ended pass applies to plans and
+   diffs alike; for diffs, run it via the axes in `doc/dev/agent_review_workflow.md` § "Attack axes
+   for code diffs" (the `adversarial-review` skill runs it in one step) — those axes are the
+   diff-shaped form of the same open-ended instruction, not a plans-vs-diffs split. The doc's
+   claim-verification template (§ "Out-of-loop verifier requirements") checks factual claims and is
+   necessary but not sufficient on its own, for plans or diffs.
 
 3. **Every high-claim-density prompt carries the fitness line** (verbatim): "Every bullet must help
    an agent know what to inspect, what contract not to break, or what verification proves safety —

--- a/doc/dev/agent_review_workflow.md
+++ b/doc/dev/agent_review_workflow.md
@@ -108,6 +108,126 @@ CLAUDE.md / doc/plans/README.md / doc/dev/testing_workflow.md. Factual accuracy 
 opinions.
 ```
 
+## Attack axes for code diffs
+
+The templates above verify **claims in an artifact** — a plan, design, or audit asserts something,
+and the reviewer confirms or refutes it. Pointed at a **code diff**, that template finds almost
+nothing: a diff doesn't assert claims, it changes behavior, and "does the diff do what the PR
+description says" is a much weaker question than "what does this diff break that nobody asked
+about." **Use claim verification for plans/designs/audits. Use this section for diffs** — it is
+the template for the out-of-loop pass required by "Post-implementation review gate" below.
+
+This section does not replace the artifact template and does not restate `doc/dev/testing_workflow.md`
+or the Orchestration Protocol. Every axis below is a real defect that shipped, or nearly shipped, in
+this repo **while the claim-verification-only version of this workflow was already in force** — the
+policy existed and did not catch these; only an open-ended diff attack did.
+
+### The axes
+
+Each is a question the reviewer must answer about the diff, not a box to tick.
+
+1. **Implicit invariants.** List every invariant the diff relies on. Who enforces it in code — a
+   type, a range check, a test? If nobody does, that is the bug. *`plot_manager` hardcoded the m0
+   card's lead to `0` while `db.py` resolved `month_0`'s lead from config; nothing enforced
+   "month_0 == lead 0." Same class recurred: a later fix inferred the forecast year by comparing
+   month numbers, valid only for leads 0–11, and the config loader range-checks nothing.*
+2. **Test contract vs code contract.** Do the tests prove the OPERATOR gets the right result, or
+   only that the code agrees with itself? A test that manually seeds the state whose absence is the
+   bug passes identically before and after the fix. *19 mutation-proven tests covered an m0-bulletin
+   fix by seeding the very attribute whose absence caused the corruption — the operator still got a
+   corrupt bulletin after save + reload.*
+3. **Lifecycle / round-trip.** Does the fix survive save → reload → new session / process restart,
+   or does it live only on an in-memory object? *The same m0 fix stored state on an in-memory
+   object and never persisted it — it silently evaporated on reload.*
+4. **Silent wrong-but-plausible fallback.** Does any error path swallow an exception (or take a
+   default branch) and produce a plausible WRONG answer while telling the operator it succeeded?
+   Failing reassuringly is worse than failing loudly. *A bare `except Exception` fell back to the
+   wrong month while the UI reported "Bulletin saved successfully"; separately, `run_tests.sh`
+   printed "All tests completed successfully!" while collecting zero tests.*
+5. **Blast radius on stored/displayed numbers.** Does the diff change a number already PERSISTED in
+   a DB table or DISPLAYED on a dashboard? If yes, treat it as the highest-severity class regardless
+   of diff size — a formula fix to a stored value is a data-migration question, not a code-review
+   question. *A skill metric's sign disagreed with its cited paper; flipping it would have silently
+   redefined every value already written to the DB and shown on dashboards.*
+6. **Kill-switch parity (flag-gated diffs only).** Attack flag-OFF and flag-ON as two separate
+   contracts. Flag-OFF must be byte-identical to trunk — exercise that path explicitly, don't infer
+   it from a green suite. Flag-ON must be correct on its own merits. *A crash existed only on the
+   flag-ON path; the whole existing suite stayed green because every test in it ran flag-OFF.*
+7. **Vacuity.** For each new/changed test, ask: would it still pass if the fix it covers were
+   reverted? If yes, say so — it doesn't pin what it claims to pin. **Caveat:** golden/kill-switch
+   tests are *supposed* to pass with the flag off, both before and after the change — that is their
+   job; do not flag those as vacuous. Only flag a test whose stated purpose was to catch this bug and
+   would not.
+
+### Process rules
+
+- **Stale premises.** Before fixing — or re-confirming — a reported finding, verify it against the
+  CURRENT code, not the note, plan, or earlier review round that reported it. A finding scoped from a
+  months-old memory note had two of three premises already false against current configs; three real
+  fixes beats four fixes where one is fiction.
+- **Run the out-of-loop diff pass BEFORE declaring the work done**, not as a formality attached to
+  the PR afterward — it is a gate on the diff, matching "Post-implementation review gate" below.
+- **Feed the reviewer the CONTRACT, not just the diff.** State explicitly what the operator/caller
+  must observe (the before/after behavior, the flag default), so the reviewer attacks the contract
+  instead of paraphrasing the diff back at you.
+- **Re-review the fixes.** A fix is new, unreviewed code. A second review round over round-1's fixes
+  found a fresh Medium-severity defect in them — a fix is not safe merely because the finding it
+  addresses was real; it needs its own pass.
+
+### Code-diff `codex exec` prompt template
+
+```
+codex exec --skip-git-repo-check --sandbox read-only -C <clean_target_checkout> --color never \
+  -o <out.json> "$(cat <<'PROMPT'
+READ-ONLY adversarial review of a DIFF — not a claim checklist. Do NOT edit any file. You are a
+fresh, out-of-loop reviewer; assume nothing from prior context and do not trust the summary below.
+
+BUG BEING FIXED (as claimed by the author):
+<one paragraph: what was broken, for whom, observed how>
+
+DIFF UNDER REVIEW:
+<paste `git diff <base>...HEAD`, or the specific files/hunks>
+
+CONTRACTS THAT MUST HOLD (what the operator/caller must observe — verify against these, not the
+diff's stated intent):
+<e.g. "operator sees the CORRECT bulletin after save+reload+new session, or an explicit error —
+never a silently wrong one"; "flag SAPPHIRE_FOO defaults to False, flag-OFF is byte-identical to
+trunk"; "value X, once written to skill_metrics, is never silently redefined by this change">
+
+SUSPICIOUS SEAMS TO ATTACK (name the specific ones for this diff):
+<e.g. "state assigned to self.foo in PlotManager — persisted, or in-memory only?"; "except Exception
+around the save path — what does it fall back to, and does the caller see success?"; "new/changed
+tests — do they seed the state whose absence was the bug?">
+
+TASK: Attack the diff against the contracts above, using these axes — do not merely restate what the
+diff does:
+1. Implicit invariants: what does the diff assume that no code enforces?
+2. Test contract: do the tests prove the OPERATOR gets the right result, or only that the code
+   agrees with itself (manually-seeded state, mocked-away the real bug, etc.)?
+3. Lifecycle: does the fix survive save/reload/restart, or only live in memory for this session?
+4. Silent fallback: any bare except / default branch that produces a plausible WRONG result while
+   reporting success?
+5. Blast radius: does this change a number already PERSISTED or DISPLAYED? If yes, flag as a
+   data-migration question, not a code-review question.
+6. Kill-switch parity (if flag-gated): is flag-OFF byte-identical to trunk? Is flag-ON correct?
+7. Vacuity: for each new/changed test, would it still pass if the fix were reverted? Do NOT flag
+   golden/kill-switch tests that are supposed to pass with the flag off both before and after.
+
+Separate findings into two buckets: defects INTRODUCED by this diff, vs pre-existing defects the
+diff happens to touch (report both; label which bucket).
+
+Return a JSON array: [{axis, file, line, severity: Critical|Important|Minor, finding, concrete
+failure scenario, introduced_by_diff: true|false}]. No prose approval, no design opinions beyond
+what a Critical/Important finding requires.
+PROMPT
+)"
+```
+
+Fallback (Codex unavailable): the same prompt via a fresh Claude general-purpose subagent (Agent
+tool, no prior session context) — same "different tool/model where possible" rule as the
+claim-verification fallback above. Triage every returned finding against the current code before
+acting on it (see "Stale premises" above) — the reviewer's verdict is evidence, not a mandate.
+
 ## Proportionality lens checklist (argue for cuts)
 
 - [ ] Present-but-unnecessary content that doesn't change what an agent does.
@@ -140,7 +260,8 @@ transcription drift introduced while applying fixes.
 No PR is approved on the implementer's `done` alone. Standard patches: in-loop `code-review`
 (correctness) + human owner. Patches touching a high-risk coupling point (below): additionally one
 **out-of-loop** reviewer running an OPEN-ENDED adversarial review of the diff (read-only `codex exec`,
-or the fresh-Claude fallback — not merely a claim-checklist).
+or the fresh-Claude fallback — not merely a claim-checklist; use the "Attack axes for code diffs"
+template above).
 PASS = `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh` zero-fail / zero-unexpected-skip
 **and** both reviewers' Critical/Important items resolved or reasoned-rebutted **and** no
 unescalated design/contract fork. Live-DB behavior changes additionally require the operational

--- a/doc/dev/agent_review_workflow.md
+++ b/doc/dev/agent_review_workflow.md
@@ -75,8 +75,12 @@ artifact/diff pasted in the prompt.
   run falsely refuted `round_3sf`/tombstone code that is present on the target; a run diffing against a
   stale local `maxat_sapphire_2` falsely reported an upstream `sapphire/services/` file as added by
   the change.)
-- Output = per-claim verdict: `confirmed` / `refuted` / `unverifiable`, each with concrete evidence
-  (path, symbol, test, or contract). No prose approval.
+- **Output contract — differs by review type; do not conflate them:**
+  - Claim-verification / plan review: per-claim verdict `confirmed` / `refuted` / `unverifiable`,
+    each with concrete evidence (path, symbol, test, or contract). No prose approval.
+  - Diff-attack review: a findings array (file:line, severity, concrete failure scenario) — see
+    "Attack axes for code diffs" § "Code-diff `codex exec` prompt template" below for the exact
+    schema.
 
 ### `codex exec` verifier prompt template
 
@@ -110,12 +114,18 @@ opinions.
 
 ## Attack axes for code diffs
 
-The templates above verify **claims in an artifact** — a plan, design, or audit asserts something,
-and the reviewer confirms or refutes it. Pointed at a **code diff**, that template finds almost
-nothing: a diff doesn't assert claims, it changes behavior, and "does the diff do what the PR
-description says" is a much weaker question than "what does this diff break that nobody asked
-about." **Use claim verification for plans/designs/audits. Use this section for diffs** — it is
-the template for the out-of-loop pass required by "Post-implementation review gate" below.
+Claim verification (above) is necessary but **not sufficient** for any artifact — plan, design,
+audit, or diff (see "Adversarial review is REQUIRED — not just claim verification"). Every artifact
+also needs the open-ended adversarial pass. This section is that pass's concrete toolkit **when the
+artifact under review is a diff**: pointed at a code diff, the claim-verification template above
+finds almost nothing — a diff doesn't assert claims the way a plan's prose does, and "does the diff
+do what the PR description says" is a much weaker question than "what does this diff break that
+nobody asked about." The seven axes below are the diff-shaped form of the same open-ended
+instruction that also applies to plans — this is **not** a "plans get claim-checking, diffs get
+axes" split; a plan/design/audit gets claim verification (its content is largely falsifiable
+claims) **plus** its own open-ended adversarial pass (no fixed axes — hand the reviewer the artifact
+with no checklist, per "Adversarial review is REQUIRED" above). This section's axes are the template
+for the out-of-loop pass required by "Post-implementation review gate" below, specifically for diffs.
 
 This section does not replace the artifact template and does not restate `doc/dev/testing_workflow.md`
 or the Orchestration Protocol. Every axis below is a real defect that shipped, or nearly shipped, in
@@ -171,7 +181,7 @@ Each is a question the reviewer must answer about the diff, not a box to tick.
   must observe (the before/after behavior, the flag default), so the reviewer attacks the contract
   instead of paraphrasing the diff back at you.
 - **Re-review the fixes.** A fix is new, unreviewed code. A second review round over round-1's fixes
-  found a fresh Medium-severity defect in them — a fix is not safe merely because the finding it
+  found a fresh Important-severity defect in them — a fix is not safe merely because the finding it
   addresses was real; it needs its own pass.
 
 ### Code-diff `codex exec` prompt template
@@ -222,6 +232,10 @@ what a Critical/Important finding requires.
 PROMPT
 )"
 ```
+
+This findings-array shape is the diff-attack output contract; it is distinct from the per-claim
+verdict contract used for plans/designs/audits (see "Out-of-loop verifier requirements" above) —
+use the one that matches the review type, not both.
 
 Fallback (Codex unavailable): the same prompt via a fresh Claude general-purpose subagent (Agent
 tool, no prior session context) — same "different tool/model where possible" rule as the


### PR DESCRIPTION
## Why

This repo already mandates out-of-loop adversarial review (`doc/dev/agent_review_workflow.md`,
CLAUDE.md § Multi-Model Review). But in practice the only concrete template on offer was a
**claim-verifier** ("check each falsifiable claim, return confirmed/refuted") — the right tool for a
*plan*, but pointed at a *code diff* it finds nothing. The policy was in place and still let real
defects through this week; the gap was *what the reviewer is told to attack*.

## What this adds

- **`doc/dev/agent_review_workflow.md` — an "Attack axes for code diffs" section.** Seven axes, each a
  question with the real defect that motivated it: implicit invariants nobody enforces; whether tests
  prove the *operator's* result or just internal consistency; lifecycle/round-trip survival; silent
  wrong-but-plausible fallbacks; blast radius on persisted/displayed numbers; kill-switch parity;
  vacuity (with the caveat that golden tests are *supposed* to pass on both sides). Plus a
  ready-to-paste diff-attack `codex exec` template and the process rules (review before "done"; feed
  the reviewer the contract, not just the diff; re-review the fixes).

- **`.claude/skills/adversarial-review/SKILL.md`** — makes the diff review one invocation: fetches and
  diffs against `origin/<target>` (**fails loud** if the fetch fails — a review against a stale base is
  worse than none), runs the out-of-loop reviewer, falls back to a fresh no-context Claude agent, and
  ends on **triage, not obey**.

- **`CLAUDE.md`** — a one-line pointer, no restated content.

The framing is deliberate: claim verification and the attack axes are **not** a plans-vs-diffs split —
open-ended adversarial review applies to both; the axes are its diff-shaped form.

## Honest note

This doc went through its own adversarial review, which found five internal contradictions — including
the skill reintroducing the exact *stale-local-ref* bug this session had already learned. All five are
fixed. The material claims only that the axes **give a reviewer the questions that caught real
defects** — not that they "prevent" defects. Full suite green (5884 passed) on the merged base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
