### PR TITLE
PP-051 P0a: a missing sapphire-api-client is a failed write, not a config skip

### DIFF
--- a/apps/postprocessing_forecasts/src/api_writer.py
+++ b/apps/postprocessing_forecasts/src/api_writer.py
@@ -70,13 +70,14 @@ class WriteOutcome(Enum):
     A single bool cannot distinguish "nothing was attempted" from "the
     attempt failed" from "the attempt correctly found nothing to send" —
     conflating them makes a benign, documented configuration state (writing
-    disabled, client absent) indistinguishable from a genuine operational
-    failure. Only `FAILED` should ever cause a caller to treat the write as
-    a failure; every other member is a non-failure outcome.
+    disabled via SAPPHIRE_API_ENABLED=false) indistinguishable from a
+    genuine operational failure (a missing required dependency). Only
+    `FAILED` should ever cause a caller to treat the write as a failure;
+    every other member is a non-failure outcome.
     """
 
     WROTE = "wrote"  # records were sent and accepted
-    SKIPPED_BY_CONFIG = "skipped_by_config"  # client absent, or SAPPHIRE_API_ENABLED=false
+    SKIPPED_BY_CONFIG = "skipped_by_config"  # SAPPHIRE_API_ENABLED=false (operator opt-out)
     SKIPPED_NO_RECORDS = "skipped_no_records"  # nothing to write after filtering
     SKIPPED_NOT_DEPLOYED = "skipped_not_deployed"  # threshold endpoint not yet deployed (Stage 2)
     FAILED = "failed"  # readiness-check failure, or the write call raised
@@ -470,9 +471,9 @@ def _write_skill_metrics_to_api(data: pd.DataFrame, horizon_type: str, year: int
 
     Returns:
         WriteOutcome: WROTE if records were sent and accepted;
-            SKIPPED_BY_CONFIG if the client is absent or
-            SAPPHIRE_API_ENABLED=false; SKIPPED_NO_RECORDS if nothing
-            remained to write after filtering; FAILED if the
+            SKIPPED_BY_CONFIG if SAPPHIRE_API_ENABLED=false;
+            SKIPPED_NO_RECORDS if nothing remained to write after
+            filtering; FAILED if the client is absent, or the
             readiness check failed. See `api_writer.WriteOutcome`.
     """
     # Validate inputs before any I/O
@@ -485,7 +486,7 @@ def _write_skill_metrics_to_api(data: pd.DataFrame, horizon_type: str, year: int
 
     if not SAPPHIRE_API_AVAILABLE:
         logger.warning("sapphire-api-client not installed, skipping skill metrics API write")
-        return WriteOutcome.SKIPPED_BY_CONFIG
+        return WriteOutcome.FAILED
 
     # Check if API writing is enabled (default: enabled)
     api_enabled = os.getenv("SAPPHIRE_API_ENABLED", "true").lower() == "true"
@@ -746,14 +747,15 @@ def _write_threshold_skill_metrics_to_api(data: pd.DataFrame, year: int) -> Writ
 
     Returns:
         WriteOutcome: WROTE if records were sent and accepted;
-            SKIPPED_BY_CONFIG if the client is absent or
-            SAPPHIRE_API_ENABLED=false; SKIPPED_NO_RECORDS if there was
-            nothing to write; SKIPPED_NOT_DEPLOYED if the endpoint isn't
-            deployed yet (Stage 2 pending); FAILED if the readiness check
-            failed or the write call raised any other exception. Note:
-            client construction and the readiness check itself (above)
-            can still raise uncaught -- only the region from here down is
-            exception-protected. See `api_writer.WriteOutcome`.
+            SKIPPED_BY_CONFIG if SAPPHIRE_API_ENABLED=false;
+            SKIPPED_NO_RECORDS if there was nothing to write;
+            SKIPPED_NOT_DEPLOYED if the endpoint isn't deployed yet
+            (Stage 2 pending); FAILED if the client is absent, the
+            readiness check failed, or the write call raised any other
+            exception. Note: client construction and the readiness check
+            itself (above) can still raise uncaught -- only the region
+            from here down is exception-protected. See
+            `api_writer.WriteOutcome`.
     """
     if data is None or data.empty:
         logger.info("No threshold skill metrics to write to API")
@@ -763,7 +765,7 @@ def _write_threshold_skill_metrics_to_api(data: pd.DataFrame, year: int) -> Writ
         logger.warning(
             "sapphire-api-client not installed, skipping threshold skill metrics API write"
         )
-        return WriteOutcome.SKIPPED_BY_CONFIG
+        return WriteOutcome.FAILED
 
     api_enabled = os.getenv("SAPPHIRE_API_ENABLED", "true").lower() == "true"
     if not api_enabled:

--- a/apps/postprocessing_forecasts/tests/test_api_integration.py
+++ b/apps/postprocessing_forecasts/tests/test_api_integration.py
@@ -520,7 +520,15 @@ class TestWriteSkillMetricsToApi:
         monkeypatch.setenv("SAPPHIRE_API_ENABLED", "true")
 
     def test_api_disabled_via_env_var(self, monkeypatch):
-        """When SAPPHIRE_API_ENABLED=false, API write should be skipped."""
+        """When SAPPHIRE_API_ENABLED=false, API write should be skipped.
+
+        Pin SAPPHIRE_API_AVAILABLE=True so this exercises the operator-choice
+        path specifically, not a coincidental overlap with the missing-client
+        path (see test_missing_client_returns_failed below) -- the two must
+        stay distinguishable rather than accidentally landing on the same
+        outcome for the same reason.
+        """
+        monkeypatch.setattr("src.api_writer.SAPPHIRE_API_AVAILABLE", True)
         monkeypatch.setenv("SAPPHIRE_API_ENABLED", "false")
         data = pd.DataFrame(
             {
@@ -537,6 +545,61 @@ class TestWriteSkillMetricsToApi:
         )
         result = _write_skill_metrics_to_api(data, "pentad", 2024)
         assert result is WriteOutcome.SKIPPED_BY_CONFIG
+
+    def test_missing_client_returns_failed(self, monkeypatch):
+        """When sapphire-api-client is absent, the write is a FAILED
+        attempt at a required dependency -- not a benign config skip.
+
+        SAPPHIRE_API_AVAILABLE is set only by whether the import succeeded
+        (api_writer.py:88-96); it is not an operator setting, so client
+        absence must never be reported the same way as the documented
+        SAPPHIRE_API_ENABLED=false opt-out.
+        """
+        monkeypatch.setattr("src.api_writer.SAPPHIRE_API_AVAILABLE", False)
+        data = pd.DataFrame(
+            {
+                "code": [12345],
+                "pentad_in_year": [1],
+                "model_short": ["LR"],
+                "sdivsigma": [0.5],
+                "nse": [0.8],
+                "delta": [0.1],
+                "accuracy": [0.9],
+                "mae": [5.0],
+                "n_pairs": [100],
+            }
+        )
+        result = _write_skill_metrics_to_api(data, "pentad", 2024)
+        assert result is WriteOutcome.FAILED
+
+    def test_missing_client_and_disabled_config_are_distinct(self, monkeypatch):
+        """Client-absent (FAILED) and SAPPHIRE_API_ENABLED=false
+        (SKIPPED_BY_CONFIG) must never collapse to the same outcome."""
+        data = pd.DataFrame(
+            {
+                "code": [12345],
+                "pentad_in_year": [1],
+                "model_short": ["LR"],
+                "sdivsigma": [0.5],
+                "nse": [0.8],
+                "delta": [0.1],
+                "accuracy": [0.9],
+                "mae": [5.0],
+                "n_pairs": [100],
+            }
+        )
+
+        monkeypatch.setattr("src.api_writer.SAPPHIRE_API_AVAILABLE", False)
+        monkeypatch.setenv("SAPPHIRE_API_ENABLED", "true")
+        missing_client_result = _write_skill_metrics_to_api(data, "pentad", 2024)
+
+        monkeypatch.setattr("src.api_writer.SAPPHIRE_API_AVAILABLE", True)
+        monkeypatch.setenv("SAPPHIRE_API_ENABLED", "false")
+        disabled_config_result = _write_skill_metrics_to_api(data, "pentad", 2024)
+
+        assert missing_client_result is WriteOutcome.FAILED
+        assert disabled_config_result is WriteOutcome.SKIPPED_BY_CONFIG
+        assert missing_client_result != disabled_config_result
 
     @patch("src.api_writer.SapphirePostprocessingClient")
     def test_api_not_ready_returns_false(self, mock_client_class):
@@ -1026,10 +1089,46 @@ class TestWriteThresholdSkillMetricsToApi:
         )
 
     def test_disabled_via_env_var_returns_skipped_by_config(self, monkeypatch):
-        """SAPPHIRE_API_ENABLED=false -> SKIPPED_BY_CONFIG (not a failure)."""
+        """SAPPHIRE_API_ENABLED=false -> SKIPPED_BY_CONFIG (not a failure).
+
+        Pin SAPPHIRE_API_AVAILABLE=True so this exercises the operator-choice
+        path specifically, not a coincidental overlap with the missing-client
+        path (see test_missing_client_returns_failed below).
+        """
+        monkeypatch.setattr("src.api_writer.SAPPHIRE_API_AVAILABLE", True)
         monkeypatch.setenv("SAPPHIRE_API_ENABLED", "false")
         result = _write_threshold_skill_metrics_to_api(self._threshold_data(), 2024)
         assert result is WriteOutcome.SKIPPED_BY_CONFIG
+
+    def test_missing_client_returns_failed(self, monkeypatch):
+        """When sapphire-api-client is absent, the write is a FAILED
+        attempt at a required dependency -- not a benign config skip.
+
+        SAPPHIRE_API_AVAILABLE is set only by whether the import succeeded
+        (api_writer.py:88-96); it is not an operator setting, so client
+        absence must never be reported the same way as the documented
+        SAPPHIRE_API_ENABLED=false opt-out.
+        """
+        monkeypatch.setattr("src.api_writer.SAPPHIRE_API_AVAILABLE", False)
+        result = _write_threshold_skill_metrics_to_api(self._threshold_data(), 2024)
+        assert result is WriteOutcome.FAILED
+
+    def test_missing_client_and_disabled_config_are_distinct(self, monkeypatch):
+        """Client-absent (FAILED) and SAPPHIRE_API_ENABLED=false
+        (SKIPPED_BY_CONFIG) must never collapse to the same outcome."""
+        data = self._threshold_data()
+
+        monkeypatch.setattr("src.api_writer.SAPPHIRE_API_AVAILABLE", False)
+        monkeypatch.setenv("SAPPHIRE_API_ENABLED", "true")
+        missing_client_result = _write_threshold_skill_metrics_to_api(data, 2024)
+
+        monkeypatch.setattr("src.api_writer.SAPPHIRE_API_AVAILABLE", True)
+        monkeypatch.setenv("SAPPHIRE_API_ENABLED", "false")
+        disabled_config_result = _write_threshold_skill_metrics_to_api(data, 2024)
+
+        assert missing_client_result is WriteOutcome.FAILED
+        assert disabled_config_result is WriteOutcome.SKIPPED_BY_CONFIG
+        assert missing_client_result != disabled_config_result
 
     def test_empty_data_returns_skipped_no_records(self):
         """An empty DataFrame short-circuits to SKIPPED_NO_RECORDS."""

--- a/doc/plans/working/pp051_p0a_client_absent_mapping_fix.md
+++ b/doc/plans/working/pp051_p0a_client_absent_mapping_fix.md
@@ -1,0 +1,131 @@
+# PP-051 P0a — a missing client is a failed write, not a config skip
+
+**Status:** Draft plan, reviewed (out-of-loop `codex exec`), not started. Fixes a defect in P0
+(`532bf00f`, merged via PR #433).
+**Revised** after review: the code change alone has **no operational effect** — see §3. The
+production fix is the pre-gate default in the `save_*` layer, which lands in P1-P3 and PP-054.
+
+---
+
+## 1. The defect
+
+P0 maps "client absent" to `WriteOutcome.SKIPPED_BY_CONFIG` — a non-failure. That is wrong:
+
+- `SAPPHIRE_API_AVAILABLE` is set **only** by whether the import succeeded
+  (`api_writer.py:88-96`). It is not an operator setting.
+- `sapphire-api-client` is a **required dependency** — a hard git pin at
+  `apps/postprocessing_forecasts/pyproject.toml:27`, not an optional extra.
+- The documented CSV-only path is `SAPPHIRE_API_ENABLED=false` (`doc/configuration.md:159`;
+  `doc/plans/sapphire_api_integration_plan.md:283`, `:321`). A **missing package** is documented
+  nowhere as supported.
+
+So a broken installation is reported as a deliberate choice. Quarterly, seasonal and daily are
+API-only: they write nothing and the recalc exits 0 — PP-051's exact failure mode, reintroduced by
+its own fix, in the case that most resembles a deployment accident.
+
+## 2. The two conditions are separable at the gate
+
+| Condition | Gate at each `save_*` | Writer called? | Correct meaning |
+|---|---|---|---|
+| `SAPPHIRE_API_AVAILABLE = False` (import failed) | **closed** | no | **failure** — required dependency missing |
+| `SAPPHIRE_API_ENABLED=false` (operator choice) | open | yes → `SKIPPED_BY_CONFIG` | benign |
+
+Every `save_*` gates on `SAPPHIRE_API_AVAILABLE` alone (`file_writer.py:339/341, 429/431, 614/616,
+624/626, 666/668, 701/703`); `SAPPHIRE_API_ENABLED` is checked **inside** the writers
+(`api_writer.py:491`, `:768`), after the gate. The two never share a path, so they can carry
+different outcomes unambiguously.
+
+**Correction to the parent plan's history:** round 2's review rejected the `False`-before-the-gate
+initialization on the grounds that it would break *both* client-absent *and*
+`SAPPHIRE_API_ENABLED=false`. Only the first is affected by the gate; the second always reaches the
+writer. `WriteOutcome` remains the right answer — it also fixes the no-records and Stage-2 cases —
+but the parent plan's §5 records the wrong reason.
+
+## 3. The code change is defensive only — this is the review's key correction
+
+The missing-client branches (`api_writer.py:486-488` skill, `:762-766` threshold) are **unreachable
+from every production call site**, because all six are already behind the `SAPPHIRE_API_AVAILABLE`
+gate. There are no other production callers. Changing those returns therefore has **no operational
+effect**; it matters for direct callers and tests, and it stops the wrong semantics being copied
+forward.
+
+**The production fix is D2: the pre-gate default in each `save_*`.** When the gate is closed, the
+`save_*` must resolve to failure, because the only thing that closes it is a missing required
+dependency. That lands in P1-P3 (pentad/decad, monthly, quarterly, seasonal) and in **PP-054** for
+the daily path.
+
+**Residual gap to state plainly:** DAILY and ALL runs can still exit 0 after writing no daily
+metrics until PP-054 implements the same gate fix. P0a does not close that.
+
+## 4. Decisions (reviewer-endorsed)
+
+- **D1 — map missing-client to `FAILED`.** No new member. Verified safe for every current consumer:
+  all six production callers discard the value or cannot reach the branch, non-asserting tests
+  ignore it, and no existing assertion covers this outcome.
+- **D2 — initialize the `save_*` outcome to `FAILED` before every `SAPPHIRE_API_AVAILABLE` gate**,
+  keeping `SAPPHIRE_API_ENABLED=false` mapped to `SKIPPED_BY_CONFIG` inside the writers.
+- **D3 — `ignore` mode does not downgrade the outcome.** `forecast_library.py:110-116` makes
+  `ignore` silent relative to `warn`; it suppresses logging, not failure accounting. The shipped LR
+  wrappers already return failure for caught errors under `warn`/`ignore`. Making failures invisible
+  to the exit code would be a separate feature, not a side effect of a logging mode.
+
+## 5. Changes
+
+**Code** — `apps/postprocessing_forecasts/src/api_writer.py`:
+1. `_write_skill_metrics_to_api` missing-client branch (`:486-488`) → `WriteOutcome.FAILED`.
+2. `_write_threshold_skill_metrics_to_api` missing-client branch (`:762-766`) → `WriteOutcome.FAILED`.
+3. Documentation that will otherwise contradict the code: the `SKIPPED_BY_CONFIG` member comment
+   (`:79`), the `WriteOutcome` class docstring (`:72-75`, calls client absence a benign
+   configuration state), and both writers' Returns docstrings (`:471-476`, `:747-756`).
+
+Do **not** touch `_write_combined_forecast_to_api` (`:190`) or any other writer — they still return
+`bool` and are out of scope. Note `api_writer.py:239` belongs to that function, not to a skill
+writer.
+
+**Tests** — the client-absent assertions the first draft assumed **do not exist**. Existing tests at
+`test_api_integration.py:522-539` and `:1028-1032` cover `SAPPHIRE_API_ENABLED=false`, not
+`SAPPHIRE_API_AVAILABLE=False`. So:
+- **Add** new missing-client tests for both writers asserting `FAILED`. Do **not** invert the
+  disabled-configuration tests — that would turn a benign state into a failure, the exact trap.
+- Keep the disabled tests asserting `SKIPPED_BY_CONFIG`, and pin `SAPPHIRE_API_AVAILABLE=True` in
+  them so the two conditions are distinguished rather than coincidentally equal.
+- One test asserting the two conditions yield **different** outcomes, so nothing can re-conflate
+  them silently.
+
+**Parent plan** — `pp051_recalc_write_failure_plan.md`. Contract 7 and §5 are **not sufficient**:
+the rejected mappings are hardcoded in phase-local prompts and criteria (`:689-704` P1, `:800-818`
+P2, `:866-884` P3, ignore-mode expectations `:714-724`, a mutation assertion `:742-744`, P5
+integration `:950-973`) and §1's narrative (`:143-166`) still calls client absence benign. Every one
+must be updated, or a phase will follow its local instructions and recreate the defect.
+
+**PP-054** — must carry the same D2 gate fix for the daily path.
+
+## 6. Out of scope — file separately
+
+`api_writer.py:491` / `:768` parse `SAPPHIRE_API_ENABLED` as `os.getenv(...).lower() == "true"`, so
+`"1"`, `"yes"` or a stray space read as deliberate disablement and yield a benign skip. Same
+silent-success class, different trigger.
+
+## 7. Acceptance criteria
+
+- RED first: the new missing-client tests fail against current trunk, using exact identity
+  (`assert result is WriteOutcome.FAILED`) — truthiness is vacuous here.
+- Both writers return `FAILED` when the client is absent and `SKIPPED_BY_CONFIG` when
+  `SAPPHIRE_API_ENABLED=false`, asserted as distinct outcomes.
+- Existing disabled-configuration tests still pass **unmodified in intent** (still `SKIPPED_BY_CONFIG`).
+- No other branch mapping, trigger condition, validation, filter or HTTP call changes.
+- `file_writer.py` and `recalculate_skill_metrics.py` untouched — D2 belongs to P1-P3/PP-054.
+- Mutation check: swap the two mappings, confirm the distinctness test goes red, restore.
+- Full unscoped `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh` — zero failures, zero
+  unexpected skips. Trust per-module pass counts, not the banner.
+
+## 8. Dependency graph
+
+```json
+{
+  "phases": {
+    "P0a": { "depends_on": [], "parallel_agents": 1 },
+    "P0b": { "depends_on": ["P0a"], "parallel_agents": 1, "note": "parent-plan + PP-054 edits per §5; must precede P1" }
+  }
+}
+```


### PR DESCRIPTION
## The defect

P0 (`532bf00f`, PR #433) mapped **client absent** to `WriteOutcome.SKIPPED_BY_CONFIG` — a non-failure. That is wrong:

- `SAPPHIRE_API_AVAILABLE` is set **only** by whether the import succeeded (`api_writer.py:88-96`). It is not an operator setting.
- `sapphire-api-client` is a **required dependency** — a hard git pin at `pyproject.toml:27`, not an optional extra.
- The documented CSV-only path is `SAPPHIRE_API_ENABLED=false` (`doc/configuration.md:159`, `sapphire_api_integration_plan.md:283`/`:321`). A *missing package* is documented nowhere as supported.

So a **broken installation** — dependency missing from the container, bad image build, version-mismatch import error — read as a deliberate choice. Quarter, season and daily are API-only, so they would write nothing while the recalc exits 0: PP-051's own failure mode, reintroduced by its fix, in the case that most resembles a deployment accident.

Found by an out-of-loop `codex exec` review of the plan whose output was not read before P0 shipped.

## The fix

Both writers return `FAILED` when the client is absent. The four documentation sites that promised otherwise are corrected: the `WriteOutcome` class docstring, the `SKIPPED_BY_CONFIG` member comment, and both writers' `Returns` docstrings.

The two conditions are **separable at the gate**, which is what keeps this small:

| Condition | Gate at each `save_*` | Writer called? | Outcome |
|---|---|---|---|
| `SAPPHIRE_API_AVAILABLE=False` (import failed) | **closed** | no | **`FAILED`** |
| `SAPPHIRE_API_ENABLED=false` (operator choice) | open | yes | `SKIPPED_BY_CONFIG` |

Every `save_*` gates on `SAPPHIRE_API_AVAILABLE` alone; `SAPPHIRE_API_ENABLED` is checked *inside* the writers (`:491`, `:768`), after the gate. They never share a path.

## Scope — this change has no operational effect, deliberately

The branches changed here are **unreachable from all six production call sites**, each already behind the availability gate. This is defensive: it stops the wrong semantics being copied forward and pins the distinction with tests.

**The production fix is the pre-gate default** in each `save_*` — when the gate is closed, the `save_*` must resolve to failure, since only a missing required dependency closes it. That belongs to P1–P3 and **PP-054**. **DAILY and ALL can still exit 0 after writing no daily metrics until PP-054 lands.** Stated in the plan rather than implied.

## Tests

The existing `SAPPHIRE_API_ENABLED=false` tests are **deliberately not inverted** — that state stays `SKIPPED_BY_CONFIG` because it is benign and documented. Inverting them would turn a supported configuration into a failure, which is the same defect class in the opposite direction. They now pin `SAPPHIRE_API_AVAILABLE=True` so they exercise the operator-choice path specifically.

New: client-absent tests on both writers, plus a **distinctness test** asserting the two conditions can never collapse to the same outcome.

- **RED first**: 4 new assertions failed against trunk with `assert <WriteOutcome.SKIPPED_BY_CONFIG> is <WriteOutcome.FAILED>`.
- **Mutation check**: swapping the mappings back reproduced the same 4 failures; restored, green.
- `postprocessing_forecasts`: **1768 passed, 1 xfailed**.
- Full unscoped `SAPPHIRE_TEST_ENV=True bash run_tests.sh`: **16/16 modules, zero failures**. Skips are pre-existing gates unrelated to this change (`long_term_forecasting` DataInterface, `forecast_dashboard` `[chromium]`, and two `@pytest.mark.skip` TODO placeholders in `preprocessing_runoff`).
- `git merge-tree` vs trunk: conflict-free.

## Noted while implementing, not fixed here

`_write_threshold_skill_metrics_to_api` has a second client-absent-shaped branch (`client is None` → `SKIPPED_BY_CONFIG`) that is currently **dead code** — `_get_postprocessing_client()` returns `None` only when the import failed, which the branch above now catches and returns `FAILED`. Left untouched per scope, but flagged: if anyone makes the earlier check non-returning, this becomes live with the wrong mapping.

Also out of scope: `SAPPHIRE_API_ENABLED` is parsed `.lower() == "true"`, so `"1"` or `"yes"` reads as deliberate disablement and yields a benign skip. Same silent-success class, different trigger — to be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)