### PR TITLE
PP-045 P3: operator runbook for the period-forecast backfill

### DIFF
--- a/apps/postprocessing_forecasts/README.md
+++ b/apps/postprocessing_forecasts/README.md
@@ -124,6 +124,29 @@ Operational (daily, boundary days)     Maintenance (nightly)
 **Note:** `postprocessing_forecasts.py` is deprecated. Use
 `recalculate_skill_metrics.py` instead.
 
+## Recovering Stranded Period Forecasts
+
+If short-term per-model PENTAD/DECADE rows are missing for a boundary date, the
+recovery tool is `backfill_period_forecasts.py`. It re-aggregates a range through the
+existing operational aggregation and save path, one calendar year per internal call.
+
+**Check first whether it applies.** The CLI re-aggregates inputs that already exist —
+it does not generate forecasts. When the inputs for the affected dates were never
+produced it cannot recreate them: if the rest of the year still has coverage the run
+exits 0 having re-upserted everything *else* and nothing new for your dates, and if the
+whole horizon-year is empty it exits 1. Neither outcome means "repaired". In the field
+cases examined so far the cause was that the pipeline had not run, and the fix for that
+is upstream in `machine_learning` — though how representative those cases are is
+inferred, not measured.
+
+Two further traps worth knowing before reading the full procedure: only the *years* of
+`--start-date`/`--end-date` are used, so a narrow date range does not narrow the work;
+and Ensemble Mean is recomputed against current skill metrics, so a historical
+backfill is not a replay.
+
+Full procedure, including the write-safety requirements:
+[`doc/prod/backfill_period_forecasts_runbook.md`](../../doc/prod/backfill_period_forecasts_runbook.md).
+
 ## Skill Metrics
 
 ### Metric tiers

--- a/doc/data_flow_short_term.md
+++ b/doc/data_flow_short_term.md
@@ -303,6 +303,26 @@ level, respecting variable period lengths:
 3. Average only the targets within the period
 4. Result: one row per (code, date, model_short) at pentad/decade level
 
+Step 1 reads a *merged* archive: the DAY records plus, for dates before each
+(code, model)'s first DAY issue date, retained rows from the migrated period
+archive. The merge retains what already exists — it does not synthesise a row for
+a date that was never written.
+
+### Recovery: stranded period rows
+
+Period rows are written on the daily/boundary-day cadence only by the operational
+path, so a missed boundary day strands them, and maintenance cannot heal a date
+that has no `combined` rows to discover. The recovery tool is
+`postprocessing_forecasts/backfill_period_forecasts.py`, which re-runs this same
+aggregation over a chosen range, one calendar year per internal call.
+
+It re-aggregates existing inputs and cannot invent them: when the pipeline never ran,
+there is nothing at step 1 for those dates. The run then writes nothing *new for them*
+while still re-upserting the rest of that year, and exits 0 — or exits 1 if the whole
+horizon-year is empty. Neither outcome is a repair. Establish coverage before using
+it — procedure in
+[`doc/prod/backfill_period_forecasts_runbook.md`](prod/backfill_period_forecasts_runbook.md).
+
 ### Ensemble Creation
 
 | Ensemble | Models | Threshold | Created In |

--- a/doc/dev/review_checklist_local_template.md
+++ b/doc/dev/review_checklist_local_template.md
@@ -1854,11 +1854,18 @@ and adds the per-model comparison that reveals stranded period rows.
 same window.
 
 **Red flags**:
-- Per-model period rows present but `EM`/`NE` at 0 for a boundary date — the
-  PP-045 class: short-term per-model PENTAD/DECADE rows are written **only** by
-  the operational path on boundary days, and maintenance cannot heal them. Use
-  `apps/postprocessing_forecasts/backfill_period_forecasts.py` (one calendar year
-  per pass) rather than expecting maintenance to fill the gap.
+- Per-model period rows **absent** for a boundary date — the PP-045 class: short-term per-model PENTAD/DECADE rows are written on the
+  daily/boundary-day cadence **only** by the operational path, and maintenance
+  cannot heal them. (Other entrypoints do write them off that cadence — the yearly
+  skill recalculation re-saves period rows as a side effect — so do not infer "an
+  operational run happened" from a row's existence.) **First check that inputs
+  exist for the affected issue dates**: the backfill re-aggregates existing inputs
+  and cannot invent them. With no coverage for the affected dates it exits 0 having
+  re-upserted the rest of the year and written nothing new for those dates (or exits 1
+  if the whole horizon-year is empty) — neither is a repair. If inputs are present, use
+  `apps/postprocessing_forecasts/backfill_period_forecasts.py` — see
+  `doc/prod/backfill_period_forecasts_runbook.md`. If they are absent the fix is
+  upstream in `machine_learning`.
 
 ---
 
@@ -2108,4 +2115,5 @@ not just PASS/FAIL where a threshold applies.
 | Long-term row with tiny `n_pairs` and a wild NSE | Min-n floor not applied on this path | Check the `ieasyhydroforecast_min_pairs_long_term*` values in effect (defaults 4/5/5) |
 | Tombstone (`n_pairs=0`) carrying metrics | Tombstone written malformed | Real defect — capture the row and file it |
 | EM parity `comparable=0` at quarter/season | EM and LR_Base/LR_SM share no key — usually a `horizon_value` mismatch | Compare `horizon_value` on the EM row vs its inputs before assuming EM is wrong |
-| Per-model period rows exist but EM/NE absent | Missed operational boundary day; maintenance cannot heal per-model period rows | Run `apps/postprocessing_forecasts/backfill_period_forecasts.py`, one calendar year per pass (PP-045) |
+| Per-model period rows **absent** on a boundary date | Missed boundary-day postprocessing, or inputs never produced | Establish coverage first, then `doc/prod/backfill_period_forecasts_runbook.md` (PP-045). No coverage ⇒ upstream `machine_learning` fix |
+| Per-model period rows present but EM/NE absent | **Not the PP-045 signature.** EM requires ≥2 models past the skill gate and is skipped when skill metrics are empty; NE needs ML members | Check skill-metric availability for the horizon before suspecting a stranded period |

--- a/doc/prod/backfill_period_forecasts_runbook.md
+++ b/doc/prod/backfill_period_forecasts_runbook.md
@@ -1,0 +1,323 @@
+# Recovering Stranded Short-Term Period Forecasts (PP-045)
+
+Operator procedure for `apps/postprocessing_forecasts/backfill_period_forecasts.py`,
+the recovery tool for missing short-term per-model PENTAD/DECADE rows in the
+`forecasts` table.
+
+> **Status of this procedure.** Sections 1-4 and 6 (diagnosis) are ready to use.
+> **The real write in section 5 is PROHIBITED**: contract C8 requires a tested
+> rollback and none exists (section 7). Use this document to decide whether the tool
+> applies and to establish coverage; do not use it to perform a recovery yet.
+
+---
+
+## 1. Does this tool apply? — read this before anything else
+
+**Most reported cases of "period rows are missing" are NOT fixable by this tool.**
+
+The CLI does not generate forecasts. It re-runs the ordinary aggregation over inputs
+that already exist and writes the result. If the inputs for your dates were never
+produced, it cannot recreate them.
+
+Be precise about what you will see, because neither outcome means "repaired":
+
+- **Some dates lack coverage, the rest of the year has it** — the likely case. The run
+  **exits 0**, having re-upserted every *other* period of that year while writing
+  nothing new for the dates you cared about. Exit 0 here is not evidence of recovery.
+- **The whole horizon-year has no writable rows** — the API writer returns failure,
+  `require_api=True` raises, and the run **exits 1**.
+
+*(In the field cases examined so far the inputs were absent because the pipeline had
+not run. How representative that is across deployments is **inferred, not measured** —
+see §H of the issue.)*
+
+Work through this in order:
+
+| Question | If yes | If no |
+|---|---|---|
+| Do the affected issue dates have usable aggregation inputs? (section 3) | Continue | **Stop.** The gap is upstream — see section 8. This tool cannot help. |
+| Is the gap inside the current calendar year? | The next boundary-day operational run may heal it on its own; consider waiting | Continue — cross-year is where this tool is the most controlled option |
+| Are per-model rows present but only `EM`/`NE` missing? | **Not this tool.** EM has an independent skill gate; absent EM is not by itself evidence of a stranded period | Continue |
+
+Two situations where this tool is the right answer:
+
+1. **Inputs exist but the boundary-day postprocessing was missed** — ML produced its
+   DAY forecasts, postprocessing failed or was skipped.
+2. **Cross-year recovery where inputs exist** — its per-year iteration is what avoids
+   the yearless-key collapse (PP-046) that defeats an unbounded skill recalculation.
+   It is the most controlled cross-year option, not the only one: a manual
+   `SAPPHIRE_FORECAST_DATE` operational run reaches a chosen historical year (the
+   chosen date must itself be a boundary date), and the un-wired raw-SQL
+   `apps/machine_learning/reaggregate_day_to_periods.py` reaches any year while
+   bypassing the application's guards.
+
+Background and the per-entrypoint matrix: section H of
+`doc/plans/issues/review_gi_draft_pp_missed_boundary_period_gap.md`.
+
+## 2. Prerequisites
+
+- The postprocessing API is reachable and `SAPPHIRE_API_ENABLED` is not `false`. This
+  is a database-write tool; an API-disabled run is meaningless.
+- ML reading is configured: `ieasyhydroforecast_run_ML_models=true` and a non-empty
+  `ieasyhydroforecast_available_ML_models`. With ML reading off, the aggregation has
+  no ML inputs regardless of what the archive holds.
+- The deployment env file is known.
+
+```bash
+export ENV_FILE=<deployment-env-file>
+export ieasyhydroforecast_env_file_path=$ENV_FILE
+```
+
+Confirm which deployment you are pointed at **before** any command in section 5.
+
+## 3. Establish coverage — the applicability test
+
+**Test merged-archive coverage, not DAY-row presence.** Checking only for DAY rows
+gives the wrong answer: the reader falls back to the migrated period archive, and for
+dates before each (code, model)'s first DAY issue date it serves retained
+period-archive rows instead. A date with no DAY row can still be recoverable; a date
+with DAY rows can still be unrecoverable if their `target` falls outside the following
+period or their discharge is null.
+
+Run the production reader over the affected year and print what it actually yields —
+this is read-only and saves nothing:
+
+```python
+# Run from apps/postprocessing_forecasts/ with the module's venv.
+import sys; sys.path.insert(0, "../iEasyHydroForecast")
+import pandas as pd
+import setup_library as sl
+from src import data_reader
+
+sl.load_environment()          # REQUIRED. Exporting the env path alone does not load
+                               # the .env, and ML reading then defaults OFF, which
+                               # would make every date look uncoverable.
+
+DATES  = ["2026-07-25", "2026-07-31"]     # the affected issue dates
+CODES  = ["19999"]                        # the affected station codes
+
+_, modelled = data_reader.read_observed_and_modelled_data(
+    "pentad",                             # or "decad"
+    codes=CODES,
+    start_year=2026, end_year=2026,
+)
+
+if modelled.empty or "date" not in modelled.columns:
+    print("NO COVERAGE AT ALL for this horizon/year -> section 8")
+else:
+    m = modelled.copy()
+    m["date"] = pd.to_datetime(m["date"]).dt.strftime("%Y-%m-%d")
+    m = m[m["model_short"] != "LR"]       # LR is dropped before the API write
+    # Report PER MODEL: this is a per-model recovery tool, so one healthy model
+    # must not be allowed to mask another that is missing or null.
+    expected = sorted(m["model_short"].unique())
+    print("models seen in this horizon/year:", expected)
+    for d in DATES:                       # check EVERY date, not the frame as a whole
+        for c in CODES:
+            hit = m[(m["date"] == d) & (m["code"].astype(str) == c)]
+            covered = sorted(
+                hit.loc[hit["forecasted_discharge"].notna(), "model_short"].unique()
+            )
+            missing = [x for x in expected if x not in covered]
+            print(f"{d} {c}: covered={covered} missing={missing}")
+```
+
+Read the result **per date, per code and per model** — a covered date elsewhere in the
+frame, or one healthy model on the right date, tells you nothing about the per-model row
+you are actually missing.
+
+- **`missing` empty for every affected date/code** → the tool can recover them. Continue.
+- **A model listed in `missing`** → that specific per-model row cannot be recovered by
+  this tool. Go to section 8.
+- Compare `expected` against the models you believe should be present: a model absent
+  from the whole horizon-year will not appear in `expected` at all, so check it against
+  `ieasyhydroforecast_available_ML_models` rather than against this list alone.
+
+Two caveats on this probe. The empty-frame guard matters: with no forecasts at all the
+reader returns a frame without a `date` column, so an unguarded filter raises rather
+than reporting "no rows". And the frame is a *necessary*, not sufficient, condition — it
+precedes ensemble creation, the yearless dedup and the writer's null-drop and dedup, so
+a covered date can still fail to land.
+
+Useful corroboration, needing no database: the rotated logs under `apps/logs/` record
+which days the pipeline actually ran. Rotation happens only on run days, so a missing
+date in the `log_operational.YYYY-MM-DD` sequence is a strong hint that nothing ran
+and the inputs were never produced.
+
+## 4. What the CLI actually does
+
+Read this before choosing arguments; several behaviours are not what the flag names
+suggest.
+
+- **Only the YEARS of `--start-date`/`--end-date` are used.** Day and month are used
+  for validation only. Every selected year is reprocessed **in full, for every
+  configured station**. `--start-date 2026-07-25 --end-date 2026-08-10` does exactly
+  the same work as `--start-date 2026-01-01 --end-date 2026-12-31`. Size the blast
+  radius from the years and from `--horizon`, never from the dates.
+- **One year per internal aggregation/save call.** The CLI accepts a multi-year range
+  and isolates each year itself, so separate invocations are *not* required. The
+  isolation is deliberate: `file_writer.get_latest_forecasts` de-duplicates on the
+  yearless key `(code, period_in_year, model_short)` (`src/file_writer.py:120-122`)
+  *before* the `year >= latest_year - 1` filter (`:129`), so a multi-year read would
+  collapse the same period across years. This is PP-046.
+- **Scope `--horizon` to the horizon you actually need.** `both` rewrites the entire
+  selected year for pentad *and* decad.
+- **Issue dates, not targets.** A period whose target starts 1 January of year Y is
+  produced by the 31 December (year Y-1) issue date. To heal it, the range must extend
+  back into the prior calendar year.
+- **API-only by default.** `--write-csv` is off so the backfill never clobbers the
+  operational combined CSVs. Pass it only if you explicitly want the CSVs rewritten.
+- **EM is not a replay.** Ensemble Mean is recomputed against *current* skill metrics,
+  so backfilling a historical period does not reproduce the ensemble values that
+  period originally had. Anything consuming historical EM — skill evaluation,
+  dashboards, bulletins — sees the new values.
+- **`--dry-run` is not coverage proof.** Its summary line reports only totals — row
+  count, distinct period count, distinct model count
+  (`"%s DRY-RUN: would write %d row(s) (%s); save skipped."`) — and never names the
+  dates or codes involved, so it cannot tell you whether *your* dates survived. Two
+  further traps: that row total is counted **before** `get_latest_forecasts`, the
+  LR-drop, the null-drop and the API dedup, so it overstates the payload; and other log
+  lines emitted during the same dry run (ensemble diagnostics, archive-cutover
+  warnings) *do* contain codes and dates, which is easy to mistake for coverage
+  evidence. Section 3 is the coverage evidence.
+
+## 5. Write-safety procedure (contract C8)
+
+**Do not skip any step — and note that step 4 cannot currently be satisfied, so the
+real run is prohibited (section 7).** The command rewrites every period of the
+selected year for every configured station.
+
+1. **Name the target.** State which deployment you are writing to and confirm it is
+   the intended one.
+2. **Open a maintenance window — a point-in-time check is not enough.** A "nothing is
+   running right now" check does not hold exclusion across snapshot -> write ->
+   read-back. Disable the cron entries for `postprocessing_forecasts` operational,
+   maintenance and skill recalculation for the whole duration, confirm no other
+   session holds the tunnels, and record when the window opened and closed. On
+   orchestrated deployments disable the **orchestrator** entries too, not only cron —
+   `apps/pipeline/` schedules the same tasks. Note the
+   yearly skill recalculation runs at 01:00 UTC on 31 December — do not run a backfill
+   across that boundary.
+3. **Snapshot the complete write set** (section 6) — the whole horizon-year for all
+   configured stations, values included, not just the dates of interest.
+4. **Build the rollback manifest** (section 7) before writing anything.
+5. **Run**, then **verify the full submitted payload against a read-back**, key and
+   value. Reading back only the dates of interest proves nothing about the rest of the
+   year. This is mandatory because `_write_combined_forecast_to_api` can return `True`
+   over a zero or partial server write (**PP-047**), so the CLI's `require_api=True`
+   catches an unreachable API, an exception, or an explicit failure — but does **not**
+   prove rows persisted.
+6. **Re-run once and compare values, not counts.** "Row counts unchanged" is a count
+   check; idempotence is a value claim.
+
+The command itself, once 1-4 are satisfied:
+
+The dry run is safe and useful on its own:
+
+```bash
+ieasyhydroforecast_env_file_path=$ENV_FILE \
+  python backfill_period_forecasts.py \
+  --start-date 2026-01-01 --end-date 2026-12-31 --horizon pentad --dry-run
+```
+
+The same command without `--dry-run` is the real write. **Do not run it until section
+7's rollback requirement is met.**
+
+Exit codes: `0` success; `1` one or more (year, horizon) combinations failed —
+remaining years are still attempted, so read the whole log rather than only the tail,
+and note an environment-load failure also surfaces as `1`, so `1` does not by itself
+mean a year/horizon failed; `2` invalid arguments (argparse errors also exit `2`). The run sets `SAPPHIRE_API_FAILURE_MODE=fail` so API write
+errors surface instead of being swallowed.
+
+## 6. Snapshot
+
+Snapshot the whole horizon-year for the configured stations before any write.
+Substitute the real station codes; `19999` is a placeholder.
+
+**Note the enum case.** `horizon_type` and `model_type` are PostgreSQL enums whose
+labels are **uppercase** (`PENTAD`, `DECADE`, `TFT`, `ENSEMBLE_MEAN`, …). A lowercase
+literal does not silently match nothing — PostgreSQL raises
+`invalid input value for enum horizontype` and the statement fails outright, which is
+the safer of the two behaviours. The same trap is documented in
+`doc/prod/remediate_quarter_horizon_type_422.md`. **And `\copy` is a psql meta-command: it must be on one
+line.** Both mistakes were made in the first draft of this runbook.
+
+```bash
+docker exec sapphire-postprocessing-db psql -U postgres -d postprocessing_db -c "\copy (SELECT horizon_type, code, model_type, date, target, horizon_value, horizon_in_year, composition, forecasted_discharge, q05, q25, q75, q95, flag FROM forecasts WHERE horizon_type = 'PENTAD' AND EXTRACT(YEAR FROM date) = 2026 AND code IN ('19999')) TO '/tmp/pp045_snapshot_pentad_2026.csv' WITH (FORMAT csv, HEADER true)"
+
+docker cp sapphire-postprocessing-db:/tmp/pp045_snapshot_pentad_2026.csv ./
+```
+
+Keep the snapshot outside the repository — it contains operational data.
+
+## 7. Rollback is UNDEFINED — the write path is prohibited
+
+> **There is no rollback procedure for this tool today, so section 5's real run must
+> not be performed.** Contract C8 requires a tested rollback, and none exists. This
+> runbook is therefore complete as a **diagnosis** document (sections 1-4, 6) and
+> explicitly incomplete as a recovery document.
+
+This is a deliberate decision, not an omission. A first draft of this section carried
+hand-written `DELETE` SQL; independent review found two defects in it that would have
+caused data loss or silent failure on a production database (see the requirements
+below). Shipping plausible-looking but unexecuted destructive SQL into a runbook is
+worse than shipping none: an operator under pressure will copy it.
+
+### What a correct rollback must satisfy
+
+Whoever implements this needs database access and a scratch target. The requirements,
+which are the useful output of the analysis so far:
+
+1. **A snapshot alone is not a rollback.** Rows the backfill *inserts* have no prior
+   value to restore. Rollback must be partitioned by whether each key existed before
+   the run: pre-existing keys are **restored** to their snapshot values, keys that did
+   not exist are **deleted**. That partition — the manifest — must be captured *before*
+   the run, as its own artefact.
+2. **The identity is the unique constraint**
+   `(horizon_type, code, model_type, date, target)`, named
+   `uq_forecasts_horizon_code_model_date_target`.
+3. **`target` is nullable, so the manifest join must be NULL-safe.** In PostgreSQL,
+   `NULL = NULL` is not true, so a plain equality anti-join treats a legacy row with
+   `target IS NULL` as "not in the manifest" and **deletes a row that existed before
+   the run**. Use `IS NOT DISTINCT FROM`, or exclude NULL-target rows from the
+   operation and handle them separately. This was defect one.
+4. **Enum literals are uppercase** (section 6). A lowercase predicate raises
+   `invalid input value for enum horizontype` and aborts the statement — loud, not
+   silent, but it means a rollback drafted with lowercase literals does not run at all
+   at the moment it is needed. This was defect two.
+5. **Both directions must be exercised on a scratch or development target** — insert
+   rollback and update rollback — and the result recorded here before the banner above
+   is lifted.
+
+### On the 2026-07-23 write
+
+The only real backfill write on record (2026-07-23, Tajik dev DB) is documented in the
+issue with before/after row counts and an idempotence re-run. **No maintenance window
+and no rollback manifest is documented in the tracked record of that run.** That is a
+statement about the record, not proof that no precaution was taken — but it means the
+C8 procedure in section 5 has no evidence of ever having been exercised, and must not
+be presented as validated.
+
+## 8. When this tool cannot help
+
+If section 3 shows no usable coverage, the gap is upstream and the fix is to
+regenerate the ML DAY forecasts first, then return to section 3:
+
+- `apps/machine_learning/fill_ml_gaps.py` — wired into `maintenance:machine_learning`
+  and the default ML run mode. **Important limitation:** it detects only gaps
+  *between* consecutive existing dates, so it cannot see an empty archive, a leading
+  gap, or a trailing gap. A stale period with no forecasts on either side may be
+  invisible to it.
+- `apps/machine_learning/hindcast_ML_models.py` — the underlying hindcast, which
+  `fill_ml_gaps.py` calls.
+- `apps/machine_learning/recalculate_nan_forecasts.py` — for rows present but
+  null-valued. Note it selects only flag `1`/`2` rows, so it is not a general remedy
+  for every null discharge.
+
+## References
+
+- Issue: `doc/plans/issues/review_gi_draft_pp_missed_boundary_period_gap.md` (PP-045),
+  especially section H for the per-entrypoint matrix.
+- Related: **PP-046** (yearless dedup key), **PP-047** (writer reports success on a
+  zero or partial write — the reason section 5 step 5 is mandatory), **PP-048**.
+- Module README: `apps/postprocessing_forecasts/README.md`.


### PR DESCRIPTION
Executes **phase P3**. Documentation only — one new runbook plus three doc updates.

## Why

`backfill_period_forecasts.py` merged in #425 a month ago with **no tracked operator-facing documentation anywhere** — only the issue file and gitignored local checklists. A manual-recovery tool nobody can find is not a recovery mechanism, and PP-045's own Desired Outcome makes "the behavior is documented" part of done.

## The runbook leads with "does this tool apply?"

Not with commands, because **most reported cases of missing period rows are not fixable by it.** It re-aggregates inputs that already exist; when the pipeline never ran there is nothing to aggregate. The applicability test is **merged-archive coverage, not DAY-row presence** — the reader falls back to the retained period archive, so a date with no DAY row can still be recoverable, and a date with DAY rows can still be unrecoverable.

## Rollback is declared UNDEFINED and the real write is prohibited

This is the plan's other allowed branch, taken deliberately. My first draft carried hand-written `DELETE` SQL. Review found two defects that would have hit a production database:

- **`target` is nullable**, so a plain equality anti-join treats a legacy `target IS NULL` row as "not in the manifest" and **deletes a row that existed before the run**.
- **The enum labels are uppercase**, so a lowercase predicate aborts with `invalid input value for enum` — at the moment the rollback is needed.

Shipping plausible-but-unexecuted destructive SQL is worse than shipping none: an operator under pressure copies it. Section 7 now specifies what a correct rollback must satisfy — including both defects as named requirements — and gates the write on someone with database access building and testing it. Sections 1–4 and 6 (diagnosis, and a read-only snapshot) are ready to use today.

## Other things review caught

- **"Exits 0 having written nothing" was wrong**, in three documents. It re-upserts the rest of the year and writes nothing *new for your dates*; and it exits **1** when the whole horizon-year is empty.
- **The coverage probe was broken**: no `sl.load_environment()` (so ML reading would default off and every date would look uncoverable), a crash on the empty-frame case, and — worst — a coverage verdict combining all models, so one healthy model masked the missing per-model row that is the very thing being diagnosed. Now per date, per code, per model.
- **The dry-run description** overstated its own limits: the total is counted pre-filter, and other log lines in the same run *do* emit codes and dates.
- **C8's maintenance window** must disable orchestrator entries, not only cron.
- The tracked review checklist template carried two wrong PP-045 diagnostics: "written only by the operational path", and treating absent EM/NE as the PP-045 signature when EM has an independent skill gate.

## Handling of the local checklists

`doc/dev/review_checklist_local_20*.md` is gitignored and untracked and contains operational data. Only the **tracked template** is corrected; the dated copies were deliberately left alone and nothing gitignored is staged.

## Review

Three out-of-loop `codex exec` passes, two of which returned NOT SAFE TO COMMIT on the items above. The probe block is syntax-checked. Final pass: all seven P3 steps done under the diagnosis-only branch, no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)