### PR TITLE
PP-045/PP-060: record owner decisions, and recover a stranded commit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,35 @@ The `apps/` modules interact with `sapphire/services/` via REST API. The codebas
 - **Legacy (being removed)**: CSV file reading/writing
 - **Current**: REST API integration with `sapphire/services/`
 
-CSV I/O will be removed once API integration is fully tested.
+**Status 2026-08-18 — the database services are deployed and CSV output is being
+deprecated.** For **pipeline data I/O** — forecasts, skill metrics, observations moving
+between modules — the API is the source of truth: do not add new CSV reads or writes,
+and when touching an existing one prefer removing it over parameterising it.
+
+**This rule is scoped to pipeline data I/O, not to CSV as a file format.** It does not
+ban migration/transfer files, operator exports (`bin/export_runoff_period_history.sh`),
+or presentation-boundary CSV output. Several modules are still legitimately CSV-only
+during the transition — the conceptual model, some `preprocessing_gateway` outputs, and
+the documented `SAPPHIRE_API_ENABLED=false` mode — and `doc/dev/testing_workflow.md`
+still requires CSV-fallback tests. Treat those as transitional exceptions, not
+violations.
+
+Two hazards to respect while the removal is in progress. Neither is loud: both log, and
+both let the run exit zero, so they surface as wrong data rather than as a failure.
+
+- **CSV fallback readers become stale-data traps.** Several readers are API-first with a
+  CSV fallback (e.g. `data_reader.read_combined_forecasts`, already marked
+  `# CSV fallback (deprecated)`). Once writing stops, the fallback serves frozen data
+  when the API is unavailable instead of failing. Remove a fallback in the same change
+  that removes its writer, never later.
+- **Some tooling still reads those CSVs by name.** `bin/reset_sapphire_db.sh` invokes
+  `data_migrator.py --type combinedforecast`, which reads `combined_forecasts_pentad.csv`
+  and `combined_forecasts_decad.csv` with `pd.read_csv`. **Note the API cannot be the
+  replacement source here** — the reset drops the database volume *before* starting the
+  API, so the restarted API is backed by the empty database it is meant to refill. That
+  path needs a pre-reset export, a backup/restore, or a regeneration step. A stale file
+  repopulates stale rows; an absent file is warned about and skipped, leaving the table
+  empty and the migrator exiting zero.
 
 ### Pipeline Data Flow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,8 +185,10 @@ both let the run exit zero, so they surface as wrong data rather than as a failu
   replacement source here** — the reset drops the database volume *before* starting the
   API, so the restarted API is backed by the empty database it is meant to refill. That
   path needs a pre-reset export, a backup/restore, or a regeneration step. A stale file
-  repopulates stale rows; an absent file is warned about and skipped, leaving the table
-  empty and the migrator exiting zero.
+  repopulates stale rows; an absent file is warned about and skipped, leaving the
+  **combined period rows** empty and the migrator exiting zero — not the whole
+  `forecasts` table, since the reset also runs `--type forecast`, which can populate DAY
+  rows.
 
 ### Pipeline Data Flow
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Files that need to be reviewed and potentially edited or replaced for local depl
       - `Dockerfile`: Dockerfile to build the docker image for the forecast dashboard.
       - `forecast_dashboard.py`: The python script that runs the forecast dashboard.
     - `iEasyHydroForecast`: A collection of python functions that are used by the linear regression tool.
-    - `internal_data`: Data that is written and used by the forecast tools.
+    - `internal_data` (legacy — CSV outputs are being deprecated, see Configuration): Data that is written and used by the forecast tools.
       - `forecasts_pentad.csv`: The forecasts produced by the forecast backend. This file is written by the forecast backend and read by the forecast dashboard.
       - `hydrograph_day.csv`: Daily data used for visualization. This file is written by the forecast configuration dashboard and read by the forecast backend.
       - `hydrograph_pentad.csv`: Pentad data used for visualization. This file is written by the forecast configuration dashboard and read by the forecast backend.
@@ -214,6 +214,8 @@ Files that need to be reviewed and potentially edited or replaced for local depl
 
 # Configuration
 The SAPPHIRE Forecast Tools interact with each other through a number of files. The configuration of these files and paths is described in detail in the file [doc/configuration.md](doc/configuration.md).
+
+> **Note — CSV outputs are being deprecated.** The SAPPHIRE database services are now deployed, and the forecast modules increasingly read and write forecasts, skill metrics and observations through the REST API rather than through the CSV files under `apps/internal_data`. For pipeline data moving between modules, the database is the source of truth and new code should not add CSV reads or writes. The transition is not complete: some components are still CSV-only (the conceptual model, parts of `preprocessing_gateway`, and the documented `SAPPHIRE_API_ENABLED=false` mode), and operator exports and migration files are unaffected. See `CLAUDE.md` § Data I/O Transition.
 
 # Deployment
 The SAPPHIRE Forecast Tools are deployed using the Docker system. The deployment of the forecast tools is described in detail in the file [doc/deployment.md](doc/deployment.md).

--- a/doc/plans/issues/high_prio_gi_draft_pp_recalc_backfill_write_divergence.md
+++ b/doc/plans/issues/high_prio_gi_draft_pp_recalc_backfill_write_divergence.md
@@ -120,18 +120,47 @@ the rows both exist. The divergence is what makes the state ambiguous.
 
 ## Desired Outcome
 
-The owner picks one contract and the code matches it:
+> **DECIDED 2026-08-18 — option (a).** The recalc stops writing period forecasts.
+> Recorded together with a repo-wide decision that **CSV output is being deprecated**
+> now the database services are deployed, which retires **two** of the eight axes below —
+> CSV writing and artefact-frame scope — rather than fixing them. **Six survive**: the EM
+> row set, `require_api`, year scope, station scope plus virtual stations,
+> empty-observation behaviour, and operator controls.
+>
+> **Precondition to verify, not to assume.** An earlier draft claimed option (a) breaks
+> new-site seeding because the recalc's API forecast write seeds a fresh deployment. The
+> pipeline shape is confirmed — `bin/initialize_site_backfill.sh` has three phases, ends
+> with the recalc, and nothing after it writes forecasts — but the seeding claim is **not
+> established**: the init flow regenerates LR only, the recalc *reads* ML rows from a
+> `forecasts` table a purged site does not have, and `api_writer` drops LR before the
+> combined write and returns false when nothing non-LR remains. Establish what a fresh
+> site actually ends up with **before** building any seeding step. See the plan's §T2
+> consequences.
+>
+> Note (b) is not being pursued, so **PP-030's `exclude_models=["EM"]` stays as-is** —
+> under (a) the recalc writes no forecast rows at all.
+>
+> **Option (a) does not retire the dashboard CSV problem.** It removes the recalc's
+> `save_forecast_data` call, but the recalc still calls `save_skill_metrics`, whose CSV
+> write is unconditional — so a station-scoped recalc can still overwrite the shared
+> skill-metric CSV until the deprecation removes that write too.
+
+The two contracts that were on the table, retained for the record — **(a) was chosen**:
 
 - **(a) The recalc should not write period forecasts.** It is a skill-metrics job; drop
-  the `save_forecast_data` call. Smallest change, removes the divergence, and removes
-  the dashboard CSV-clobber path entirely.
+  the `save_forecast_data` call. Smallest change, and it removes the divergence. It
+  removes the *combined-CSV* clobber path but **not** the dashboard problem entirely —
+  `save_skill_metrics` still writes its CSV unconditionally.
 - **(b) The recalc legitimately refreshes period forecasts.** Then it must write the
   same row set as the operational path and share its CSV and failure-reporting
   semantics — and the scoped dashboard invocation needs its own answer, because a
   one-station recalc must not rewrite shared artefacts.
 
-**Independently of (a)/(b), the dashboard's scoped recalc should not inherit
-`write_csv=True`.** That is arguably a separate, smaller, higher-urgency fix.
+**Independently of the contract, the dashboard's scoped recalc should not rewrite shared
+artefacts.** Note what (a) does and does not do here: it removes the `save_forecast_data`
+call, so the inherited `write_csv=True` on *that* path goes away — but `save_skill_metrics`
+has **no `write_csv` parameter at all**, so its shared-CSV write survives (a) and needs
+either a new parameter or the CSV deprecation. Separate, smaller, higher-urgency fix.
 
 ---
 
@@ -169,9 +198,11 @@ contract nobody chose for it.
 
 ## Open questions for the owner
 
-1. **(a) or (b)** — a design decision that shapes all the work.
-2. **Should the dashboard's scoped recalc write anything shared at all?** It currently
-   can rewrite the combined CSVs from one station.
+1. ~~**(a) or (b)**~~ — **DECIDED 2026-08-18: option (a)**, see Desired Outcome.
+2. **Should the dashboard's scoped recalc write anything shared at all?** After decision
+   (a) this is a **scheduling** question about the surviving **skill-metric** CSV, not a
+   design question about the combined CSVs: fix it now, or let the CSV deprecation remove
+   that write. See the plan's T2.2 / T3.1.
 3. **Should `forecasts` carry provenance?** It would have made this diagnosable. That is
    a `sapphire/services/postprocessing` schema change — **colleague-managed, discuss
    first**, and likely out of scope here.
@@ -181,15 +212,34 @@ contract nobody chose for it.
 
 ## Testing
 
-- [ ] Unit: for one fixed input frame, assert both paths produce the same set of
-      `model_short` values **under equal skill conditions** — the test that would have
-      caught the EM divergence without being defeated by the skill gate.
-- [ ] Unit: assert a station-scoped recalc does not rewrite shared combined CSVs.
-- [ ] Unit: assert a failed API write is reported identically by both paths.
-- [ ] Regression: **do not simply delete `exclude_models=["EM"]`.** PP-030 introduced it
-      because boundary-date misalignment produced EM rows with `n_pairs` of 1-2;
-      removing it restores that defect unless the alignment is fixed first.
+Rewritten for **option (a)**. Under (a) the recalc writes no forecast rows, so the
+original checklist's "both paths produce the same set" and "both report forecast-API
+failure identically" are not meaningful — they are retained at the bottom, struck out, as
+the record of what option (b) would have required.
+
+- [ ] Unit: the recalc performs **no** forecast write — `save_forecast_data` is not
+      called from `_run_short_term_recalc`.
+- [ ] Unit: the recalc's **skill-metric** write and its failure return are unchanged.
+- [ ] Unit: a station-scoped recalc does not rewrite the shared **skill-metric** CSV
+      (this one survives option (a) — `save_skill_metrics` has no `write_csv` parameter).
+- [ ] Unit: an **unscoped** recalc's behaviour is unchanged by that suppression.
+- [ ] Unit: the suppression also disables the CSV-backed consistency check — exercise it
+      with `SAPPHIRE_CONSISTENCY_CHECK=true`, or an API-only run verifies a scoped frame
+      against stale or absent shared CSV state and reports a spurious mismatch.
+- [ ] Update, narrowly: the existing tests asserting two forecast-save calls, four recalc
+      output CSVs, saved forecast contents, and forecast-save failure propagation. These
+      are intentional expectation changes; do not weaken unrelated coverage.
 - [ ] `cd apps && SAPPHIRE_TEST_ENV=True bash run_tests.sh postprocessing_forecasts`
+
+Option-(b) checklist, retained as record only — **not** current work:
+
+- [ ] ~~Unit: for one fixed input frame, assert both paths produce the same set of
+      `model_short` values under equal skill conditions.~~
+- [ ] ~~Unit: assert a failed forecast-API write is reported identically by both paths.~~
+- [ ] ~~Regression: do not simply delete `exclude_models=["EM"]` — PP-030 introduced it
+      because boundary-date misalignment produced EM rows with `n_pairs` of 1-2.~~
+      *(Moot under (a): the recalc writes no forecast rows, so the exclusion stays
+      untouched. This constraint returns only if the contract is revisited.)*
 
 ## Documentation Impact
 
@@ -207,7 +257,9 @@ contract nobody chose for it.
 
 ## Dependencies
 
-- **PP-030** — owns `exclude_models=["EM"]`; its rationale must be understood first.
+- **PP-030** — owns `exclude_models=["EM"]`. **Not a prerequisite under option (a)**: the
+  recalc writes no forecast rows, so the exclusion is untouched. It becomes a prerequisite
+  again only if the contract is revisited toward (b).
 - **PP-045** — the field case this divergence made ambiguous; §H carries the matrix.
 - **PP-046, PP-047, PP-051** — manifested or partially manifested here.
 

--- a/doc/plans/issues/high_prio_gi_draft_pp_recalc_backfill_write_divergence.md
+++ b/doc/plans/issues/high_prio_gi_draft_pp_recalc_backfill_write_divergence.md
@@ -199,10 +199,10 @@ contract nobody chose for it.
 ## Open questions for the owner
 
 1. ~~**(a) or (b)**~~ — **DECIDED 2026-08-18: option (a)**, see Desired Outcome.
-2. **Should the dashboard's scoped recalc write anything shared at all?** After decision
-   (a) this is a **scheduling** question about the surviving **skill-metric** CSV, not a
-   design question about the combined CSVs: fix it now, or let the CSV deprecation remove
-   that write. See the plan's T2.2 / T3.1.
+2. ~~**Should the dashboard's scoped recalc write anything shared at all?**~~ —
+   **DECIDED 2026-08-18: fix it now, carved out as its own change** (the plan's T3.1),
+   rather than waiting for the CSV deprecation to remove the write. Scope is the
+   surviving **skill-metric** CSV; option (a) handles the combined CSVs via T3.2.
 3. **Should `forecasts` carry provenance?** It would have made this diagnosable. That is
    a `sapphire/services/postprocessing` schema change — **colleague-managed, discuss
    first**, and likely out of scope here.
@@ -283,6 +283,7 @@ is fixed separately and quickly.
   parallel session allocated PP-059 to a different issue ("Remove monthly EM"); this one
   yielded the id. Any earlier reference to PP-059 for the write divergence — including
   PR #445's title and description — means this issue.
-- **Index row still pending** — `doc/plans/module_issues.md` has uncommitted changes in
-  that parallel session. `PP-060` was free at the time of renaming; re-verify before
-  adding the row.
+- **Index row still pending, but now unblocked** — the parallel session's registry work
+  landed in PR #448, so the tree is clean and `PP-059` is now formally "Remove monthly
+  EM". `PP-060` is confirmed free and unindexed as of 2026-08-18; re-verify immediately
+  before adding the row (the plan's T0.2).

--- a/doc/plans/issues/review_gi_draft_pp_missed_boundary_period_gap.md
+++ b/doc/plans/issues/review_gi_draft_pp_missed_boundary_period_gap.md
@@ -1142,10 +1142,11 @@ Silence here is indistinguishable from health.
 
 **File as a new ticket, do not bundle into PP-045.** PP-045's scope was "provide a
 recovery mechanism", and that is delivered. "Make the condition visible" is a
-different contract with a different risk profile. **Do not assume PP-056 is free:**
-it is unused on trunk `8e3fc1bc` but claimed by an uncommitted entry (quarter
-skill-metric `horizon_value=0`) in a parallel session's working copy of
-`doc/plans/module_issues.md`. Allocate against the *current* index, not trunk's.
+different contract with a different risk profile. **Do not assume any id is free:**
+PP-056 and PP-059 were both claimed by a parallel session and landed in the registry via
+PR #448 — PP-059 is "Remove monthly EM", and the write-divergence issue this plan
+references was renamed to **PP-060** as a result. Allocate against the *current* index
+immediately before writing the row, never against a remembered value.
 
 ### G. Remaining checklist to move Review → Complete
 
@@ -1247,14 +1248,18 @@ issue's own Desired Outcome:**
       (§A6). `recalculate_skill_metrics.py:191` passes no year bounds; the save
       path collapses period-in-year across years. Silent under-write, not data
       loss. Strongest concrete instance of PP-046.
-- [ ] **Detect-and-report for stranded boundary days** (§F). Allocate a free ID —
-      allocate against the *current* `module_issues.md`, not trunk's (see §F —
-      PP-056 is free on trunk but claimed in a parallel session's working copy).
+- [ ] **Detect-and-report for stranded boundary days** (§F). Allocate against the
+      *current* `module_issues.md` immediately before writing the row — PP-056 and
+      PP-059 were both taken by a parallel session and landed via PR #448, and the
+      write-divergence issue had to be renumbered to PP-060 as a result.
 
-**Owner decisions still open (carried forward, unchanged):**
+**Owner decisions:**
 
-- [ ] API-only-by-default write (`--write-csv` opt-in) — behavioural choice on the
-      combined-CSV artifact; owner may override to CSV+API.
+- [x] **API-only-by-default write (`--write-csv` opt-in) — CONFIRMED 2026-08-18.** The
+      backfill CLI keeps CSV writing off by default. This was carried as an open flag
+      since 2026-07-23; the answer is now consistent with the repo-wide decision that
+      **CSV output is being deprecated** (`CLAUDE.md` § Data I/O Transition), which also
+      means the flag retires with the CSVs rather than needing a change of its own.
 
 **Explicitly NOT blocking Complete:** PP-046 (yearless key — worked around by the
 per-year loop), PP-048 (decade EM freeze). **PP-047 is not a code blocker either,

--- a/doc/plans/working/pp_period_write_consistency_plan.md
+++ b/doc/plans/working/pp_period_write_consistency_plan.md
@@ -11,8 +11,10 @@ files (six paths at the time of writing — do not rely on the count, re-check).
 and the id collision in §0a.4 must be settled first. This is residual risk 6 arriving
 within the hour it was written.
 
-**Scope.** Close out PP-045 honestly, land the two follow-up tickets it owes, and — only
-after an owner decision — fix the write divergence filed as PP-060.
+**Scope.** Close out PP-045 honestly, land the two follow-up tickets it owes, and
+implement **option (a)** for the write divergence filed as PP-060 — the contract was
+decided 2026-08-18 (§4 T2). Option (b) survives only as historical alternative; where
+this plan mentions it, that is the record of what was considered, not live work.
 
 **Scope honesty.** Tiers 0 and 1 are documentation only. **Tier 3 changes runtime code**
 in `apps/postprocessing_forecasts/` and possibly `apps/forecast_dashboard/`, on paths
@@ -88,10 +90,10 @@ refutation of the cause; T0.1 must not repeat that.)
    an **existing** one, so the defect manifests today. May justify re-rating.
 6. **Detect-and-report ticket.** No such file exists under `doc/plans/issues/`.
 
-### 0c. Genuinely open, needing an owner
+### 0c. Owner decisions — one settled, the rest open
 
 7. The **kyg criterion** (PP-045's last acceptance item).
-8. **PP-060's contract** — (a) or (b), see §4 T2.
+8. ~~**PP-060's contract**~~ — **DECIDED 2026-08-18: option (a)** (§4 T2).
 9. PP-045's carried **API-only-by-default** flag.
 
 ### 0d. Housekeeping
@@ -109,7 +111,7 @@ refutation of the cause; T0.1 must not repeat that.)
 | Operator runbook, write path | Documented, **write path prohibited** pending a tested rollback | Yes (#441 §7) | Rollback SQL still unwritten — deliberate |
 | PP-045 diagnosis (cause C1) | — | Asserted in §B2/§H as the live hypothesis | **Unresolved, not refuted.** The 2026-08-18 probe refutes only "the archive is empty today". Tier 0 restates it |
 | PP-045 §G as sole live checklist | — | Asserted | **Stale both ways** (§0a.2) |
-| Recalc/operational write divergence | Present in code | Filed as PP-060 (#445) | Unfixed; owner decision pending |
+| Recalc/operational write divergence | Present in code | Filed as PP-060 (#445) | Unfixed; **contract decided 2026-08-18 (option a)**, implementation pending T3.2 |
 | Detect-and-report | No | Recommended in PP-045 §F | Ticket never filed |
 
 ---
@@ -273,10 +275,11 @@ draft of this plan missed entirely. Note the interaction with the
 broader frame than the API payload. Flag the priority for owner re-rating; **do not
 re-rate unilaterally.**
 
-**Sequencing caution.** If T2 chooses option (a), the recalc stops being a caller and
-this text goes stale the moment T3.2 lands. Either run T0.3 *after* T2 decides, or write
-it so it survives both outcomes — state the maintenance caller unconditionally and the
-recalc caller as "as of trunk `6e28647a`, and subject to PP-060's contract decision".
+**Sequencing — resolved.** T2 chose option (a), so the recalc *will* stop being a caller
+once T3.2 lands. Write this text so it survives that: state the maintenance caller
+unconditionally, and the recalc caller as "as of trunk `6e28647a`; removed by PP-060
+option (a), see T3.2". T0.3 therefore runs after T2 (which it now does) and does not need
+revisiting when T3.2 lands.
 
 - **Acceptance:** PP-046 no longer says "future" caller; cross-references PP-060.
 
@@ -308,18 +311,35 @@ latter is not the PP-045 signature.
 
 ### T2 — Owner decisions (gate; no work)
 
-1. **PP-060 contract:** (a) the recalc stops writing period forecasts, or (b) it writes
-   the same row set as operational (larger; pulls in PP-030 per C3).
+> **DECIDED 2026-08-18 — option (a), and CSV output is being deprecated repo-wide.**
+> The two are linked: with CSV writing going away, the recalc's only remaining *forecast*
+> side effect is the API forecast write, so removing it is a far smaller conceptual
+> change than when it also owned two CSV artefacts. (It still writes skill metrics to the
+> API — that is its job and is untouched.) **Decision 1 is settled; 2, 3 and 4 remain
+> open** — 2 has changed from a design question to a scheduling one, because option (a)
+> does not by itself retire the dashboard CSV problem. See "Consequences of the decision"
+> after the list.
+
+1. **PP-060 contract — DECIDED: (a)**, the recalc stops writing period forecasts.
+   Option (b) (write the same row set as operational) is **not** being pursued, which
+   also means **PP-030 is not pulled in** — the `exclude_models=["EM"]` exclusion stays
+   exactly as it is, because under (a) the recalc writes no forecast rows at all. C3
+   remains in force for anyone later revisiting (b).
 
    **Option (a) is one edit but not a small change** — an earlier draft of this plan
    called it "the removal of one call", which understated it badly. Deleting that call
    removes, from *every* short-term recalc: combined and `_latest` CSV generation **and**
-   the forecast API write. Before choosing (a), the owner must answer:
-   - **What seeds initial combined-forecast and API state on a new deployment?** Both
+   the forecast API write. Now that (a) is chosen, these are **verification items for
+   T3.2**, not inputs to the decision:
+   - **What actually seeds combined-forecast API state on a new deployment?** Determine
+     this empirically; do not assume the recalc does (see the consequences section — the
+     evidence suggests its write may already be a no-op on a fresh site). Both
      initialization implementations (`apps/run_locally.sh`, `apps/pipeline/pipeline_docker.py`)
-     *finish* with the recalc and have no subsequent operational or backfill step. New-site
-     backfill (`bin/initialize_site_backfill.sh`) also runs a `BOTH` recalc. Under (a),
-     nothing seeds that state unless something is added.
+     *finish* with the recalc and have no subsequent operational or backfill step, and
+     new-site backfill (`bin/initialize_site_backfill.sh`) also ends on a `BOTH` recalc —
+     so **if** the recalc's write is what seeds that state, (a) removes it with no
+     replacement. Whether it seeds anything is the open question; answer it before
+     building a replacement.
    - **What about the tooling that hardcodes those CSVs?** DB reset and the postprocessing
      `data_migrator` reference them by name, and `doc/prod/backfill_ml_fromfile.md`
      identifies them as what puts short-term ML into the dashboard.
@@ -327,16 +347,91 @@ latter is not the PP-045 signature.
      CLI docstring, and the review-checklist template all state that the recalc writes
      period rows. Option (a) invalidates each — including text T0.3 would have just
      written.
-2. **Whether the dashboard `write_csv` fix is carved out** as its own change ahead of
-   (a)/(b). Recommended: yes.
+2. **Whether the dashboard `write_csv` fix is carved out** — **still open, and now a
+   scheduling question.** See "T3.1's status" below: option (a) does not by itself retire
+   it, because the scoped `save_skill_metrics` CSV overwrite survives option (a).
 3. **The kyg criterion** — run the full kyg pipeline when available, or waive in writing.
 4. **PP-045's API-only-by-default flag** — confirm or override.
 
-**Nothing in Tier 3 may start before 1 and 2 are answered.**
+**Gating, stated once so the graph and prose agree:** T3.2 is gated on **decision 1**,
+which is settled. T3.1 is gated on **decision 2**, which is open. In §6's default
+scenario T3.1 also precedes T3.2 and T4 — if decision 2 drops T3.1, re-parent per §6
+rather than leaving T3.2 without its Tier-0 chain.
 
-### T3.1 — Dashboard scoped recalc must not rewrite shared CSVs
+### Consequences of the 2026-08-18 decision
 
-- **Goal:** a single-station user action stops rewriting the operational combined CSVs.
+**PP-060 shrinks — by two axes, not three.** Of its eight, exactly two are CSV-shaped:
+**CSV writing** and **what each artefact receives**. Both are retired by the deprecation
+rather than fixed. (An earlier draft also counted the CSV-backed consistency check; that
+is a detail of T3.1, not one of the eight rows.) **Six survive**: the EM row set,
+`require_api`, year scope, station scope plus virtual stations, empty-observation
+behaviour, and operator controls.
+
+**T3.1's status — option (a) does NOT retire it.** The carve-out existed to stop a scoped
+recalc rewriting shared CSVs, and there are two:
+- the **combined** forecast CSVs, written via `save_forecast_data` — option (a) removes
+  that call from the recalc entirely, so these are retired by (a);
+- the **skill-metric** CSV, written via `save_skill_metrics`, which the recalc still calls
+  because writing skill metrics is its job. **Option (a) leaves this one live**, so a
+  station-scoped dashboard recalc can still overwrite the shared skill-metric CSV with a
+  single station's data.
+
+T3.1 is therefore superseded only once the CSV deprecation removes the skill-metric CSV
+write. Until then it is a live defect. The owner's remaining choice (T2.2) is scheduling:
+- if the deprecation will remove that write soon, **drop T3.1** and let it absorb the fix;
+- otherwise **keep T3.1, scoped to `save_skill_metrics` only** — option (a) handles the rest.
+Record whichever is chosen; the dependency graph assumes T3.1 runs, and §6 says how to
+re-derive it if not.
+
+**The seeding concern is WEAKER than an earlier draft claimed — verify it before acting
+on it.** That draft asserted the recalc's API forecast write is what seeds a new site.
+The pipeline *shape* is confirmed — `bin/initialize_site_backfill.sh` has three phases,
+ends with the recalc, and nothing after it writes forecasts — but the seeding claim is
+**not established**, and the evidence points the other way:
+- the init flow regenerates **LR forecasts only**;
+- the recalc obtains ML rows by *reading* the already-populated `forecasts` API, so on a
+  purged site there is nothing for it to read;
+- `api_writer` drops LR rows before the combined write and returns false when nothing
+  non-LR remains — so on a fresh site that write plausibly does nothing at all;
+- `doc/prod/first_deploy_checklist.md` promises only LR state and skill metrics from a
+  fresh deployment.
+
+**Action before T3.2:** establish empirically what a fresh site ends up with in
+`forecasts`, and whether removing the recalc's write changes it. If it changes nothing,
+option (a) needs no seeding step and the main objection to it disappears. Do not build a
+seeding step on the strength of the earlier claim.
+
+**Two deprecation hazards, filed here because no other plan owns them.** Neither is
+loud: both log, and both let the run exit zero, so they surface as wrong data rather than
+as a failure — the same shape as the seeding gap, a green run with a wrong result,
+discovered much later:
+1. **CSV fallback readers become stale-data traps.** `data_reader.read_combined_forecasts`
+   is API-first with a fallback already marked deprecated in code. Once writing stops it
+   serves frozen data when the API is down instead of failing. Remove each fallback in
+   the same change as its writer.
+2. **`bin/reset_sapphire_db.sh` invokes `data_migrator.py --type combinedforecast`**,
+   which reads `combined_forecasts_pentad.csv` / `combined_forecasts_decad.csv` by name.
+   **The API cannot be the replacement source here** — the reset drops the database volume
+   *before* starting the API, so the restarted API is backed by the empty database it is
+   meant to refill. This path needs a pre-reset export, a backup/restore, or a
+   regeneration step. Left as is: a stale file repopulates stale rows; an absent file is
+   warned about and skipped, leaving the table empty and the migrator exiting zero.
+These belong to the deprecation effort, not to PP-060; record them wherever that work is
+tracked. They are noted in `CLAUDE.md` § Data I/O Transition.
+
+### T3.1 — Dashboard scoped recalc must not rewrite the shared skill-metric CSV
+
+**Scope narrowed by decision (a) — with one interim exception.** Option (a) removes the
+recalc's `save_forecast_data` call, so the *combined* forecast CSVs stop being at risk
+from this path **once T3.2 lands**. In the default ordering T3.1 runs *first*, so it must
+still cover them in the meantime; its steps below mark that work interim and T3.2 step 5
+deletes it. The artefact that survives permanently, and the reason T3.1 exists at all,
+is `save_skill_metrics`, whose CSV write is unconditional and which the recalc still
+calls. **That artefact is T3.1's permanent scope; the combined CSVs are temporary scope**
+it carries only until T3.2 removes the call ahead of it.
+
+- **Goal:** a single-station user action stops rewriting shared CSVs — after (a), that
+  means the skill-metric CSV.
 - **Files:** the call sites — `apps/forecast_dashboard/src/vizualization.py`,
   `recalculate_skill_metrics.py`, and possibly a new parameter on
   `file_writer.save_skill_metrics` (see step 1). **Not** `save_forecast_data`'s
@@ -356,9 +451,12 @@ saw only the combined forecast CSVs:
 
 Steps:
 
-1. Decide the mechanism for each artefact. For the combined CSVs, pass `write_csv=False`
-   explicitly on the scoped path. For the skill-metric CSV, either add a `write_csv`
-   parameter to `save_skill_metrics` **defaulting to `True`** so no existing caller
+1. Decide the mechanism. **After decision (a) the only artefact in scope is the
+   skill-metric CSV** — the combined CSVs leave via T3.2. (If T3.1 lands *before* T3.2,
+   also pass `write_csv=False` on the scoped `save_forecast_data` call as an interim
+   guard; drop that half once T3.2 removes the call.) For the skill-metric CSV, either
+   add a `write_csv` parameter to `save_skill_metrics` **defaulting to `True`** so no
+   existing caller
    changes (C1's principle applied to a new parameter), or stop the dashboard invoking a
    writing path at all. Prefer whichever leaves the unscoped recalc byte-identical,
    since T3.2 will revisit that path.
@@ -366,47 +464,64 @@ Steps:
    consistency check**, which re-reads that CSV to verify the write. Left enabled on an
    API-only run it would verify a scoped frame against stale or absent shared CSV state
    and report a spurious mismatch. Suppress both together.
-3. Tests (C5), covering **all three physical files** — combined, `_latest`, and skill
-   metrics: a scoped recalc touches none of them; an unscoped recalc's behaviour is
-   unchanged; and the suppression is exercised with `SAPPHIRE_CONSISTENCY_CHECK=true`.
-   The skill **API write and its failure return must be preserved** — this phase removes
-   a CSV side effect, not the write.
+3. Tests (C5). **Primary, and the only ones that outlive T3.2:** a scoped recalc does not
+   touch the shared **skill-metric** CSV; an unscoped recalc's behaviour is unchanged; the
+   consistency-check suppression is exercised with `SAPPHIRE_CONSISTENCY_CHECK=true`; and
+   the skill **API write and its failure return are preserved** — this phase removes a CSV
+   side effect, not the write. *Interim only, if T3.1 lands before T3.2:* the same
+   assertions for the combined and `_latest` CSVs. Delete those two when T3.2 removes the
+   `save_forecast_data` call, rather than leaving tests asserting a path that no longer
+   exists.
 4. Decide C9 explicitly: should the dashboard's swallowed failures now surface? If yes,
    it is a **separate** change (C4).
 
-- **Acceptance:** C2 evidence; the scoped path provably writes **none of the three**
-  shared CSVs; the skill API write still happens and still reports failure;
+- **Acceptance:** C2 evidence; the scoped path provably writes **no shared skill-metric
+  CSV** (and, while T3.2 is outstanding, no combined CSV either); the skill API write
+  still happens and still reports failure;
   unscoped behaviour byte-identical; the new parameter (if added) defaults to current
   behaviour; one axis only.
 
 ### T3.2 — Implement the chosen PP-060 contract
 
-- **Goal:** the recalc and operational paths stop disagreeing.
-- **Files:** depends on the decision. Under (a) the *code* edit is one call — but the
-  phase also touches existing tests that assert that call, and the documents listed in
-  T2.1 that describe the recalc as a period-row writer. It is one decision, not one file.
-- **Depends on:** T2.1, T3.1.
+- **Goal:** the recalc stops writing period forecasts (option (a), decided 2026-08-18).
+- **Files:** `recalculate_skill_metrics.py` — the `save_forecast_data` call. The *code*
+  edit is one call, but the phase also touches the existing tests that assert that call
+  and the documents that describe the recalc as a period-row writer. One decision, not
+  one file.
+- **Depends on:** T2.1 (settled), T3.1 in the default scenario.
 
-Steps: implement the chosen contract. Under (b), **one axis per PR** (C4), each with C5
-tests and C2 evidence, and PP-030's boundary misalignment addressed first or waived in
-writing (C3). Under (a), the change lands alone under C4's atomic-responsibility-removal
-exception, and **only after** the seeding question in T2.1 has an answer that is itself
-implemented or explicitly deferred with the risk accepted.
+Steps:
 
-Under (a), the phase must also: update the existing tests that assert the forecast-save
-occurs (narrowly, per C2); and refresh the documents listed in T2.1 that state the recalc
-is a period-row writer — otherwise the fix ships alongside documentation asserting the
-opposite.
+1. **Answer the seeding question first** (§T2 consequences): establish empirically what a
+   fresh site ends up with in `forecasts`, and whether removing this call changes it. If
+   it changes nothing, proceed. If it does, the replacement seeding step must be
+   implemented or the risk explicitly accepted in writing **before** this lands.
+2. Remove the call. It lands **alone**, under C4's atomic-responsibility-removal
+   exception.
+3. Update the existing tests that assert the forecast-save occurs — narrowly, per C2.
+   Existing tests require two forecast-save calls, four recalc output CSVs, saved
+   forecast contents, and forecast-save failure propagation; these are intentional
+   expectation changes, not weakened coverage.
+4. Refresh the documents that state the recalc is a period-row writer: PP-045's writer
+   inventory and §H matrix, the backfill CLI docstring, and
+   `doc/dev/review_checklist_local_template.md`. Otherwise the fix ships beside
+   documentation asserting the opposite.
+5. Drop T3.1's interim combined-CSV assertions, now that the call is gone.
 
-- **Acceptance:** for a fixed input frame under equal skill conditions, both paths
-  produce the same `model_short` set (or, under (a), only one path writes at all); C2
-  evidence on every PR; no document left asserting the superseded writer inventory.
+**PP-030 is not in scope.** Under (a) the recalc writes no forecast rows, so
+`exclude_models=["EM"]` stays exactly as it is. Only option (b) would have required
+reconciling it.
+
+- **Acceptance:** the recalc performs no forecast write; its skill-metric write and
+  failure return are unchanged; C2 evidence; no document left asserting the superseded
+  writer inventory.
 
 ### T4 — Record the decisions and close PP-045
 
-- **Goal:** the thing this plan is named for. T2 produces decisions; **without this phase
-  nothing writes them down**, and PP-045's live checklist still shows kyg and the
-  API-default flag as open. An earlier draft of this plan had no such phase — its stated
+- **Goal:** the thing this plan is named for. T2 produces decisions; the PP-060 contract
+  and the CSV deprecation are now recorded in §T2 and in PP-060 itself, but **the kyg and
+  API-default decisions still are not written anywhere**, and PP-045's live checklist
+  still shows both as open. An earlier draft of this plan had no such phase — its stated
   close-out goal was unreachable from its own dependency graph.
 - **Files:** `doc/plans/issues/review_gi_draft_pp_missed_boundary_period_gap.md`;
   `doc/plans/module_issues.md`.
@@ -457,9 +572,12 @@ Steps:
    the first draft of T3.1 and found only in review. Before implementing T3.1, grep
    `file_writer.py` for every `atomic_write_csv` call and check which are gated — do not
    assume the three known ones are all of them.
-9. **Option (a) can strand a new deployment.** If it lands before the seeding question is
-   answered, initialization completes with no combined-forecast CSV or API state and no
-   step that creates it. This risk is invisible on an existing deployment and appears
+9. **Option (a) *may* strand a new deployment — unverified, and the evidence now points
+   away from it.** The concern is that initialization completes with no combined-forecast
+   API state and no step that creates it. But the recalc reads ML rows from `forecasts`,
+   which a purged site does not have, and the writer drops LR rows, so its write may
+   already be a no-op on a fresh site (see the T2 consequences). Verify before treating
+   this as a blocker. If real, the risk is invisible on an existing deployment and appears
    only on the next fresh install — the worst place to discover it.
 10. **This plan has twice understated a change's blast radius** — first calling option (a)
     "the removal of one call", then covering only one of three shared CSVs. Both were
@@ -483,7 +601,8 @@ Prerequisites and conditionals not expressible in the graph:
   `["T0.1", "T0.2", "T0.3", "T2"]`. Simply deleting the T3.1 edges would leave T3.2 with
   no Tier-0 dependency at all and silently break C6. The JSON below is one named
   scenario, not a representation of both branches.
-- Option (b) requires PP-030 addressed or waived (C3).
+- Option (b) is not being implemented; its PP-030 prerequisite (C3) applies only if the
+  contract is ever revisited.
 
 ```json
 {

--- a/doc/plans/working/pp_period_write_consistency_plan.md
+++ b/doc/plans/working/pp_period_write_consistency_plan.md
@@ -3,12 +3,12 @@
 **Status:** Draft, not started. Subject to CLAUDE.md's mandatory out-of-loop review
 before any phase executes.
 
-**Base:** `origin/maxat_sapphire_2` @ `6e28647a` (PR #445 merged).
+**Base:** `origin/maxat_sapphire_2` @ `c9e91f83` (PR #448 merged).
 
-**C8's gate is CLOSED again.** The shared checkout was briefly clean when this plan was
-started; a parallel session has since dirtied `doc/plans/module_issues.md` and several issue
-files (six paths at the time of writing — do not rely on the count, re-check). Every phase that edits the registry (T0.2, T1.2, T4) is blocked until it is clean,
-and the id collision in §0a.4 must be settled first. This is residual risk 6 arriving
+**C8's gate is OPEN as of 2026-08-18** — the parallel session's work landed in PR #448
+and the checkout is clean, so T0.2, T1.2 and T4 are unblocked. The gate has opened and
+closed twice during this plan's life; **re-check immediately before writing a registry
+row** rather than trusting this line. The earlier closure was residual risk 6 arriving
 within the hour it was written.
 
 **Scope.** Close out PP-045 honestly, land the two follow-up tickets it owes, and
@@ -76,12 +76,14 @@ refutation of the cause; T0.1 must not repeat that.)
 4. **The write-divergence issue is PP-060 — an id collision, resolved by yielding.**
    It was filed as `PP-059` in PR #445 and merged to trunk without an index row (C8's
    gate was closed). A parallel session then allocated **PP-059 to a different issue**
-   ("Remove monthly EM") in an uncommitted registry row. Owner decision 2026-08-18:
+   ("Remove monthly EM"), **which has since landed in the registry via PR #448** — so the
+   collision is now settled fact, not a pending clash. Owner decision 2026-08-18:
    **this issue yields and becomes PP-060**; PP-059 stays with the parallel session's
    work. Renamed here across the issue file and this plan in one commit, so no
    intermediate state has the two documents disagreeing. `PP-060` was free on trunk and
-   in the dirty working copy at the time — **re-verify before T0.2 writes the row**,
-   since the parallel session is still in flight.
+   in the working copy at the time, and remains free and unindexed on trunk `c9e91f83`
+   after PR #448 landed the parallel session's rows — **still re-verify before T0.2
+   writes the row.**
 
 ### 0b. Owed but never written
 
@@ -90,15 +92,24 @@ refutation of the cause; T0.1 must not repeat that.)
    an **existing** one, so the defect manifests today. May justify re-rating.
 6. **Detect-and-report ticket.** No such file exists under `doc/plans/issues/`.
 
-### 0c. Owner decisions — one settled, the rest open
+### 0c. Owner decisions (the four T2 gates) — three settled 2026-08-18, one open
 
-7. The **kyg criterion** (PP-045's last acceptance item).
-8. ~~**PP-060's contract**~~ — **DECIDED 2026-08-18: option (a)** (§4 T2).
-9. PP-045's carried **API-only-by-default** flag.
+7. **The kyg criterion** (PP-045's last acceptance item) — **still OPEN.** The only
+   unsettled T2 gate.
+8. ~~**PP-060's contract**~~ — **DECIDED: option (a)** (§4 T2.1).
+9. ~~**The dashboard `write_csv` carve-out**~~ — **DECIDED: carve it out**; T3.1 runs as
+   its own change (§4 T2.2).
+10. ~~**PP-045's carried API-only-by-default flag**~~ — **DECIDED: confirmed**, CSV
+    writing stays off by default (§4 T2.4).
+
+**Open items outside these four gates**, so that "only kyg is open" is not misread as
+"nothing else needs a decision": **C9** (whether the dashboard's swallowed failures
+should now surface) is an explicit product choice, and **PP-060's priority** is still
+marked owner-to-confirm.
 
 ### 0d. Housekeeping
 
-10. Seven scratchpad worktrees and seven merged branches from this sequence remain. A
+11. Seven scratchpad worktrees and seven merged branches from this sequence remain. A
     prior cleanup attempt was declined; not re-attempted here without an explicit ask.
 
 ---
@@ -171,9 +182,9 @@ is a colleague-managed schema change and needs its own discussion. No migration 
 plan.
 
 **C8 — `module_issues.md` is edited once per phase that needs it, on a clean tree,
-re-reading the file to allocate ids.** **The gate is currently CLOSED** — see the Base
-note. Three phases (T0.2, T1.2, T4) wait on it, and the id collision in §0a.4 must be
-settled before any of them writes a row.
+re-reading the file to allocate ids.** **The gate is OPEN as of 2026-08-18** (PR #448
+landed; checkout clean), and the §0a.4 id collision is settled. It has opened and closed
+twice already, so T0.2, T1.2 and T4 must each re-check rather than trust this line.
 
 **C9 — The dashboard change alters failure visibility.** The scoped recalc's failures
 are currently swallowed as non-fatal, and the container runner prints rather than raises.
@@ -315,10 +326,9 @@ latter is not the PP-045 signature.
 > The two are linked: with CSV writing going away, the recalc's only remaining *forecast*
 > side effect is the API forecast write, so removing it is a far smaller conceptual
 > change than when it also owned two CSV artefacts. (It still writes skill metrics to the
-> API — that is its job and is untouched.) **Decision 1 is settled; 2, 3 and 4 remain
-> open** — 2 has changed from a design question to a scheduling one, because option (a)
-> does not by itself retire the dashboard CSV problem. See "Consequences of the decision"
-> after the list.
+> API — that is its job and is untouched.) **Decisions 1, 2 and 4 are settled as of
+> 2026-08-18; only 3 — the kyg criterion — remains open.** See "Consequences of the
+> decision" after the list.
 
 1. **PP-060 contract — DECIDED: (a)**, the recalc stops writing period forecasts.
    Option (b) (write the same row set as operational) is **not** being pursued, which
@@ -347,16 +357,23 @@ latter is not the PP-045 signature.
      CLI docstring, and the review-checklist template all state that the recalc writes
      period rows. Option (a) invalidates each — including text T0.3 would have just
      written.
-2. **Whether the dashboard `write_csv` fix is carved out** — **still open, and now a
-   scheduling question.** See "T3.1's status" below: option (a) does not by itself retire
-   it, because the scoped `save_skill_metrics` CSV overwrite survives option (a).
+2. **Whether the dashboard `write_csv` fix is carved out** — **DECIDED 2026-08-18:
+   yes, carve it out.** T3.1 runs as its own change rather than waiting for the CSV
+   deprecation to absorb it. The §6 dependency graph's default scenario therefore holds
+   as written and needs no re-derivation. Scope per "T3.1's status" below: permanently
+   the `save_skill_metrics` CSV, plus the combined CSVs on an interim basis until T3.2
+   removes that call.
 3. **The kyg criterion** — run the full kyg pipeline when available, or waive in writing.
-4. **PP-045's API-only-by-default flag** — confirm or override.
+4. **PP-045's API-only-by-default flag** — **DECIDED 2026-08-18: confirmed.** The
+   backfill CLI keeps `--write-csv` off by default. Consistent with the CSV deprecation,
+   and it means the flag needs no change now; it retires with the CSVs themselves.
 
-**Gating, stated once so the graph and prose agree:** T3.2 is gated on **decision 1**,
-which is settled. T3.1 is gated on **decision 2**, which is open. In §6's default
-scenario T3.1 also precedes T3.2 and T4 — if decision 2 drops T3.1, re-parent per §6
-rather than leaving T3.2 without its Tier-0 chain.
+**Gating, stated once so the graph and prose agree:** T3.2 is gated on **decision 1**
+and T3.1 on **decision 2** — both settled 2026-08-18, so Tier 3's *owner-decision* gates
+are cleared. It is **not** otherwise unblocked: C6 still requires all of Tier 0 to land
+first, which the graph encodes. T3.1 runs,
+so §6's default scenario applies as written and the re-derivation note there is now
+hypothetical.
 
 ### Consequences of the 2026-08-18 decision
 
@@ -377,10 +394,11 @@ recalc rewriting shared CSVs, and there are two:
   single station's data.
 
 T3.1 is therefore superseded only once the CSV deprecation removes the skill-metric CSV
-write. Until then it is a live defect. The owner's remaining choice (T2.2) is scheduling:
-- if the deprecation will remove that write soon, **drop T3.1** and let it absorb the fix;
-- otherwise **keep T3.1, scoped to `save_skill_metrics` only** — option (a) handles the rest.
-Record whichever is chosen; the dependency graph assumes T3.1 runs, and §6 says how to
+write. Until then it is a live defect. **DECIDED 2026-08-18 (T2.2): carve it out** — T3.1
+runs as its own change, scoped permanently to `save_skill_metrics` (option (a) handles
+the combined CSVs via T3.2). The alternative, letting the deprecation absorb it, was
+declined. The dependency graph's default scenario therefore applies as written; §6's
+re-derivation note is now hypothetical and says how to
 re-derive it if not.
 
 **The seeding concern is WEAKER than an earlier draft claimed — verify it before acting
@@ -415,7 +433,9 @@ discovered much later:
    *before* starting the API, so the restarted API is backed by the empty database it is
    meant to refill. This path needs a pre-reset export, a backup/restore, or a
    regeneration step. Left as is: a stale file repopulates stale rows; an absent file is
-   warned about and skipped, leaving the table empty and the migrator exiting zero.
+   warned about and skipped, leaving the **combined period rows** empty and the migrator
+   exiting zero. (Not the whole `forecasts` table — the reset also runs
+   `--type forecast`, which can populate DAY rows.)
 These belong to the deprecation effort, not to PP-060; record them wherever that work is
 tracked. They are noted in `CLAUDE.md` § Data I/O Transition.
 
@@ -518,10 +538,10 @@ reconciling it.
 
 ### T4 — Record the decisions and close PP-045
 
-- **Goal:** the thing this plan is named for. T2 produces decisions; the PP-060 contract
-  and the CSV deprecation are now recorded in §T2 and in PP-060 itself, but **the kyg and
-  API-default decisions still are not written anywhere**, and PP-045's live checklist
-  still shows both as open. An earlier draft of this plan had no such phase — its stated
+- **Goal:** the thing this plan is named for. Three of T2's four decisions — the PP-060
+  contract, the dashboard carve-out and the API-only default — are now recorded in §T2,
+  in PP-060, and (for the API default) in PP-045's §G checklist. **The kyg decision is
+  the one still unwritten**, because it is the one still unmade. An earlier draft of this plan had no such phase — its stated
   close-out goal was unreachable from its own dependency graph.
 - **Files:** `doc/plans/issues/review_gi_draft_pp_missed_boundary_period_gap.md`;
   `doc/plans/module_issues.md`.
@@ -532,9 +552,11 @@ reconciling it.
 Steps:
 
 1. Record the **kyg** decision in §G — run, waived, or downgraded — with the rationale
-   and the decider named.
-2. Record the **API-only-by-default** decision.
-3. Record PP-060's contract decision and its effect on §H's matrix.
+   and the decider named. **This is the only T2 decision still unrecorded, because it is
+   the only one still unmade.**
+2. ~~Record the API-only-by-default decision~~ — already done: PP-045 §G, 2026-08-18.
+3. Record PP-060's contract decision (option (a)) and its effect on §H's matrix —
+   recorded in PP-060 and this plan; §H's matrix still needs the update.
 4. Propose the status transition and the `review_gi_draft_*` → archive move.
    **Do not execute without approval** (owner-owned, per the preceding plan's C2).
 5. Final `module_issues.md` pass so the PP-045 row matches the issue's Status.
@@ -595,8 +617,9 @@ Prerequisites and conditionals not expressible in the graph:
 - **T0.2, T1.2 and T4 all edit `module_issues.md`** and therefore require a clean tree
   (C8) *and* must not run concurrently with each other. The graph serialises them; the
   C8 gate is an external condition it cannot express.
-- **T3.1 is conditional, and the graph encodes only the case where it runs.** If the
-  owner declines the dashboard carve-out (T2.2), **re-derive the graph**: drop T3.1, and
+- **T3.1 runs** (T2.2, decided 2026-08-18), so the graph below applies as written. The
+  following is retained only against a future reversal: if T3.1 were ever dropped,
+  **re-derive the graph** —
   **re-parent its Tier-0 dependencies onto T3.2 and T4** — that is, T3.2 becomes
   `["T0.1", "T0.2", "T0.3", "T2"]`. Simply deleting the T3.1 edges would leave T3.2 with
   no Tier-0 dependency at all and silently break C6. The JSON below is one named


### PR DESCRIPTION
Docs only. Two things.

## A commit was stranded — worth knowing about

The CSV-deprecation note and the option-(a) record were pushed to **#446's branch minutes after that PR merged**. #446 went in with two of its three commits; the third never landed. So `CLAUDE.md` never got the deprecation note and PP-060 never got its decision recorded, even though both looked committed.

Recovered here by cherry-pick. `git range-diff` and a matching patch id confirm the content is byte-identical to what was lost.

## Decisions recorded

**Dashboard `write_csv` fix — carved out.** T3.1 runs as its own change rather than waiting for the CSV deprecation to absorb it. Scoped permanently to `save_skill_metrics`, whose CSV write is unconditional and survives option (a); the combined CSVs leave via T3.2. The dependency graph's default scenario applies as written, no re-derivation.

**API-only-by-default — confirmed.** The backfill CLI keeps CSV writing off by default. This had been carried open since 2026-07-23. It's now consistent with the deprecation, and it retires with the CSVs rather than needing a change of its own.

**Kyg is the only unsettled T2 gate.** §0c says so without implying nothing else needs deciding — **C9** (should the dashboard's swallowed failures surface?) and **PP-060's priority** are called out as separate open choices.

## Destaled against #448

That PR landed while this was in flight and changed the facts: PP-056 and PP-059 are now indexed, and **PP-059 is formally "Remove monthly EM"** — which vindicates the earlier rename to PP-060, still free and unindexed. **C8's registry gate is OPEN again** with a clean tree, so T0.2/T1.2/T4 are unblocked. That gate has opened and closed twice during this plan's life, so every phase that writes a row is now told to re-check rather than trust the line.

## Review

Four out-of-loop `codex exec` passes. They caught the decisions being recorded in some places and not their twins, "Tier 3 is unblocked" overclaiming past C6's Tier-0 requirement, and "leaves the table empty" being too broad — the reset also runs `--type forecast`, so it's the combined *period* rows that stay empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)