### PR TITLE
docs: rescue PREPG-007 remediation preconditions (with stale reference corrected)

### DIFF
--- a/doc/plans/issues/review_gi_draft_prepg_snow_population_self_heal.md
+++ b/doc/plans/issues/review_gi_draft_prepg_snow_population_self_heal.md
@@ -299,6 +299,33 @@ No implementation agent required. Operator/orchestrator action after deploy.
 
 Scope:
 
+> **Preconditions (learned during local validation 2026-06-26; rescued to trunk 2026-08-20).**
+>
+> - **The archive must be fully loaded first.** Run the snow recalc only after the full historical
+>   snow archive is present in the DB — **not** merely after the 365-day maintenance sync, which
+>   loads only the recent window. Recalc against a partially-loaded archive yields starved
+>   per-day-of-year climatology counts and missing or seamed bands. Observed: HS/SWE early-January
+>   `count` of **2-5 instead of the full ~26**. Verify completeness first, e.g.
+>
+>   ```sql
+>   SELECT snow_type, count(DISTINCT EXTRACT(YEAR FROM date))
+>   FROM snow
+>   WHERE value IS NOT NULL AND EXTRACT(DOY FROM date) BETWEEN 1 AND 10
+>   GROUP BY snow_type;
+>   ```
+>
+> - **The pagination precondition is now SATISFIED — no longer a blocker.** The recalc's climatology
+>   read paginates `get_snow()`, which used to be nondeterministic without a stable sort, so bands
+>   could flicker or come back incomplete regardless of archive completeness. **`crud.get_snow()` now
+>   orders by `(snow_type, code, date, id)`** — a stable sort with a unique tiebreaker — so this no
+>   longer gates the remediation. Re-verify it is present in the **target environment** before
+>   running, since the fix lives in `sapphire/services/preprocessing` and deploys on its own cadence.
+>
+>   *Reference correction:* the original note called this dependency "PREPG-009". **That ID now
+>   belongs to a different issue** (gateway reports PASS with all six snow tasks errored). The
+>   pagination issue was drafted but never merged, and its fix shipped anyway — do not go looking
+>   for it under that number.
+
 - Before remediation, take a database backup: snow-table `pg_dump` or a volume snapshot.
 - Before remediation, capture a SQL count snapshot for each `snow_type` over
   `2025-09-01 ... 2026-08-31`, counting non-null `value`, `current`, `norm`, `previous`, `q50`, and


### PR DESCRIPTION
Rescues the PREPG-007 remediation preconditions from the unmerged
`prepg-007-snow-population` branch, where they have sat since 2026-06-26. Docs only.

**P3 has never been run**, so these are live guidance, not history.

## What's rescued

**The archive must be fully loaded before the snow recalc** — not merely the 365-day maintenance
sync, which loads only the recent window. Recalc against a partial archive starves the
per-day-of-year climatology (observed: HS/SWE early-January `count` of **2–5** against a full
**~26**) and produces missing or seamed bands. The verification SQL is included, because the
symptom looks like a recalc bug rather than a precondition violation.

## What's corrected rather than copied

The second precondition **inverted while it sat on the branch**. It said band correctness was
*blocked* on a stable `ORDER BY` in `crud.get_snow()`. That is now on trunk —
`order_by(Snow.snow_type, Snow.code, Snow.date, Snow.id)`, with a unique tiebreaker — so the
dependency is **satisfied**, not outstanding. Kept as a re-verify-in-the-target-environment step,
since the fix lives in `sapphire/services/preprocessing` and deploys on its own cadence.

**Reference correction:** the original called that dependency **"PREPG-009"**, and that ID now
belongs to a different issue entirely (gateway reports PASS with all six snow tasks errored). The
pagination issue was drafted, never merged, and its fix shipped anyway — so anyone following the
old reference lands on an unrelated issue. Saying so explicitly is cheaper than letting the next
person re-derive it.

## Context on the source branch

Checked while assessing whether PREPG-007 is still current:

- **Its implementation is on trunk and matches the issue** — `dg_utils.py:941`/`:1015` carry the
  365-day maintenance window (Change B). PREPG-007 is genuinely just awaiting review.
- The branch also held a 307-line **High-priority** draft, "Snow climatology API pagination
  nondeterminism", which is now **obsolete** — the service-side `ORDER BY` it asked for is exactly
  what shipped. Not rescued, deliberately.

With this merged, `prepg-007-snow-population` holds nothing of value and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
