### PR TITLE
PP-045: re-assessment, update plan, and CLI contract corrections

### DIFF
--- a/apps/postprocessing_forecasts/backfill_period_forecasts.py
+++ b/apps/postprocessing_forecasts/backfill_period_forecasts.py
@@ -1,11 +1,53 @@
 """PP-045 backfill CLI for stranded short-term PENTAD/DECADE period forecasts.
 
-Per-model PENTAD/DECADE period rows are created only by the operational path on
-boundary days. If an operational boundary day was missed, those rows are never
-written and routine maintenance cannot heal them (maintenance recalculates skill
-metrics, not period forecasts). This CLI re-aggregates a date range through the
-EXISTING operational aggregation + save path so the stranded rows are recomputed
-and written.
+Per-model PENTAD/DECADE period rows are written on boundary days by the
+operational path, which is the only path that writes them *on a schedule*. If an
+operational boundary day was missed, routine maintenance cannot heal it. This CLI
+re-aggregates a date range through the EXISTING operational aggregation + save
+path so the stranded rows are recomputed and written.
+
+What maintenance actually does (and does not)
+---------------------------------------------
+``postprocessing_maintenance.py`` does NOT recalculate skill metrics -- it *reads*
+them; ``recalculate_skill_metrics.py`` recalculates. And it DOES write period
+forecasts: its ``refresh_parts`` build emits refreshed stale individual/NE rows
+(block 7a), NE gap rows (7b) and EM rows (7c, "requires skill metrics"), then
+writes them straight to the API ("bypasses get_latest_forecasts").
+
+Its actual limitation is narrower, and is the reason this CLI exists: maintenance
+can only act on dates it can *discover*, and it builds that universe solely from
+existing ``combined`` rows. It returns early when combined is empty, and its
+``gap_detector.detect_missing_ensembles`` call omits the ``modelled_forecasts``
+argument that would widen the universe. A boundary date with ZERO combined rows is
+therefore invisible to it -- and even if it were made discoverable, its write set
+never emits fresh per-model rows for a newly-discovered date.
+
+Note also that ``recalculate_skill_metrics.py`` re-saves period rows as a side
+effect of a skill recalculation, so this CLI is not the only non-operational
+writer of them.
+
+What must be true for a date to be recoverable
+-----------------------------------------------
+This CLI re-runs the ordinary aggregation; it cannot invent inputs. For a given
+issue date to produce a row, TWO independent stages must both pass.
+
+1. The merged archive must yield a row for that issue date that survives the
+   boundary-day drop AND the in-period ``target`` filter (a daily target counts
+   only if ``get_pentad_in_year(target) == get_pentad_in_year(date + 1 day)``).
+   The row may come either from the DAY archive or from a retained pre-cutover
+   period-archive row -- ``_merge_archives_by_day_cutover`` keeps period rows for
+   dates before each (code, model)'s first DAY issue date. A DAY row is therefore
+   NOT strictly required, but a retained period row is not exempt from these
+   filters either.
+2. SEPARATELY, a surviving row reaches the API only if ``forecasted_discharge``
+   is non-null -- ``api_writer`` drops null-discharge records before the write.
+
+If a date yields nothing, the gap is upstream and this CLI cannot close it.
+``machine_learning/fill_ml_gaps.py`` and ``recalculate_nan_forecasts.py`` are the
+usual upstream tools, with one important caveat: ``fill_ml_gaps.py`` detects only
+gaps BETWEEN consecutive existing dates, so it cannot see an empty archive, a
+leading gap, or a trailing gap. A stale period with no forecasts on either side
+may be invisible to it.
 
 Whole-year granularity, ONE YEAR AT A TIME
 ------------------------------------------
@@ -16,6 +58,16 @@ The run iterates one calendar year per call to ``_run_short_term_postprocessing`
 once would collapse the same period across years into a single row and drop
 older years. Processing one year at a time keeps each year's period rows
 distinct.
+
+Only the YEARS of --start-date/--end-date matter
+-------------------------------------------------
+The day and month components are used ONLY for validation. The loop is
+``range(start.year, end.year + 1)`` and every selected year is reprocessed IN
+FULL, for every configured station. ``--start-date 2026-07-25 --end-date
+2026-08-10`` therefore does exactly the same work as ``--start-date 2026-01-01
+--end-date 2026-12-31``: it rewrites all of 2026. Sub-year bounds do NOT narrow
+the write set, and there is no option that does. Size the blast radius from the
+YEARS you pass and from ``--horizon``, never from the dates.
 
 Issue-date vs target (Dec 31 -> Jan 1)
 --------------------------------------
@@ -102,10 +154,11 @@ def _build_parser() -> argparse.ArgumentParser:
         required=True,
         metavar="YYYY-MM-DD",
         help=(
-            "First ISSUE date of the range to backfill (inclusive). The range is "
-            "interpreted by issue year; a target period starting Jan 1 of year Y "
-            "is healed by its Dec 31 (year Y-1) issue date, so include the prior "
-            "calendar year to heal it."
+            "First ISSUE date of the range to backfill. ONLY ITS YEAR IS USED: "
+            "every selected year is reprocessed in full for every configured "
+            "station, so a narrow date range does NOT narrow the work. A target "
+            "period starting Jan 1 of year Y is healed by its Dec 31 (year Y-1) "
+            "issue date, so include the prior calendar year to heal it."
         ),
     )
     parser.add_argument(
@@ -113,8 +166,8 @@ def _build_parser() -> argparse.ArgumentParser:
         required=True,
         metavar="YYYY-MM-DD",
         help=(
-            "Last ISSUE date of the range to backfill (inclusive). The range is "
-            "interpreted by issue year (the loop iterates over issue years)."
+            "Last ISSUE date of the range to backfill. ONLY ITS YEAR IS USED -- "
+            "the loop iterates whole issue years and reprocesses each in full."
         ),
     )
     parser.add_argument(

--- a/doc/plans/issues/review_gi_draft_pp_missed_boundary_period_gap.md
+++ b/doc/plans/issues/review_gi_draft_pp_missed_boundary_period_gap.md
@@ -1,8 +1,12 @@
 # PP-045 — Missed boundary-day operational run leaves short-term per-model period gap that maintenance cannot heal
 
-**Status**: Implemented — awaiting human review (Option B shipped on branch
-`fix_postprocessing_boundary_gap`, NOT pushed). Secondary decade-EM anomaly →
-separate ticket (still to file). See "Verification" and "Decision & Workplan".
+**Status**: Review — Option B **merged to trunk** via PR #425 (`cd97db57`,
+2026-07-23); commits `cce5922a` + `62bbba65`. Secondary decade-EM anomaly filed
+as PP-048. See "Verification", "Decision & Workplan", and the 2026-08-17
+re-assessment at the end of this file for what still blocks Complete.
+*(Header corrected 2026-08-17: the previous text said "shipped on branch
+`fix_postprocessing_boundary_gap`, NOT pushed" — stale; the branch is gone and
+`git merge-base --is-ancestor` confirms both commits are on `maxat_sapphire_2`.)*
 **Module**: postprocessing_forecasts
 **Priority**: High
 **Labels**: `postprocessing`, `data-integrity`, `operational`
@@ -617,8 +621,454 @@ owner.
 
 ---
 
+## Confirmed on trunk 2026-08-17 (tjhm)
+
+Re-assessment against `maxat_sapphire_2` @ `8e3fc1bc`. Every claim is tagged
+**PROVEN** (direct code read and/or a green test in this repo), **INFERRED**
+(consistent with the evidence, not established), or **REPORTED** (supplied to
+this session, not re-verified here). This section was itself put through an
+out-of-loop adversarial review (`codex exec`, read-only, fresh context) before
+being committed; that reviewer refuted several claims in the first draft, and the
+corrections are folded in below — including one that corrects this issue's own
+original premise (§A6).
+
+### A. Code re-verification — PROVEN
+
+1. **The fix is on trunk.** `apps/postprocessing_forecasts/backfill_period_forecasts.py`
+   and `tests/test_backfill_period_forecasts.py` exist at `8e3fc1bc`;
+   `git merge-base --is-ancestor` succeeds for both `cce5922a` and `62bbba65`;
+   the file first appears on the first-parent history at `cd97db57` "Merge pull
+   request #425". The branch is deleted — treat as merged.
+
+2. **The yearless-dedup rationale for one-year-at-a-time is still accurate.**
+   `file_writer.get_latest_forecasts` sorts by `date` descending and calls
+   `drop_duplicates(subset=["code", <period_col>, "model_short"], keep="first")`
+   (`src/file_writer.py:118`) **before** applying `year >= latest_year - 1`
+   (`:124`). The key carries no year, so the same period-in-year across two years
+   collapses to the later row. The load-bearing detail: `save_forecast_data`
+   hands **`simulated_latest`** — the deduped frame — to
+   `api_writer._write_combined_forecast_to_api` (`:244`), so the collapse reaches
+   the API write and is not merely a CSV artifact. Locked by
+   `TestGetLatestForecastsCollapsesAcrossYears::test_same_period_two_years_collapses_to_later_year`.
+   The CLI docstring's "ONE YEAR AT A TIME" section is correct as written. (The
+   underlying defect remains open as PP-046.)
+
+3. **Maintenance still cannot discover a zero-`combined` date.**
+   `postprocessing_maintenance.py:185` early-returns on empty combined; `:192`
+   calls `gap_detector.detect_missing_ensembles(...)` **without**
+   `modelled_forecasts`, which the detector still accepts and still uses to widen
+   its universe (`src/gap_detector.py:88`). Unchanged from the original diagnosis.
+
+4. **Test suite green on trunk** — *this item is REPORTED, not PROVEN: the run
+   happened in the 2026-08-17 session and no durable log is attached, so it is not
+   reproducible from this file. Re-run to confirm.*
+   `SAPPHIRE_TEST_ENV=True bash run_tests.sh postprocessing_forecasts` →
+   **1832 passed, 1 xfailed, 0 failed, 0 skipped** (30.7 s).
+   **PROVEN (static):** `test_backfill_period_forecasts.py` contains **23** test
+   methods (an earlier draft of this section said 26 — a miscount that included
+   `class` lines; 23 matches the 2026-07-23 record above).
+
+5. **`validate_pipeline` structurally cannot see a stranded historical boundary
+   day.** `run_tier1_short_term` computes
+   `boundary = most_recent_pentad_boundary(forecast_date)`
+   (`apps/validate_pipeline/validate_pipeline.py:389`) and queries every
+   configured short-term model over `[boundary, forecast_date]` only (`:459`). On
+   2026-08-17 that window is `[2026-08-15, 2026-08-17]`. **PROVEN:** the window
+   never looks further back than the most recent boundary, so any earlier stranded
+   day is outside it by construction. **INFERRED (not verified here):** that the
+   validator therefore actually returned PASS on the reported tjhm data — that
+   depends on DB contents this session did not query. Same family as INFRA-024 (a
+   check that cannot fail) and INFRA-026 (expectations that do not match the
+   product's schedule); neither currently names the "historical boundary day
+   silently empty" case, so it should be added to one of them.
+
+6. **CORRECTION to this issue's own premise: per-model PERIOD rows are written by
+   at least three entrypoints, not "only the operational code path".** The
+   Summary and Problem sections above say per-model period rows "are created
+   **only** by the operational code path". That is wrong on trunk:
+   - `postprocessing_operational.py` — the boundary-gated path (as described).
+   - `recalculate_skill_metrics.py::_run_short_term_recalc` — calls
+     `file_writer.save_forecast_data(config, modelled)` (`:233`) after
+     re-aggregating, i.e. it writes per-model PERIOD rows as a side effect of a
+     skill recalculation.
+   - `backfill_period_forecasts.py` — PP-045's own CLI.
+   Plus `apps/machine_learning/reaggregate_day_to_periods.py`, which upserts
+   individual/NE period rows by raw SQL (un-wired, noted in the original analysis).
+
+   Two consequences worth carrying:
+   - Observing a PERIOD row for a date does **not** identify which entrypoint
+     produced it. Any diagnosis that reasons backwards from "a period row exists,
+     therefore an operational run happened" is unsound (see §C).
+   - `_run_short_term_recalc` calls `read_observed_and_modelled_data(config.name,
+     codes=codes)` with **no** `start_year`/`end_year`
+     (`recalculate_skill_metrics.py:191`), and those parameters default to `None`
+     = unbounded (`src/data_reader.py:2746-2751`). So the ST skill recalc reads
+     **every** year at once and then saves through the same yearless-key dedup as
+     everything else (`src/file_writer.py:118`) — precisely the multi-year collapse
+     that PP-046 describes and that PP-045's CLI iterates per year to avoid. Stated
+     precisely: the unbounded input is collapsed to **one row per
+     `(code, period_in_year, model_short)`**, then filtered to the last two years.
+     It is therefore *not* true that the recalc writes rows across all years, and
+     *not* true that only the latest year survives — a period-in-year absent from
+     the latest year can retain its prior-year row. The net effect is a silent
+     *under-write* (at most one row per period-in-year reaches the API, regardless
+     of how many years were read), not data loss, since rows are upserted rather
+     than deleted. **Not fixed here** — record and file as a new ticket per the
+     repo's found-while-mapping rule; it is the strongest concrete argument that
+     PP-046 is worth fixing.
+
+### B. Field evidence — REPORTED, not re-run here
+
+This session was read-only and did not query the shared DBs (a concurrent module
+review held the tunnels). Recorded verbatim as context:
+
+- LR raw forecasts (`/lr-forecast/`, pentad) present for **all** issue days
+  including 2026-07-25, 07-31, 08-05, 08-10 (78 rows each).
+- Per-model PERIOD rows (`/forecast/?horizon=pentad`) present **only** for
+  07-05, 07-10, 07-15, 07-20 and 08-15 — the four days above are absent.
+- `maintenance:postprocessing_forecasts` ran (26 s, PASS, ~12.8k records,
+  13-month window) and created none of them; it only enriched dates that already
+  had `combined` rows.
+- EM **and** NE both absent for the four days.
+
+A similar signature was independently recorded on kghm on 2026-08-14
+(`doc/dev/review_checklist_local_2026-08-14_kyg.md`: "TFT pentad present only for
+08-15, nothing for 08-05/08-10") — but that record explicitly labels its own
+PP-045 attribution as underdetermined (`:2158`) and also records an LR **hindcast**
+run producing fourteen write batches (`:2122`). So kghm is a second *observation*,
+not a second confirmation, and it must be probed on its own data and config
+(§E) rather than assumed to share tjhm's cause. That checklist additionally
+states PP-045's fix is "not on trunk" — stale and wrong; PR #425 merged
+2026-07-23, three weeks earlier. What it actually observed is trunk behaviour
+*with* the fix present, because the fix is a manual tool that nobody ran.
+
+### C. What is established, and what decides the diagnosis — READ THIS FIRST
+
+**Established (PROVEN, code-only):** maintenance cannot heal a zero-`combined`
+boundary date (§A3), and the validator's window cannot see one (§A5). Those two
+facts are independent of any DB state.
+
+**REPORTED, not proven here:** that the condition is currently live on tjhm and
+kghm (§B). This session did not query the DBs; the kghm record self-labels as
+underdetermined. Do not cite §B as proof of a live defect until §E runs.
+
+**Two earlier inferences are withdrawn:**
+
+- ~~"An operational pentad run executed on 2026-08-15, because only operational
+  writes per-model PERIOD rows."~~ **Refuted by §A6** — at least three entrypoints
+  write those rows. The producer of the 08-15 rows is unknown.
+- ~~"LR rows on all four days indicate the pipeline was invoked on those days."~~
+  **Refuted** — `linear_regression.py` has a `--hindcast` mode that iterates
+  historical forecast dates (`:698`, `:813`), and the kghm checklist records
+  exactly such a hindcast. LR presence carries no information about when, or
+  through which mode, those rows were created.
+
+**The remaining question, which decides everything:** for each (code, model) and
+each of the four dates, did a **usable row survive merged-archive normalization**
+at the time the aggregation ran? Note this is *not* the same as "does a DAY row
+exist": `_read_ml_forecasts_pp_api` fetches both `horizon="day"` and the migrated
+period archive and merges them (`src/data_reader.py:2194`), retaining period rows
+for dates before each (code, model)'s first DAY issue date
+(`_merge_archives_by_day_cutover`, `:2087`, `:2148`). With no DAY rows at all it
+returns the period archive unchanged. LR presence in `/lr-forecast/` is
+independent of both (`:2630`), and LR is dropped before the combined write —
+returning `False` if the frame is LR-only (`src/api_writer.py:230`, `:242`).
+
+**Decision tree — the first draft's H1/H2 split was not exhaustive.** At least
+six distinct causes produce the observed pattern, and they need different fixes:
+
+| # | Cause | How to detect it | Who fixes it |
+|---|---|---|---|
+| C1 | No usable row for those issue dates in either archive | **Derived-frame probe (P2), not a log line.** `No <model> forecasts from API` (`src/data_reader.py:2661`) fires only when the *entire* scoped read is empty, so it cannot single out four missing dates when other dates exist. | `machine_learning` (see caveat below) |
+| C2 | Rows present, `target` outside the following period | `Filtered %d/%d daily targets outside …` (`src/data_reader.py:2418`) — an **aggregate count**, not per-date; a non-zero count says "look here", P2 says which dates | ML output / aggregation filter |
+| C3 | Rows present, `forecasted_discharge` NULL | `Dropped %d null-discharge forecast records …` (`src/api_writer.py:413`), again aggregate | ML output. `recalculate_nan_forecasts.py` is the usual tool but is **not** a general remedy — it selects only flag `1`/`2` rows, not every null-discharge row |
+| C4 | Rows exist **now** but were absent/unreadable **during** the historical run — the reader turns exceptions into `None` (`src/data_reader.py:2183`, `:2198`) | historical operational log only; no query of current state can see this | transient; needs log evidence |
+| C5 | Codes or models excluded by the operational station-selection or `ieasyhydroforecast_available_ML_models` config (station scoping invoked at `postprocessing_operational.py:146`; the model gate and config parsing follow `src/data_reader.py:2646`) | config diff, not DB | configuration |
+| C6 | Rows usable and written, but the write silently under-persisted (PP-047: `_write_combined_forecast_to_api` receives a server `count` but returns `True` without comparing it to the submitted record count, `src/api_writer.py:445`, `:463`) | server-side count vs submitted | PP-047 |
+
+Only **C6**, and a hypothetical seventh case where everything above is clean and
+the rows still never appeared, would represent a genuine *new* defect in PP-045's
+territory. C1–C5 mean the four days are **not** a PP-045 reproduction: PP-045's
+original "self-heals at the next within-year boundary run" claim survives (its
+stated proviso (a) — "the DAY archive still holds those issue dates" — simply
+failed), and `backfill_period_forecasts.py` cannot recover them, because it
+re-runs the same aggregation over the same inputs.
+
+**Caveat on the C1 remedy.** The obvious upstream tool is
+`machine_learning/fill_ml_gaps.py` (wired into `maintenance:machine_learning` and
+the default ML `RUN_MODE`; the orchestrator already sequences ML maintenance
+before postprocessing maintenance, `apps/pipeline/pipeline_docker.py:1860`). But
+its gap detection only examines gaps *between consecutive dates for codes already
+present* (`fill_ml_gaps.py:265`, `:278`, `:304`) — it cannot discover an empty
+model/code archive, a leading gap, or a trailing gap. If the first DAY date is
+around 08-13/08-15, the four earlier dates may be invisible to it as well, which
+would explain why routine maintenance did not close the gap. Verify before
+recommending it as the remedy.
+
+Also note the mechanism that keeps the *existing* period rows alive:
+`_merge_archives_by_day_cutover` retains period-archive rows for dates before each
+(code, model)'s first DAY issue date, so 07-05..07-20 can be re-emitted unchanged
+from the period archive with no DAY data behind them. A DAY archive that begins
+around 08-13 would reproduce the entire observed pattern on its own.
+
+### D. Two defects in the shipped artefact's stated contract — PROVEN
+
+1. **Inaccurate parenthetical.** `backfill_period_forecasts.py:3-8` says
+   maintenance "recalculates skill metrics, not period forecasts". Both halves are
+   wrong. Maintenance *reads* skill metrics, it does not recalculate them (that is
+   `recalculate_skill_metrics.py`), and it *does* write period forecasts —
+   refreshed individual, NE and EM rows (`postprocessing_maintenance.py:291`,
+   `:348`, `:380`). What it cannot do is discover a date with zero `combined`
+   rows, and its write set never emits fresh per-model rows for a newly-discovered
+   date. The rest of this issue states it correctly; only the CLI docstring is
+   wrong, and an operator reading only the CLI would draw the wrong conclusion
+   about what maintenance did.
+
+2. **Understated precondition.** Neither the docstring nor `--help` states what
+   the backfill actually requires: **a usable row must survive merged-archive
+   normalization for that issue date** — a DAY row with an in-period `target` and
+   a non-null discharge, *or* a retained pre-cutover period-archive row. The first
+   draft of this section wrote "ML DAY rows must exist", which is too strong: with
+   no DAY rows the reader falls back to the period archive
+   (`src/data_reader.py:2103`, `:2148`, `:2194`). The docstring should state the
+   real precondition, name the three filters that can silently empty a date
+   (boundary drop, in-period target filter, null-discharge drop), and point at the
+   upstream tools (`fill_ml_gaps.py`, `recalculate_nan_forecasts.py`) **with** the
+   caveat in §C that `fill_ml_gaps.py` cannot see leading/trailing gaps.
+
+Both are documentation-only fixes to a shipped file; neither changes behaviour.
+They are **blocking**, not cosmetic — this issue's own Desired Outcome states
+that "done" includes "the behavior is documented".
+
+### E. Verification design — DESIGNED, NOT RUN
+
+Not run this session: the shared DBs and SSH tunnels were in use by a concurrent
+module review, and the constraint was read-only. **P0–P3 are read-only and safe to
+run alone. P4 writes and needs owner go-ahead plus an idle tunnel.** Run the whole
+sequence **independently on tjhm and on kghm** — §B establishes two observations,
+not one shared cause.
+
+- **P0 (config, read-only).** Record, per org: `ieasyhydroforecast_run_ML_models`,
+  `ieasyhydroforecast_available_ML_models`, and the station-selection file's
+  `stationsID`. A code or model absent here is cause **C5** and explains the gap
+  with no DB work at all.
+- **P1 (logs, read-only, no DB access).** Preserve the historical operational and
+  maintenance logs covering 2026-07-20 → 2026-08-17 **before any write**, then grep
+  them for: `No <model> forecasts from API` (**C1**),
+  `Filtered %d/%d daily targets outside` (**C2**),
+  `Dropped %d null-discharge forecast records` (**C3**),
+  `No non-LR forecast records to write`, and any reader exception around the ML
+  fetch (**C4**). Read these as *signals, not verdicts*. The two filter lines
+  (`Filtered …`, `Dropped …`) carry an aggregate count for the whole run and never
+  the specific dates or codes, so a non-zero count says "C2/C3 is in play" and P2
+  says which dates. The other three carry no count at all: they are presence/absence
+  markers for the whole scoped read. What makes
+  this step non-optional is **C4** — an input that was absent or unreadable *then*
+  and is present *now* leaves no trace in current DB state, so the log is the only
+  evidence that will ever exist for it. Run it first, and preserve the logs before
+  anything writes.
+- **P2 (derived frame, read-only) — the primary discriminator.** Do **not** stop at
+  counting raw rows: that inspects the wrong frame and cannot separate C1 from
+  C2/C3. Call the production reader on the real config and print exact coverage:
+  `data_reader.read_observed_and_modelled_data("pentad", codes=<selection>,
+  start_year=2026, end_year=2026)`, then print
+  `(date, code, model_short, forecasted_discharge)` for the four dates plus the
+  controls. This exercises the archive merge, boundary drop, in-period target
+  filter, aggregation and station scoping. **It is not the final write payload** —
+  it still contains LR, may contain null-discharge rows, and precedes virtual
+  stations, NE, EM, the yearless-key dedup and the writer's LR/null/dedup filters.
+  What it establishes is the necessary condition: if the four dates are absent
+  *here*, no backfill can write them, and the cause is C1–C5. Reading is
+  side-effect-free; nothing is saved.
+- **P3 (controls + cutover).** Same query for 2026-08-15 (a date that does have
+  period rows) and 2026-07-20 (present, but possibly served from the retained
+  period archive rather than DAY). Separately — the derived frame has discarded
+  archive origin, so this cannot come from P2 — query the raw archives directly for
+  each (code, model)'s **first DAY issue date**:
+  `client.read_short_term_forecasts(horizon="day", model=<M>, code=<code>)` and
+  take the minimum `date`. That is the cutover boundary; a DAY archive beginning
+  ~08-13 explains the whole pattern.
+- **P3b (branch).** Map the result onto the C1–C6 table in §C and route
+  accordingly. C1–C5 ⇒ **not a PP-045 reproduction**; file the real cause against
+  the owning module and do not attribute these days to PP-045. C6 or "all clean
+  and still absent" ⇒ re-open the within-year self-heal analysis in this issue
+  **before** running any backfill.
+- **P4 (only if P3b lands on C6/unexplained; writes; owner go-ahead required).**
+  - Snapshot the affected rows (counts + values) before touching anything.
+  - **`--horizon pentad` only.** The reported anomaly is pentad-specific, and the
+    CLI expands each touched year to a whole-year read and save
+    (`backfill_period_forecasts.py:203`, `:209`); `--horizon both` would needlessly
+    rewrite the entire 2026 decad population and its EM rows.
+  - `--dry-run` first, but do **not** treat its output as coverage proof: the
+    dry-run logs only total rows, distinct period count and distinct model count
+    (`postprocessing_operational.py:197`) — it never lists dates or codes and
+    cannot show whether the four dates survive. P2 is the coverage evidence.
+  - Then the real run (API-only, `require_api=True`), then an **exact post-write
+    read-back** of the four dates for all five DB models. The read-back is
+    mandatory, not a nicety: PP-047 means `require_api=True` catches
+    API-unavailable / exception / explicit-`False` but **not** a `True` returned
+    over a zero or partial server write.
+  - Then re-run once and confirm counts are unchanged (idempotence), mirroring the
+    2026-07-23 verification recorded above.
+
+Caveat that applies to P4 under any cause: EM is recomputed against **current**
+skill metrics (`postprocessing_operational.py:170`, `:187`;
+`src/ensemble_calculator.py:115`, `:165`), so a backfill of historical dates does
+not replay the original ensemble values.
+
+### F. Manual vs automatic — ANSWER AND RECOMMENDATION
+
+**Recommendation: keep the *repair* manual; open a separate small ticket for
+*detection and reporting*. Do not make PP-045 self-repairing.**
+
+Three honest arguments, with the overreach of the first draft removed:
+
+- **A postprocessing-side automatic repair is not sufficient on its own.** Under
+  causes C1–C5 (§C) there is no usable input to aggregate, so a PP-side healer
+  would run, find nothing, and — absent care — report success. This does **not**
+  mean automatic repair is impossible: the orchestrator already sequences ML
+  maintenance before postprocessing maintenance
+  (`apps/pipeline/pipeline_docker.py:1860`), so a coordinated upstream-plus-PP
+  automation is conceivable. But it would need cross-module contracts that do not
+  exist today (notably a `fill_ml_gaps.py` that can see leading/trailing gaps, and
+  PP-047's write-count check), which is a substantially larger design than PP-045.
+- **Repair rewrites history.** EM is recomputed against current skill metrics
+  (confirmed, §E caveat), so a backfill of historical dates does not replay the
+  original ensemble values whenever the inputs or skill membership have changed.
+  It is *not* true that every invocation changes them — unchanged inputs are
+  deterministic — and it is *not* true that this feeds back into the short-term
+  skill store: `recalculate_skill_metrics.py` recomputes skill from raw
+  observed/modelled data and explicitly excludes EM re-derivation (`:191`, `:219`,
+  `:224`). The exposure is to downstream consumers of historical EM —
+  `forecast_skill_eval`, dashboards, bulletins. A tool an operator invokes
+  deliberately, having read that caveat, is a different risk from a cron job doing
+  it unattended.
+- **The blast radius is a whole calendar year.** The CLI's granularity is a full
+  year per pass by construction (whole-year read plus PP-046's yearless-key
+  constraint). Acceptable for a deliberate recovery; poor as automatic behaviour.
+
+The case for *some* automation is nonetheless strong, and this session's evidence
+is why: a routine three-week dev-machine staleness produced four apparently
+stranded issue days, and **no layer reported it** — maintenance ran green, and the
+validator's window (§A5) never looks further back than the most recent boundary.
+Silence here is indistinguishable from health.
+
+**Recommendation: detect-and-report, never auto-fix.**
+
+- **Where:** `maintenance:postprocessing_forecasts` — it runs frequently from cron
+  and is where an operator already looks. Emit a WARN listing boundary dates in the
+  lookback window with zero per-model period rows and, because that is the
+  operator's actual next decision, which of the C1–C6 causes the evidence points
+  at. **No writes, no exit-code change** (the exit contract is PP-051/PP-055
+  territory; do not entangle them).
+- **Cost — corrected, and not as cheap as the first draft claimed.** Maintenance
+  does *not* already own this. `read_combined_forecasts` reads the combined archive
+  **without date bounds** (`src/data_reader.py:844`); the 13-month cutoff lives in
+  `gap_detector` and is relative to the maximum observed date (`:72`, `:80`); and
+  maintenance never enumerates *expected* boundary dates at all — it only ever
+  reasons about dates that already exist. A zero-row detector therefore needs three
+  things that do not exist yet: an expected-boundary calendar, an active
+  code/model history (so retired stations do not alarm), and DAY/archive
+  availability logic (so C1 is reported as an upstream gap rather than a PP gap).
+  Small, but a real ticket — not a two-line WARN.
+- **Why not `validate_pipeline`:** that is where such a check morally belongs, but
+  its expectation model is itself under repair (INFRA-024 / INFRA-026). Adding a
+  boundary-history sweep before those land risks re-opening INFRA-026 from the
+  other side — a check that fires on healthy deployments. Lift it there afterwards.
+- **Honest counter-argument:** `postprocessing_maintenance.py` already carries the
+  most contested write/exit semantics in the module (PP-007, PP-024, PP-051,
+  PP-055), and a WARN nobody reads is not detection. Mitigation: the change touches
+  no write path, and the post-run log scan in the local review checklists
+  (`doc/dev/review_checklist_local_*.md` §8a) already greps these logs.
+
+**File as a new ticket, do not bundle into PP-045.** PP-045's scope was "provide a
+recovery mechanism", and that is delivered. "Make the condition visible" is a
+different contract with a different risk profile. **Do not assume PP-056 is free:**
+it is unused on trunk `8e3fc1bc` but claimed by an uncommitted entry (quarter
+skill-metric `horizon_value=0`) in a parallel session's working copy of
+`doc/plans/module_issues.md`. Allocate against the *current* index, not trunk's.
+
+### G. Remaining checklist to move Review → Complete
+
+**Blocking — evidence:**
+
+- [ ] Run P0–P3b (§E, read-only) **on tjhm** and record the outcome here.
+- [ ] Run P0–P3b **on kghm** independently — §B is two observations, not one
+      confirmed cause, and the kghm record self-labels as underdetermined.
+- [ ] Preserve the 2026-07-20 → 2026-08-17 operational/maintenance logs for both
+      orgs **before** any write. Cause C4 (input absent *then*, present *now*) is
+      invisible to any query of current DB state; the logs are the only evidence.
+- [ ] Resolve the deferred kyg criterion. As written it demands the **kyg server**;
+      the 2026-08-14 kghm local review reproduced a *condition* on kyg data but
+      never exercised the *fix*. Owner decision: exercise the backfill on kghm
+      locally (equivalent evidence, available now) or formally waive/downgrade the
+      criterion with a rationale. This is the only Acceptance Criterion above still
+      unchecked.
+
+**Blocking — the tool is invisible to operators, and "documented" is in this
+issue's own Desired Outcome:**
+
+- [ ] `doc/prod/` runbook entry for `backfill_period_forecasts.py`. Currently
+      referenced only in this issue, `doc/plans/module_issues.md`, and the
+      `doc/dev/review_checklist_local_*.md` diagnostics tables. For a
+      manual-recovery tool the operator-facing runbook *is* the deliverable.
+      It must require an **exact post-write read-back** (PP-047: the writer can
+      return `True` over a zero/partial persist) and recommend `--horizon` scoped
+      to the affected horizon rather than `both`.
+- [ ] CLI docstring fix 1 — the maintenance parenthetical (§D1), including that
+      maintenance does *not* recalculate skill metrics.
+- [ ] CLI docstring/`--help` fix 2 — the real precondition and the three silent
+      filters (§D2), with the `fill_ml_gaps.py` leading/trailing-gap caveat.
+- [ ] `apps/postprocessing_forecasts/README.md` — recovery procedure (no backfill
+      section exists at all).
+- [ ] `doc/data_flow_short_term.md` — the backfill as the recovery path for
+      stranded period rows.
+
+**Non-blocking corrections (factual, safe to apply):**
+
+- [ ] This issue's Summary/Problem sections still say per-model period rows are
+      created "only" by the operational path — corrected in §A6, but the prose
+      above should be fixed too so the two halves of the file agree.
+- [ ] `doc/dev/review_checklist_local_2026-08-14_kyg.md` — three errors, not one:
+      the stale "not on trunk" claim; the "period rows are written **only**
+      operationally" claim (`:4924`); and the diagnostics-table row that reads
+      "per-model period rows present but EM/NE absent ⇒ PP-045" (`:5179`), when
+      PP-045 concerns *missing per-model rows* and EM has a separate skill gate.
+      Dated review record — the owner should choose correct-in-place vs annotate.
+- [ ] `doc/plans/module_issues.md` PP-045 row — Status cell still reads "Option B
+      implemented (branch `fix_postprocessing_boundary_gap`)"; should read merged
+      via PR #425. **Deliberately not edited on 2026-08-17**: a concurrent session
+      had uncommitted changes to that file, and a one-row edit on a separate branch
+      would have handed them a needless conflict.
+- [ ] Claude memory — the self-heal-within-year vs permanent-across-year nuance,
+      the real backfill precondition, and the three-writers correction (§A6).
+
+**New tickets to file (found while mapping; per repo rule, not fixed here):**
+
+- [ ] **ST skill recalc reads all years and saves through the yearless-key dedup**
+      (§A6). `recalculate_skill_metrics.py:191` passes no year bounds; the save
+      path collapses period-in-year across years. Silent under-write, not data
+      loss. Strongest concrete instance of PP-046.
+- [ ] **Detect-and-report for stranded boundary days** (§F). Allocate a free ID —
+      allocate against the *current* `module_issues.md`, not trunk's (see §F —
+      PP-056 is free on trunk but claimed in a parallel session's working copy).
+
+**Owner decisions still open (carried forward, unchanged):**
+
+- [ ] API-only-by-default write (`--write-csv` opt-in) — behavioural choice on the
+      combined-CSV artifact; owner may override to CSV+API.
+
+**Explicitly NOT blocking Complete:** PP-046 (yearless key — worked around by the
+per-year loop), PP-048 (decade EM freeze). **PP-047 is not a code blocker either,
+but it does change the runbook**: without a post-write read-back, the manual
+recovery can report success after zero/partial persistence.
+
+---
+
 ## References
 
 - Investigation + independent (codex) verification: this session (2026-07-17).
+- 2026-08-17 status re-assessment (trunk `8e3fc1bc`, tjhm evidence): sections
+  "Confirmed on trunk 2026-08-17" above.
 - Related: PP-007, PP-024, PP-023, PP-031; prior art
   `apps/preprocessing_runoff/backfill_discharge_aggregation.py`.

--- a/doc/plans/working/pp045_issue_draft_update_plan.md
+++ b/doc/plans/working/pp045_issue_draft_update_plan.md
@@ -213,16 +213,19 @@ un-rollback-able whole-year write is a worse outcome than leaving the question o
 
 ## 4. Phasing rationale
 
-P0 runs **first and immediately**, before any other work: it preserves evidence that
-expires. All three short-term writers — operational, maintenance and
-`recalculate_skill_metrics.py` — use `TimedRotatingFileHandler(when="midnight",
-backupCount=30)`, so logs age out on a rolling basis. Note the retention is a
-*rotation count*, not a wall-clock TTL: 30 backups equals ~30 days only if rollover
-happens daily, which it does not on days the job never runs. Either way, 2026-07-20 is
-28 rollovers back as of 2026-08-17 — at the edge. Deferring preservation until P4 — as
-the first revision did — risks
-losing the only evidence that can ever distinguish cause C4 (input absent *then*, present
-*now*), because no query of current state can recover it.
+P0 runs first because it preserves the only evidence that can ever distinguish cause C4
+(input absent *then*, present *now*) — no query of current state can recover it. All three
+short-term writers — operational, maintenance and `recalculate_skill_metrics.py` — use
+`TimedRotatingFileHandler(when="midnight", backupCount=30)`.
+
+**Corrected 2026-08-17 after running P0 — the earlier urgency framing was wrong.** This
+plan previously called P0 time-critical, reasoning from `backupCount=30` to roughly 30
+days of retention. That is not how it behaves: rotation happens only on days the job
+actually runs, so the 30 retained backups span **2026-04-01 → 2026-08-16**, about four and
+a half months. Evicting the 2026-07-24 file would take ~30 further run-days. P0 remains
+first — it is cheap and it must precede anything that writes — but it is **not** a race.
+The lesson is worth keeping: this premise survived three adversarial review passes and was
+corrected only by looking at the directory.
 
 P1 and P2 are independent of each other and run in parallel. P3 depends on P2 because the
 corrected docstring is the source text the runbook quotes; writing the runbook first
@@ -264,6 +267,25 @@ Steps:
 
 - **Acceptance:** an inventory listing exists naming every file captured and every gap in
   the sequence, dated.
+
+**STATUS: DONE — 2026-08-17.** 155 files (2.8 MB) copied to
+`~/sapphire_evidence/pp045_2026-08-17/logs/`, with `INVENTORY.md` alongside. Kept outside
+any repo: the source is gitignored because it carries operational data. Three results,
+recorded here because they change later phases:
+
+- **The run-day sequence is itself evidence.** `log_operational.2026-07-24` (mtime Jul 24)
+  is followed directly by `log_operational.2026-08-13` (mtime Aug 13) — a **20-day gap
+  with no runs**, spanning all four stranded pentad issue days (07-25, 07-31, 08-05,
+  08-10). This is direct corroboration for **C1**, not proof of it: absence of a rotated
+  file is strong but not conclusive, and LR rows exist for all four days, so something ran
+  later — most plausibly an LR hindcast. P4 must still confirm from contents.
+- **Retention is not a race** — see §4.
+- **Contamination trap.** The live `log_operational` (no date suffix) has mtime
+  2026-08-17 14:10, which is this session's `run_tests.sh`: the backfill tests write into
+  `apps/logs/`. Do not read the live file as operational history, and snapshot before
+  running the suite.
+- **Org attribution is not available from filenames.** The same log paths are reused for
+  whichever `.env` was active, so tjhm/kghm separation requires log *contents*.
 
 ### P1 — Reconcile the draft with itself
 
@@ -364,6 +386,19 @@ Steps:
     **unmodified** (C4, regression check).
   - `--help` renders; the year-semantics correction is visible in it.
 
+**STATUS: DONE — 2026-08-17.** All four steps applied.
+
+- **C4 scope proof, mechanised.** Rather than eyeballing the diff, both versions were
+  parsed with `ast`, docstrings stripped and every `help=`/`description=` value replaced
+  with a placeholder; the resulting trees are **identical**. That is positive evidence no
+  executable code changed, which a reviewed diff only approximates.
+- **Regression check:** 1832 passed, 1 xfailed, 0 failed, 0 skipped — identical to the
+  trunk baseline, with `tests/` unmodified (`git status` clean for that path).
+- **`--help` verified** to render the year-semantics warning.
+- Note for whoever runs this next in a fresh worktree: `run_tests.sh` first reported
+  "Errored — could not be verified" because the worktree had no venv. It did **not**
+  report a false pass. Run `uv sync --all-extras` in the module directory first.
+
 ### P3 — Operator-facing documentation
 
 - **Goal:** the recovery tool stops being invisible in *tracked* documentation. PP-045's
@@ -418,7 +453,13 @@ Steps:
   the preserved logs can say about what was true then. Not more than that.
 - **Files:** the issue file, sections §B / §C / §G. **No other file** — in particular not
   `module_issues.md` (C3).
-- **Depends on:** P0 (logs) and P1. **Externally blocked** on tunnel availability and
+- **Split by prerequisite (revised 2026-08-17, after P0).** Step 2 — analysing the
+  preserved logs — needs **no tunnels and no DB access at all**, and P0 has already
+  supplied its input. It can run today. Steps 1 and 3–5 need the live databases. Do not
+  report P4 as wholly blocked; the log-only half is available now and may settle the C1
+  question on its own.
+- **Depends on:** P0 (logs) and P1. Steps 1 and 3–5 are **externally blocked** on tunnel
+  availability and
   owner authorisation.
 
 **Evidentiary ceiling — the constraint that shapes this phase.** A probe of current
@@ -507,9 +548,11 @@ Steps:
    C8 exists for this. Note specifically that a snapshot alone does **not** make the run
    reversible — rows the backfill *inserts* have no prior value to restore, which is why
    C8 requires a rollback manifest partitioned into pre-existing versus absent keys.
-6. **Historical logs may already be gone.** 30 rotated backups puts 2026-07-20 at the
-   edge as of 2026-08-17. P0 may find the evidence already lost — record that outcome
-   explicitly rather than leaving it indistinguishable from "not yet checked".
+6. **~~Historical logs may already be gone.~~ RETIRED 2026-08-17** — P0 ran and the
+   archive spans 2026-04-01 → 2026-08-16. The risk was real in principle and false in
+   fact. Kept visible rather than deleted, because the *reasoning* that produced it
+   (inferring retention from `backupCount=30` instead of listing the directory) is the
+   recurring error, and it survived three adversarial review passes.
 7. **Gitignored operational records.** The dated local checklists contain operational data
    and are untracked by design. Any instruction to edit or commit them is a data-handling
    violation; P3 step 5 is the guard.

--- a/doc/plans/working/pp045_issue_draft_update_plan.md
+++ b/doc/plans/working/pp045_issue_draft_update_plan.md
@@ -1,0 +1,592 @@
+# PP-045 — issue-draft update: implementation plan
+
+**Status:** Draft, not started. Revised twice against out-of-loop `codex exec` reviews
+(read-only, fresh context). The first pass returned NOT SAFE TO COMMIT with 2 Critical and
+26 Important findings (P4 causal overclaiming and P4 write-safety were the Criticals); the
+confirm-fixes pass cleared 30 of 37 and drove a second revision, chiefly to C8 and P0.
+
+**Base:** `origin/maxat_sapphire_2` @ `8e3fc1bc`, **plus** the 2026-08-17 re-assessment
+commit `31370164` on the unmerged branch `docs_pp045_status_2026-08-17`. See §0 — this is
+the plan's largest dependency, and P1/P4/P5 are void without it.
+
+**Target artefact:** `doc/plans/issues/review_gi_draft_pp_missed_boundary_period_gap.md`
+(PP-045), 624 lines on trunk, 1074 after `31370164`.
+
+**Owner-locked scope:** bring PP-045's issue draft to a state where it is internally
+consistent and where a Review → Complete decision is defensible.
+
+**Scope honesty — read this before calling the plan "docs-only".** The *repository patch*
+is documentation and string literals only; no runtime behaviour changes anywhere. But the
+plan as a whole is **not** side-effect-free: P0 and P4 read shared operational logs and
+databases, and P4 step 5 schedules a **real database write** against a live deployment,
+conditionally and behind owner authorisation. Any summary of this plan that says
+"documentation work only" is wrong.
+
+**Not in scope:** fixing PP-046, PP-047 or PP-048; any change to
+`apps/postprocessing_forecasts/` runtime behaviour; building the detect-and-report
+feature (this plan updates/creates its ticket, it does not implement it).
+
+**Anchoring convention (deliberate).** Locations are anchored by **section heading or
+symbol name plus a quoted phrase**, with line numbers as a secondary hint only. Line
+numbers in the target file are invalidated the moment `31370164` merges. The sibling plan
+`doc/plans/working/pp051_recalc_write_failure_plan.md` records anchor drift as a recurring
+failure mode in this repo's plan documents; the first revision of *this* plan carried four
+wrong anchors of its own, caught in review. **An executing agent must grep for the quoted
+phrase, never seek to a line number.**
+
+---
+
+## 0. The base dependency, stated plainly
+
+The 2026-08-17 re-assessment — sections "A. Code re-verification" through "G. Remaining
+checklist to move Review → Complete", referred to below as §A–§G — is **committed but not
+merged**: branch `docs_pp045_status_2026-08-17`, commit `31370164` (parent `8e3fc1bc`),
+one file changed, +453/−3.
+
+Consequences an executing agent must respect:
+
+- **P1, P4 and P5 all depend on it.** P1 rewrites prose so it agrees with §A6; P4 edits
+  §B/§C/§G; P5 works the §G checklist. Only **P2 and P3 are genuinely independent** — the
+  first revision of this plan wrongly claimed P2–P5 were.
+- **Branch P1 off `docs_pp045_status_2026-08-17`, not off trunk**, or the two edits
+  conflict in the same file. Treat plan and re-assessment as one review unit.
+- If the owner rejects or materially revises the re-assessment, P1 must be re-planned,
+  not patched.
+
+**The finding P1 exists to propagate**, restated so this plan is standalone: PP-045's
+Summary asserts that short-term per-model PENTAD/DECADE rows are created *only* by the
+operational code path. That is false on trunk. `recalculate_skill_metrics.py::_run_short_term_recalc`
+reads with no year bounds (`:191-194`; the reader's `start_year`/`end_year` default to
+`None` = unbounded, `src/data_reader.py:2746-2751`) and then calls
+`file_writer.save_forecast_data(config, modelled)` (`:233`). `backfill_period_forecasts.py`
+is a third writer; the un-wired `apps/machine_learning/reaggregate_day_to_periods.py` a
+fourth. Confirmed by direct code read and by two independent `codex exec` reviewers.
+
+---
+
+## 1. Separating implemented / documented / drift
+
+| Item | Implemented? | Documented? | Drift |
+|---|---|---|---|
+| Option B backfill CLI (`backfill_period_forecasts.py`) | **Yes** — merged PR #425, `cd97db57`, 2026-07-23 | Only inside PP-045, `module_issues.md`, and *gitignored* local review checklists | **No tracked operator-facing doc exists.** No `doc/prod/` runbook, no README section. P3 closes this. |
+| `save_forecast_data(write_csv=, require_api=)` | **Yes** | In-code docstring only | none |
+| 23 locked tests in `tests/test_backfill_period_forecasts.py` | **Yes** (23 methods, statically verified) | PP-045 §Verification | Green status is **REPORTED, not proven** — no durable test log exists. |
+| Maintenance cannot heal a zero-`combined` date | n/a (this is the defect) | §A3, re-verified 2026-08-17 | none |
+| "Only operational writes period rows" | — | Asserted in PP-045 Summary/Problem | **Drift — false.** P1 closes this. |
+| The four stranded tjhm days are a PP-045 reproduction | — | Implied by `module_issues.md` and local checklists | **Unproven, and may be unprovable** — see §2 D7 and P4. |
+| kyg end-to-end verification | **No** | DEFERRED in Acceptance Criteria | Blocked on infra since 2026-07-23; P5 forces a decision. |
+
+---
+
+## 2. Defects in the artefact, confirmed by direct inspection
+
+Quoted phrases are exact. Unless noted, each was verified against the file at `8e3fc1bc`.
+
+**D1 — Self-contradiction.** `## Summary` contains "are created **only** by the
+operational" (trunk L15). §A6 refutes it. A reader who stops at the Summary — which is
+what `module_issues.md` links to — acquires a wrong model of the system.
+
+**D2 — The entry-point count is itself wrong.** `## Context` opens "The
+`postprocessing_forecasts` app has two entry points:" (trunk L24). The module has **six
+top-level production scripts** with a `__main__` block — short- and long-term operational,
+short- and long-term maintenance, `recalculate_skill_metrics.py`, and
+`backfill_period_forecasts.py` (test utilities elsewhere in the tree also have `__main__`
+blocks and are not counted). P1 must **correct the count**, not merely add a
+writers-versus-entry-points distinction — the first revision of this plan made exactly
+that mistake.
+
+**D3 — Stale recovery inventory.** `## Problem` contains "**Current recovery options
+(both manual / out-of-band):**" (trunk L98), listing a `SAPPHIRE_FORECAST_DATE`
+operational re-run and the un-wired `reaggregate_day_to_periods.py`. It omits
+`backfill_period_forecasts.py` — the tool this issue exists to deliver, merged three weeks
+earlier. Most actively harmful staleness in the file: an operator following the Problem
+section reaches for the wrong tool.
+
+**D4 — Obsolete decision framing, in three places.**
+`### Approach — OPEN DECISION FOR THE HUMAN OWNER` (trunk L168) and
+`### Recommendation (for the owner to weigh, not a decision)` (trunk L221) present A/B/C
+as live; the decision was taken 2026-07-17 and shipped, and the section saying so
+(`## Decision & Workplan (Option B — backfill entrypoint)`, trunk L238) sits 70 lines
+below. **Third instance:** `## Desired Outcome` still reads "The remediation depth is the
+open decision below (A/B/C)."
+
+**D5 — Two sections still defer tickets that are already filed.**
+`### Latent defect found while mapping (record, do not necessarily fix here)` ends "worth
+a separate ticket" → filed as **PP-046**.
+`## Secondary anomaly (triage — recommend SEPARATE ticket)` → filed as **PP-048**. Both
+are indexed in `doc/plans/module_issues.md`.
+
+**D6 — Competing "what remains" lists, no stated authority.** On **trunk**, two:
+`## Documentation Impact` (four unchecked boxes) and `## Acceptance Criteria` (one
+unchecked — the kyg deferral). On the **combined base** (trunk + `31370164`), three, with
+§G added. Nothing tells a reader which to work from. The defect is real on the base this
+plan executes against; it is not a trunk-only defect.
+
+**D7 — An unprovable attribution is being treated as settled.** `module_issues.md` and the
+local review checklists attribute the stranded boundary days to PP-045. §C lists six
+candidate causes; five mean they are not PP-045. Critically, **no probe of current state
+can establish which inputs or configuration existed during the historical run** — see P4.
+The plan must not promise a resolution it cannot deliver.
+
+---
+
+## 3. Hard contracts every phase must preserve
+
+**C1 — Preserve the audit trail, with an explicit split.** The issue is the record for a
+*merged* PR, so:
+- **Preserve verbatim, banner above, no edits inside:** `## Implementation Plan` through
+  `### Dependency graph`, and `## Verification (2026-07-23)`. A diff showing deletions
+  inside these ranges is rejected.
+- **Correct in place, with a dated correction line:** `## Summary`, `## Context`,
+  `## Problem`, `## Desired Outcome`. These are the reader's entry point; strikethrough
+  there is worse for the reader than a clean sentence plus a recorded correction. Every
+  such correction appends one line to a new `## Corrections log` at the end of the file
+  giving date, the superseded claim, and why it was wrong. **The original claim survives
+  in the log, not in the body.** (The first revision left C1 protecting only the first
+  group while P1 silently replaced Summary/Problem text — an internal contradiction.)
+
+**C2 — Do not change `Status:` and do not rename the file.** The status word and the
+`review_gi_draft_*` → archive move are the owner's call; `doc/plans/README.md` owns the
+status vocabulary (`Open → Draft → Ready → In Progress → Complete`), and `review_` is a
+*filename/workflow stage*, not a second competing status list. Note the artefact-level
+inconsistency this creates: the target file's header currently reads `**Status**: Review`,
+a value that vocabulary does not contain. Flag it for the owner at P5; do not resolve it
+as a side effect of this plan.
+
+**C3 — `doc/plans/module_issues.md` is edited once, in P5, on a clean tree.** A parallel
+session held uncommitted changes to it on 2026-08-17, including an entry claiming the
+`PP-056` identifier which is unused on trunk. Any ID allocation re-reads the *current*
+file. **No other phase may edit it** — P4 in the first revision violated this.
+
+**C4 — P2 is literal-only, and the tests are not the proof of that.** In
+`backfill_period_forecasts.py`, only the module docstring and `argparse`
+`help=`/`description=` string literals may change. **Scope evidence is a reviewed diff
+confirming every changed line is inside a string literal** — token- or AST-level if the
+diff is large. Passing tests are a *regression check*, not scope proof: unmodified green
+tests cannot demonstrate that no behavioural line changed, only that covered behaviour
+still works. Both are required; neither substitutes for the other. If any test needs
+editing, scope was exceeded — stop and escalate.
+
+**C5 — No real station codes.** Placeholder `19999` only in anything committed.
+
+**C6 — Preserve evidence tags, and never upgrade inference to proof.** §A–§G tag claims
+PROVEN / INFERRED / REPORTED. Rewritten prose inherits the tag of the claim it carries. A
+tag may be downgraded only by evidence that actually bears on it — see C8 and P4.
+
+**C7 — One live checklist, and historical boxes are frozen.** After P1, §G is the sole
+authority. `## Documentation Impact` and `## Acceptance Criteria` become **frozen**
+historical snapshots as of 2026-07-23: their checkboxes are never ticked again. Any item
+in them still outstanding — notably the kyg deferral — is **migrated into §G**, and §G is
+where it is resolved. (The first revision left it ambiguous whether P5 ticked the old
+boxes or not.)
+
+**C8 — Write-safety contract, binding on P4 step 5 and any future backfill run.** The CLI
+does **not** write only the dates under investigation: `--horizon pentad` still reads and
+re-upserts *every period of the whole selected year for every configured station*, with EM
+recomputed from current skill metrics. Therefore, before any real run:
+
+1. **Name the target deployment explicitly** and confirm it is the intended one.
+2. **Enforce a maintenance window — a point-in-time check is not enough.** A "no writer is
+   running right now" check does not hold exclusion across snapshot → write → read-back.
+   Disable the cron/orchestrator entries for `postprocessing_forecasts` operational,
+   maintenance and recalc (and confirm no other session holds the tunnels) **for the whole
+   duration**, and re-enable only after the read-back completes. Record when the window
+   opened and closed.
+3. **Snapshot the complete write set** — every `(code, date, model)` row of the affected
+   horizon and year, values included — not merely the dates of interest.
+4. **Build a rollback manifest, not just a snapshot.** Restoring a snapshot of
+   pre-existing rows cannot undo rows the backfill *inserted*, because those keys had
+   nothing to restore. The manifest must therefore partition the intended write set into
+   **keys that already existed** (rollback = restore prior values) and **keys that did
+   not** (rollback = delete). Write and test both commands *before* the run; an untested
+   rollback is not a rollback.
+5. **Verify by comparing the full submitted payload against the read-back**, key and
+   value. Reading back the four dates of interest proves nothing about the rest of the
+   year.
+6. **Do not treat "row counts unchanged on a second run" as idempotence** — that is a
+   count check, not a value check.
+
+If any of 2 or 4 cannot be satisfied, the run does not happen. An unauthorised or
+un-rollback-able whole-year write is a worse outcome than leaving the question open.
+
+---
+
+## 4. Phasing rationale
+
+P0 runs **first and immediately**, before any other work: it preserves evidence that
+expires. All three short-term writers — operational, maintenance and
+`recalculate_skill_metrics.py` — use `TimedRotatingFileHandler(when="midnight",
+backupCount=30)`, so logs age out on a rolling basis. Note the retention is a
+*rotation count*, not a wall-clock TTL: 30 backups equals ~30 days only if rollover
+happens daily, which it does not on days the job never runs. Either way, 2026-07-20 is
+28 rollovers back as of 2026-08-17 — at the edge. Deferring preservation until P4 — as
+the first revision did — risks
+losing the only evidence that can ever distinguish cause C4 (input absent *then*, present
+*now*), because no query of current state can recover it.
+
+P1 and P2 are independent of each other and run in parallel. P3 depends on P2 because the
+corrected docstring is the source text the runbook quotes; writing the runbook first
+propagates a wrong precondition into operator-facing documentation, which is the expensive
+direction of that error.
+
+P4 is isolated because it is the only phase gated on contended external resources and on
+owner authorisation, and because its conclusions are inherently weaker than the plan first
+assumed (D7).
+
+P5 is last: every action in it is owner-owned and effectively irreversible.
+
+**Deliberate deviation from §G's own priorities:** §G files the Summary/Problem prose fix
+as "non-blocking". P1 elevates it. It is the cheapest item in the plan, actively
+misleading today (D1/D3), and upstream of every later phase's quoted text.
+
+---
+
+## 5. Phases
+
+### P0 — Preserve expiring evidence (do this first, today)
+
+- **Goal:** capture logs before they rotate out. Read-only; no analysis yet.
+- **Files:** none in the repo. Output goes to an out-of-repo archive location.
+- **Depends on:** nothing. **Blocks:** P4's ability to reach a conclusion.
+
+Steps:
+
+1. Copy the postprocessing logs covering 2026-07-20 → 2026-08-17 for **both** tjhm and
+   kghm to durable storage outside the repo. Capture **all three** short-term writers'
+   logs — `log_operational*`, `log_maintenance*` **and `log_recalc*`**. The recalc log is
+   not optional: `recalculate_skill_metrics.py` is itself a writer of period rows (§0), so
+   it is a candidate producer of the rows that *do* exist, and it has the same 30-backup
+   retention. `apps/logs/` is gitignored; nothing here is committed.
+2. Record which rotated files existed and which were already gone — an absence recorded
+   now is itself evidence; an absence discovered in P4 is indistinguishable from never
+   having looked.
+3. Do **not** analyse yet. Analysis is P4 step 2.
+
+- **Acceptance:** an inventory listing exists naming every file captured and every gap in
+  the sequence, dated.
+
+### P1 — Reconcile the draft with itself
+
+- **Goal:** the narrative sections state only true things; historical sections are visibly
+  historical; §G is the single live checklist.
+- **Files:** `doc/plans/issues/review_gi_draft_pp_missed_boundary_period_gap.md` only.
+- **Branch base:** `docs_pp045_status_2026-08-17` (§0). **Depends on:** nothing further.
+
+Steps:
+
+1. `## Summary` — replace "are created **only** by the operational code path" with the
+   multi-writer statement, cross-referencing §A6. The boundary-day mechanism the Summary
+   describes is still correct; keep it. Log the correction (C1).
+2. `## Context` — **correct the count**: "two entry points" is false. State the actual
+   executable scripts and distinguish *entry points* from *writers of period rows*,
+   pointing at §A6 for the inventory (D2).
+3. `## Problem` — retitle "**Current recovery options (both manual / out-of-band):**",
+   dropping "both", and add `backfill_period_forecasts.py` as the primary option. Demote
+   the two existing bullets to fallbacks, keeping their caveats verbatim — the CSV-rewrite
+   side effect and the raw-SQL bypass are both still accurate.
+4. `## Problem` — qualify the absolute language in the "Net effect" bullets ("no re-run
+   heals a missed period", "never recreated at all"). Those were written when operational
+   was believed to be the only writer; a recalc run is now known to re-save period rows,
+   and the raw-SQL script can too. Add the qualification; do **not** attempt to re-derive
+   what the corrected net effect is — that needs analysis this plan has not done, so state
+   the uncertainty and leave it.
+5. `## Problem` — the self-heal bullet asserts "provided (a) the DAY archive still holds
+   those issue dates". Keep it; append a pointer to §C's C1–C6 table, which enumerates the
+   ways proviso (a) fails. Do not restate the table (C7).
+6. `## Desired Outcome` — "The remediation depth is the open decision below (A/B/C)" is
+   stale; the decision was taken and shipped (D4).
+7. `### Latent defect found while mapping` — prepend: filed as PP-046. Keep the mechanism
+   text; it is the clearest statement of that defect anywhere.
+8. `## Secondary anomaly (triage — recommend SEPARATE ticket)` — prepend: filed as PP-048;
+   retitle to drop "recommend SEPARATE ticket".
+9. Insert the historical banner below `## Implementation Plan`, covering through
+   `### Dependency graph`: decision taken 2026-07-17, Option B shipped PR #425 2026-07-23,
+   A/B/C not open. **No edits below the banner** (C1).
+10. `## Documentation Impact` and `## Acceptance Criteria` — mark frozen as of 2026-07-23;
+    live checklist is §G. Migrate the unchecked kyg criterion into §G (C7).
+11. Add the `## Corrections log` section required by C1.
+
+- **Acceptance criteria:**
+  - No statement above `## Confirmed on trunk 2026-08-17` contradicts §A–§G — verified by
+    reading the two halves against each other, not by spot-check.
+  - The entry-point count is correct. The stale "open decision" language is corrected in
+    `## Desired Outcome`; the two `OPEN DECISION` / `Recommendation` headings inside the
+    C1 preserve-verbatim range are **left untouched** and are disarmed by the banner
+    instead. (Correcting all three would breach C1 — the first revision of this plan
+    demanded exactly that.)
+  - Exactly one checklist is live; the other two say so and are frozen.
+  - `git diff --stat`: one file. `git diff`: no deletions inside the C1 preserve-verbatim
+    ranges.
+  - Every in-place correction has a `## Corrections log` entry (C1).
+  - Evidence tags intact; the stranded days still read REPORTED (C6).
+
+### P2 — CLI contract corrections
+
+- **Goal:** close §D1/§D2 of the re-assessment plus one further defect found in review.
+- **Files:** `apps/postprocessing_forecasts/backfill_period_forecasts.py`.
+- **Depends on:** nothing. Parallel with P1.
+
+Steps:
+
+1. Module docstring, "maintenance recalculates skill metrics, not period forecasts"
+   (`:3-8`): **both halves are wrong.** Maintenance *reads* skill metrics
+   (`recalculate_skill_metrics.py` recalculates them) and *does* write period rows —
+   refreshed individual, NE and EM. Anchor by name: the `refresh_parts` build in
+   `postprocessing_maintenance.py`, blocks `7a` (stale individual/NE), `7b` (NE gaps),
+   `7c` (EM gap-fill + stale EM, comment "requires skill metrics"), and the direct write
+   whose comment reads "bypasses get_latest_forecasts". State the real limitation: it
+   cannot discover a date with zero `combined` rows (early return on empty combined; the
+   `detect_missing_ensembles` call omits `modelled_forecasts`, which
+   `src/gap_detector.py` uses to widen the universe), and its write set never emits fresh
+   per-model rows for a newly-discovered date.
+2. Replace the implied "DAY rows must exist" precondition with the accurate one, **kept
+   distinct from the later API-side filter**: for the aggregation to produce a row, the
+   merged archive must yield, for that issue date, a row that survives the boundary drop
+   *and* the in-period `target` filter (`src/data_reader.py:2386-2439`) — supplied either
+   by the DAY archive or by a retained pre-cutover period-archive row
+   (`_merge_archives_by_day_cutover`, `src/data_reader.py:2087-2158`). **Separately**, a
+   surviving row still reaches the API only if `forecasted_discharge` is non-null
+   (`src/api_writer.py:413-423`). A retained period row is not automatically exempt from
+   either filter. The first revision conflated these two stages.
+3. Name the upstream tools, **with** the caveat that `fill_ml_gaps.py` detects only gaps
+   between consecutive existing dates and therefore cannot see an empty archive, a leading
+   gap, or a trailing gap.
+4. **New defect found in review:** `--start-date` / `--end-date` are documented as
+   inclusive date bounds, but the implementation uses only their *years*
+   (`for year in range(start.year, end.year + 1)`) and reprocesses each selected year in
+   full. Sub-year bounds are silently ignored. Correct both the docstring and the two
+   `help=` strings so an operator is not misled into believing the range narrows the work.
+
+- **Acceptance criteria:**
+  - Reviewed diff confirms every changed line lies inside a string literal (C4).
+  - `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh postprocessing_forecasts` — zero
+    failures, zero unexpected skips, `tests/test_backfill_period_forecasts.py`
+    **unmodified** (C4, regression check).
+  - `--help` renders; the year-semantics correction is visible in it.
+
+### P3 — Operator-facing documentation
+
+- **Goal:** the recovery tool stops being invisible in *tracked* documentation. PP-045's
+  `## Desired Outcome` makes "the behavior is documented" part of done.
+- **Files:** new `doc/prod/<name>.md`; `apps/postprocessing_forecasts/README.md`;
+  `doc/data_flow_short_term.md`; `doc/dev/review_checklist_local_template.md`.
+- **Depends on:** P2.
+
+Steps:
+
+1. New `doc/prod/` runbook. Must contain, at minimum: exact commands with environment
+   selection; **one year per internal aggregation/save call** — note that the CLI accepts
+   a multi-year range and isolates each year itself, so separate invocations are *not*
+   required (the first revision implied they were) — and why the isolation exists
+   (yearless-key dedup at `src/file_writer.py:120-122`, before the year filter at `:129`);
+   that `--horizon` should be scoped to the affected horizon because each touched year is
+   a whole-year read and save for all configured stations; API-only default and what
+   `--write-csv` changes; that EM is recomputed against *current* skill metrics so a
+   historical backfill is not a replay; the dry-run's limits (it logs totals, never dates
+   or codes — the `"%s DRY-RUN: would write %d row(s) (%s); save skipped."` message);
+   failure handling; and the full **C8 write-safety procedure**, including that read-back
+   must cover the whole submitted payload rather than the dates of interest, because
+   PP-047 means `_write_combined_forecast_to_api` can return `True` over a zero or partial
+   server write (`src/api_writer.py:445-466`) and `require_api=True` therefore does not
+   prove persistence. Name PP-047 so the coupling is discoverable if it is later fixed.
+2. `apps/postprocessing_forecasts/README.md` — recovery section; none exists. Link the
+   runbook rather than duplicating it.
+3. `doc/data_flow_short_term.md` — add the backfill as the recovery path for stranded
+   period rows.
+4. `doc/dev/review_checklist_local_template.md` (**tracked**) — correct two substantive
+   errors: "short-term per-model PENTAD/DECADE rows are written **only** by [the
+   operational path]", and the diagnostics row reading "per-model period rows present but
+   EM/NE absent ⇒ PP-045", when PP-045 concerns *missing per-model rows* and EM has an
+   independent skill gate.
+5. **Do not edit the dated local checklists.** `doc/dev/review_checklist_local_20*.md` is
+   gitignored (`.gitignore:269`) and untracked — `doc/dev/review_checklist_local_2026-08-14_kyg.md`
+   is not in the repository and contains operational data. Correct the tracked template
+   only; the owner may optionally annotate their local copy by hand. Never `git add -f`
+   one of these. (The first revision instructed editing that file and scheduled a blanket
+   decision over all dated copies — both wrong.)
+
+- **Acceptance criteria:**
+  - An operator who has never read PP-045 can recover a stranded boundary day from
+    `doc/prod/` alone, including knowing a full-payload read-back is required.
+  - No runbook statement contradicts the P2 docstring — check them against each other
+    explicitly; they assert the same facts.
+  - `git status` shows no gitignored checklist staged.
+
+### P4 — Probe, within its evidentiary limits
+
+- **Goal:** establish **what is true now** about the stranded days, and recover whatever
+  the preserved logs can say about what was true then. Not more than that.
+- **Files:** the issue file, sections §B / §C / §G. **No other file** — in particular not
+  `module_issues.md` (C3).
+- **Depends on:** P0 (logs) and P1. **Externally blocked** on tunnel availability and
+  owner authorisation.
+
+**Evidentiary ceiling — the constraint that shapes this phase.** A probe of current
+configuration and current database contents establishes *present recoverability*. It
+**cannot** establish which inputs or configuration existed during the historical run. The
+filter logs are aggregate counts for a whole run and frequently do not name dates or
+codes. Therefore P4 **may not** conclude "the cause was C_n" from present state alone,
+**may not** detach the observations from PP-045 on that basis, and **may not** clear the
+REPORTED tag except for the specific sub-claims the evidence actually reaches. Doing so
+would present inference as proof and violate C6. This was the first revision's most
+serious error.
+
+Steps:
+
+1. Run §E's P0–P3 **read-only**, independently on tjhm and kghm. §B is two observations,
+   not one confirmed shared cause: the kghm record self-labels its attribution as
+   underdetermined and separately records an LR hindcast, so LR row presence carries no
+   information about when those rows were created.
+2. Analyse the P0 archive for the aggregate filter signals, recording for each whether it
+   fired, with what count, and whether it can be attributed to specific dates. Where it
+   cannot, say so.
+3. Record the result as a **present-state finding** against the C1–C6 table, with an
+   explicit statement of what remains undetermined about the historical run. Downgrade
+   REPORTED only for sub-claims the evidence reaches.
+4. If the present state shows the days are **not currently recoverable** (C1–C5
+   conditions), record that PP-045's tooling cannot heal them and that the owning module
+   is elsewhere — as a *finding*, not as a re-attribution of historical cause. Any
+   consequent edit to `module_issues.md` is deferred to P5 (C3).
+5. **Only** if the present state shows the days *are* recoverable and the question is
+   whether the write path drops them, **and** with explicit owner go-ahead: execute the
+   §E P4 write verification under the **full C8 procedure**. `--horizon pentad`, dry-run
+   first for shape, full write-set snapshot, full-payload read-back parity, value-level
+   (not count-level) idempotence check.
+
+- **Acceptance criteria:**
+  - Every §E step recorded as run / not-run with its result — no silent omissions.
+  - Every conclusion is scoped "as of <date>, present state" unless a preserved log
+    supports a historical claim, in which case the log is cited.
+  - The residual unknown about the historical run is stated explicitly rather than
+    resolved by assertion.
+  - If step 5 ran: the C8 checklist is reproduced with each item ticked and evidenced.
+
+### P5 — Close out
+
+- **Goal:** a defensible Review → Complete decision, and the follow-ups landed.
+- **Files:** the issue file; `doc/plans/module_issues.md`; PP-046's draft; one new
+  `gi_draft_*` file.
+- **Depends on:** P1, P2, P3, P4.
+
+Steps:
+
+1. Resolve the kyg deferral — now migrated into §G (C7). The criterion as written requires
+   **the full kyg short-term pipeline** end-to-end. Running only the backfill against local
+   kghm data is **not** equivalent evidence, and still needs a configured API/database plus
+   write authorisation; the first revision wrongly offered it as a no-server substitute.
+   Real options: run the full pipeline when kyg is available, or formally waive/downgrade
+   the criterion with written rationale. **Owner decides.**
+2. Land the follow-ups per §7.
+3. Propose the status transition and the archive move. **Do not execute without approval**
+   (C2); flag the `Status: Review` vocabulary mismatch at the same time.
+4. `doc/plans/module_issues.md` — the PP-045 row still reads "Option B implemented (branch
+   `fix_postprocessing_boundary_gap`)". Update to merged-via-PR-#425 and reflect P4's
+   finding. **Last action, clean tree only** (C3).
+
+- **Acceptance criteria:**
+  - Every §G item ticked or carrying a written waiver naming the decider.
+  - `module_issues.md` PP-045 row matches the issue file's Status.
+  - Frozen historical checklists untouched (C7).
+
+---
+
+## 6. Residual risk — do not summarise away in the PR description
+
+1. **The base is unmerged.** If `31370164` is rejected or revised, P1/P4/P5 are void.
+   Mitigation: branch off `docs_pp045_status_2026-08-17`; review both as one unit.
+2. **Anchor drift.** Line numbers here are hints only; the first revision of this plan
+   shipped four wrong ones (`file_writer.py:118`/`:124` for what is `:120`/`:129`; a
+   dry-run log line; a checklist line). Grep the quoted phrase.
+3. **P4 is not schedulable** — contended shared infrastructure. The plan must not be
+   reported as blocked overall because P4 is blocked; P0–P3 deliver most of the value.
+4. **Present-state probes cannot prove historical cause.** The central question — why
+   those days were never written — may be permanently unanswerable if the logs have
+   rotated. P0 is the only mitigation and it is time-critical.
+5. **Whole-year, all-station blast radius.** Any real backfill run rewrites every period of
+   the selected year for every configured station, with EM recomputed from current skill.
+   C8 exists for this. Note specifically that a snapshot alone does **not** make the run
+   reversible — rows the backfill *inserts* have no prior value to restore, which is why
+   C8 requires a rollback manifest partitioned into pre-existing versus absent keys.
+6. **Historical logs may already be gone.** 30 rotated backups puts 2026-07-20 at the
+   edge as of 2026-08-17. P0 may find the evidence already lost — record that outcome
+   explicitly rather than leaving it indistinguishable from "not yet checked".
+7. **Gitignored operational records.** The dated local checklists contain operational data
+   and are untracked by design. Any instruction to edit or commit them is a data-handling
+   violation; P3 step 5 is the guard.
+8. **P1 edits the audit record of a merged PR.** C1's split rule plus the corrections log
+   is the mitigation; a phase that "tidies" the preserved sections destroys the trail.
+9. **`module_issues.md` conflict risk** is real and recurring — a parallel session held it
+   dirty during the 2026-08-17 session. C3 costs nothing to obey.
+10. **P4 could invalidate PP-045's framing.** If the days turn out to belong to another
+    module, P5's index row must say something quite different from what is currently
+    expected — and, per the evidentiary ceiling, it may have to say "undetermined".
+
+---
+
+## 7. Follow-up filing (P5)
+
+**Allocate any new ID against the current `module_issues.md`, not trunk's** — `PP-056` is
+unused on trunk but claimed by an uncommitted entry in a parallel working copy (C3).
+
+1. **Update PP-046 — do not file a new ticket.** `mid_prio_gi_draft_pp_get_latest_forecasts_yearless_key.md`
+   already covers the class: "Anything that feeds `save_forecast_data` more than one
+   calendar year at once writes only the latest year's rows". But it frames the risk as a
+   footgun "for any future multi-year caller". **An existing caller already does this:**
+   `recalculate_skill_metrics.py::_run_short_term_recalc` reads unbounded (`:191-194`) and
+   saves through `save_forecast_data` (`:233`), which dedups to at most one row per
+   `(code, period_in_year, model_short)` (`src/file_writer.py:120-122`) before the
+   two-year filter (`:129`). Net: at most one row per period-in-year reaches the API
+   regardless of how many years were read. Rows are upserted rather than deleted, so the
+   mechanism is a silent **under-write**, not data loss — though rows missing from older
+   years stay missing. This converts PP-046 from latent to actively manifesting and may
+   justify re-rating its priority. Filing a second ticket would duplicate it.
+2. **New ticket — detect-and-report for stranded boundary days.** Report-only, in
+   `maintenance:postprocessing_forecasts`; no writes, no exit-code change. Cost note for
+   the ticket, stated honestly: maintenance does **not** already own the machinery.
+   `read_combined_forecasts` / `_read_combined_forecasts_api` (`src/data_reader.py:791-847`)
+   take no date parameters — the read is unbounded; the 13-month cutoff lives inside
+   `gap_detector.detect_missing_ensembles` as
+   `cutoff = max_date - pd.DateOffset(months=max_lookback_months)`, relative to the maximum
+   *observed* date; and maintenance builds its universe only from existing pairs, never
+   enumerating *expected* boundary dates. A zero-row detector therefore needs an
+   expected-boundary calendar, an active code/model history so retired stations do not
+   alarm, and archive-provenance logic so an upstream gap is reported as such. Do not
+   describe this as small. Do not attribute the exit contract to PP-051/PP-055 — those
+   concern skill-metric writer outcomes, not maintenance's exit code.
+
+---
+
+## 8. Dependency graph
+
+Prerequisites not expressible in the graph, and binding regardless of it: **all phases
+except P0, P2 and P3 require commit `31370164` in the branch base** (§0); **P4 requires**
+the P0 log archive, DB/tunnel availability, and owner authorisation, plus C8 for its
+step 5; **P5 requires** a clean `module_issues.md` tree (C3) and, for its kyg option, a
+configured kyg deployment with write authorisation.
+
+```json
+{
+  "phases": {
+    "P0": { "depends_on": [], "parallel_agents": 1 },
+    "P1": { "depends_on": [], "parallel_agents": 1 },
+    "P2": { "depends_on": [], "parallel_agents": 1 },
+    "P3": { "depends_on": ["P2"], "parallel_agents": 1 },
+    "P4": { "depends_on": ["P0", "P1"], "parallel_agents": 1 },
+    "P5": { "depends_on": ["P1", "P2", "P3", "P4"], "parallel_agents": 1 }
+  }
+}
+```
+
+---
+
+## References
+
+- Issue draft: `doc/plans/issues/review_gi_draft_pp_missed_boundary_period_gap.md`
+- Shipped fix: PR #425, `cd97db57` (2026-07-23); commits `cce5922a`, `62bbba65`
+- 2026-08-17 re-assessment: commit `31370164`, branch `docs_pp045_status_2026-08-17`
+- Related: PP-046 (yearless key — updated by §7, not duplicated), PP-047 (write reports
+  success on zero/partial), PP-048 (decade EM freeze), INFRA-024 / INFRA-026 (validator
+  cannot see this class of gap)
+- Conventions: `CLAUDE.md` § Orchestration Protocol, § Multi-Model Review;
+  `doc/plans/README.md` (status vocabulary — see C2 on the disagreement);
+  `doc/dev/agent_review_workflow.md`


### PR DESCRIPTION
Documentation and string literals only — no runtime behaviour changes. Three commits, all PP-045.

## What's here

**`31370164` — re-assessment of PP-045 on trunk.** The Option B backfill CLI merged in #425 three weeks ago; this records what is actually true now, tagging every claim PROVEN / INFERRED / REPORTED.

**`a4b55ba2` — the plan** (`doc/plans/working/pp045_issue_draft_update_plan.md`) sequencing the work to a Complete-ready state, in six phases with hard contracts and a dependency graph.

**`1e8aef46` — P0 and P2 executed**, plus a correction to the plan's own premise.

## The finding that matters most

**PP-045's core premise is wrong.** Its Summary says short-term per-model PENTAD/DECADE rows are created *only* by the operational path. They are not: `recalculate_skill_metrics.py::_run_short_term_recalc` reads with no year bounds and then calls `save_forecast_data`, so a skill recalculation re-saves period rows as a side effect. The backfill CLI is a third writer, `reaggregate_day_to_periods.py` a fourth.

Two consequences: reasoning backwards from "a period row exists, therefore operational ran" is unsound; and PP-046 is no longer latent — it has an existing multi-year caller, which may justify re-rating it. The plan updates PP-046 rather than filing a duplicate.

## Also corrected

- **The stranded-days attribution is not established.** Six candidate causes; five mean those days are not a PP-045 reproduction at all. A current-state probe cannot recover which inputs existed during a historical run — the plan now states that ceiling rather than promising a resolution it cannot deliver.
- **The CLI's `--start-date`/`--end-date` read as inclusive bounds but only their years are used.** A narrow range does not narrow the work; an operator sizing blast radius from the dates would have been badly wrong.
- **`--horizon pentad` still rewrites the whole year for every configured station**, with EM recomputed from current skill. Contract C8 now requires an enforced exclusion window and a rollback manifest that separates pre-existing keys from inserted ones — a snapshot alone cannot undo an insert.

## Verification

- `SAPPHIRE_TEST_ENV=True bash run_tests.sh postprocessing_forecasts` — **1832 passed, 1 xfailed, 0 failed, 0 skipped**, identical to the trunk baseline, `tests/` unmodified.
- CLI scope proved by **AST comparison** against trunk (docstrings stripped, `help=`/`description=` placeholdered → trees identical), so no executable code changed.
- Re-assessment: four out-of-loop `codex exec` passes. Plan: three, converging 2 Critical + 26 Important → 6 → 0.

## What this PR does not do

No status change, no file rename, no `module_issues.md` edit — all owner-owned, and `module_issues.md` had uncommitted changes in a parallel session. The PP-045 index row still names a branch that no longer exists; it's on the plan's checklist.

One open decision for you: §F recommends keeping repair **manual** and adding report-only detection as a separate ticket. That is a design call, not a finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)