### PR TITLE
Add an operator-invoked recovery path for one missed long-term month

### DIFF
--- a/apps/long_term_forecasting/lt_recovery.py
+++ b/apps/long_term_forecasting/lt_recovery.py
@@ -18,6 +18,20 @@ Acceptance is defined on DATABASE rows only. ``run_forecast.py --today`` also
 overwrites ``{model}_forecast.csv`` and rewrites the hindcast CSV; that is an
 accepted side effect of the recovery, deliberately not guarded here.
 
+Limitation: the guard is not a lock
+-----------------------------------
+The guard reads and the forecast writes as two separate steps, with the whole
+model run in between. A concurrent operational run, another recovery, or a
+manual writer that inserts rows for the same
+``(horizon_type, horizon_value, effective_date)`` during that window will be
+silently overwritten by this run's upsert, which updates every submitted field.
+Nothing here detects that; ``max_retries = 1`` on the Luigi task closes the
+*retry* bypass (a second attempt would skip the guard and overwrite the first
+attempt's rows) but not this one. So "never overwrites good data" holds only for
+rows that already existed when the guard ran. Run a recovery when no long-term
+forecast is in flight. Closing this properly needs a conditional insert or an
+advisory lock on the service side, which is out of scope for Stage A.
+
 Authoritative clock
 -------------------
 ``now_local()`` is the single clock used for the "not in the future" and
@@ -29,7 +43,9 @@ service sets no timezone, so this is the container's local time.
 """
 
 import calendar
+import math
 import os
+import re
 from collections.abc import Callable, Iterable
 from datetime import datetime
 from typing import Any
@@ -77,6 +93,9 @@ EXECUTION_WINDOW_DAYS = 5
 
 #: Page size for long-forecast reads.
 READ_PAGE_SIZE = 500
+
+#: Zero-padded ISO date, the only form the operator entry points accept.
+_ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 
 # ─────────────────────────────────────────────────────────────────
@@ -183,12 +202,14 @@ def parse_issue_date(value: Any) -> pd.Timestamp:
     text = "" if value is None else str(value).strip()
     if not text:
         raise RecoveryRefused("No issue date supplied. Expected ISO YYYY-MM-DD.")
+    # strptime alone would accept "2026-8-1". Require the zero-padded form so
+    # what the operator types is what the log, the marker and the guard show.
+    if not _ISO_DATE_RE.fullmatch(text):
+        raise RecoveryRefused(f"Issue date {text!r} is not zero-padded ISO (expected YYYY-MM-DD).")
     try:
         parsed = datetime.strptime(text, "%Y-%m-%d").date()
     except ValueError as exc:
-        raise RecoveryRefused(
-            f"Issue date {text!r} is not a valid ISO date (expected YYYY-MM-DD)."
-        ) from exc
+        raise RecoveryRefused(f"Issue date {text!r} is not a valid calendar date: {exc}.") from exc
     return pd.Timestamp(parsed)
 
 
@@ -353,6 +374,21 @@ def _row_flag(record: dict[str, Any]) -> int | None:
         return None
 
 
+def _is_usable_value(value: Any) -> bool:
+    """Return True only for a finite numeric discharge value.
+
+    NaN is not the only way a value can be unusable: a divide-by-zero upstream
+    can persist +/-inf, which is not a forecast anyone can act on and must not
+    let an empty recovery pass the read-back.
+    """
+    if value is None:
+        return False
+    try:
+        return math.isfinite(float(value))
+    except (TypeError, ValueError):
+        return False
+
+
 def _count_matching_rows(
     frame: pd.DataFrame,
     wanted_codes: set[str],
@@ -375,10 +411,8 @@ def _count_matching_rows(
             continue
         if flags is not None and _row_flag(record) not in flags:
             continue
-        if require_value:
-            value = record.get("q")
-            if value is None or pd.isna(value):
-                continue
+        if require_value and not _is_usable_value(record.get("q")):
+            continue
         matched += 1
     return matched
 
@@ -406,7 +440,8 @@ def count_member_rows(
         station_codes: Configured station codes; rows for other codes are
             ignored so the count stays organisation-scoped.
         flags: If given, only rows whose ``flag`` is in this set are counted.
-        require_value: If True, only rows with a non-null ``q`` are counted.
+        require_value: If True, only rows whose ``q`` is a finite number are
+            counted; null, NaN and +/-inf all fail.
         page_size: Rows requested per API call.
 
     Returns:

--- a/apps/long_term_forecasting/lt_recovery.py
+++ b/apps/long_term_forecasting/lt_recovery.py
@@ -1,0 +1,647 @@
+"""Guarded recovery of one missed long-term forecast month.
+
+Stage A of the "long-term missing-month recovery" issue: an operator names
+one forecast mode and one issue date, and this module performs
+
+    guard  ->  run  ->  read-back
+
+inside a *single* process, so the whole sequence sits behind one exit code.
+
+Why one process: the Luigi retry helper (``DockerTaskBase.execute_with_retries``
+in ``apps/pipeline/pipeline_docker.py``) creates the task's completion marker
+immediately after the child container exits 0. A check performed in the parent
+task would therefore run *after* the marker exists and could not veto a false
+success. The child container already joins ``sapphire_sapphire-network`` and so
+already has API access; the Luigi worker does not.
+
+Acceptance is defined on DATABASE rows only. ``run_forecast.py --today`` also
+overwrites ``{model}_forecast.csv`` and rewrites the hindcast CSV; that is an
+accepted side effect of the recovery, deliberately not guarded here.
+
+Authoritative clock
+-------------------
+``now_local()`` is the single clock used for the "not in the future" and
+"current or previous calendar month" checks. It is deliberately the same naive,
+process-local clock that ``lt_utils.check_valid_forecast_issue_date`` uses
+(``pd.Timestamp.now()``), because the two must agree: if they disagreed a run
+could be admitted here and then skipped or snapped there. The long-term Compose
+service sets no timezone, so this is the container's local time.
+"""
+
+import calendar
+import os
+from collections.abc import Callable, Iterable
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+from __init__ import SAPPHIRE_API_AVAILABLE, logger
+from config_forecast import ForecastConfig
+from lt_utils import map_model_name_to_model_type, nearest_scheduled_issue_date
+
+try:
+    from sapphire_api_client import SapphirePostprocessingClient
+except ImportError:  # pragma: no cover - exercised by the dependency-gated path
+    SapphirePostprocessingClient = None
+
+
+# ─────────────────────────────────────────────────────────────────
+# Constants
+# ─────────────────────────────────────────────────────────────────
+
+#: Exit code: recovery ran and rows were read back.
+EXIT_OK = 0
+#: Exit code: the forecast ran but could not be proven to have written rows.
+EXIT_FAILED = 1
+#: Exit code: refused before anything ran; the database was not touched.
+EXIT_REFUSED = 2
+
+#: Flag persisted on rows produced by a recovery run (see API-006).
+RECOVERY_FLAG = 1
+#: Flag persisted on rows whose value is missing / all-NaN.
+MISSING_VALUE_FLAG = 2
+#: Flag persisted on ordinary operational rows.
+OPERATIONAL_FLAG = 0
+
+#: Ensemble aggregates. They are derived from members by the postprocessing
+#: maintenance job, never produced by ``run_forecast.py``, so they are neither
+#: guarded on nor read back.
+AGGREGATE_MODEL_NAMES = frozenset({"em", "skilled mean", "naive mean"})
+
+#: Mirrors the +-5 day execution gate in ``lt_utils.check_valid_forecast_issue_date``.
+#: A member model whose scheduled issue date differs from the requested date by
+#: at most this much would be *snapped* to its own scheduled date while the
+#: guard checked the requested one — the exact mismatch this module refuses.
+#: (The scheduler admits modes up to 10 days out; see LTF-007.)
+EXECUTION_WINDOW_DAYS = 5
+
+#: Page size for long-forecast reads.
+READ_PAGE_SIZE = 500
+
+
+# ─────────────────────────────────────────────────────────────────
+# Errors
+# ─────────────────────────────────────────────────────────────────
+
+
+class RecoveryError(Exception):
+    """Base class for recovery failures."""
+
+
+class RecoveryRefused(RecoveryError):
+    """The recovery was refused; no forecast was run."""
+
+
+class RecoveryQueryError(RecoveryError):
+    """A long-forecast query failed. Always treated as fail-closed."""
+
+
+# ─────────────────────────────────────────────────────────────────
+# Clock
+# ─────────────────────────────────────────────────────────────────
+
+
+def now_local() -> pd.Timestamp:
+    """Return the authoritative clock for recovery-window checks.
+
+    Naive, process-local, date-only — deliberately identical to the clock
+    ``lt_utils.check_valid_forecast_issue_date`` compares against.
+
+    Returns:
+        Today's date as a normalized ``pd.Timestamp``.
+    """
+    return pd.Timestamp.now().normalize()
+
+
+# ─────────────────────────────────────────────────────────────────
+# Members
+# ─────────────────────────────────────────────────────────────────
+
+
+def _normalize_model_name(name: Any) -> str:
+    return str(name).strip().lower().replace("_", " ")
+
+
+def member_model_names(forecast_config: Any) -> list[str]:
+    """Return the configured raw member models for a mode.
+
+    Members are the models ``run_forecast.py`` actually runs. Ensemble
+    aggregates (``EM`` / ``Skilled Mean`` / ``Naive Mean``) are excluded.
+
+    Args:
+        forecast_config: A loaded ``ForecastConfig`` (or equivalent).
+
+    Returns:
+        List of internal model names, in configuration order.
+    """
+    return [
+        name
+        for name in forecast_config.get_models_to_run()
+        if _normalize_model_name(name) not in AGGREGATE_MODEL_NAMES
+    ]
+
+
+def member_model_types(forecast_config: Any) -> list[str]:
+    """Return the API ``model_type`` values for a mode's member models.
+
+    Mapped exactly the way the writer maps them
+    (``lt_utils.map_model_name_to_model_type``), de-duplicated, order preserved.
+
+    Args:
+        forecast_config: A loaded ``ForecastConfig`` (or equivalent).
+
+    Returns:
+        List of API model_type strings.
+    """
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for name in member_model_names(forecast_config):
+        model_type = map_model_name_to_model_type(name)
+        if model_type not in seen:
+            seen.add(model_type)
+            ordered.append(model_type)
+    return ordered
+
+
+# ─────────────────────────────────────────────────────────────────
+# Validation
+# ─────────────────────────────────────────────────────────────────
+
+
+def parse_issue_date(value: Any) -> pd.Timestamp:
+    """Parse an operator-supplied ISO issue date.
+
+    Args:
+        value: Date string in strict ``YYYY-MM-DD`` form.
+
+    Returns:
+        The parsed date as a normalized ``pd.Timestamp``.
+
+    Raises:
+        RecoveryRefused: If the value is missing or not strict ISO.
+    """
+    text = "" if value is None else str(value).strip()
+    if not text:
+        raise RecoveryRefused("No issue date supplied. Expected ISO YYYY-MM-DD.")
+    try:
+        parsed = datetime.strptime(text, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise RecoveryRefused(
+            f"Issue date {text!r} is not a valid ISO date (expected YYYY-MM-DD)."
+        ) from exc
+    return pd.Timestamp(parsed)
+
+
+def _month_key(timestamp: pd.Timestamp) -> tuple[int, int]:
+    return (int(timestamp.year), int(timestamp.month))
+
+
+def _previous_month_key(timestamp: pd.Timestamp) -> tuple[int, int]:
+    if timestamp.month == 1:
+        return (int(timestamp.year) - 1, 12)
+    return (int(timestamp.year), int(timestamp.month) - 1)
+
+
+def check_recovery_window(effective_date: pd.Timestamp, now: pd.Timestamp) -> None:
+    """Refuse dates outside the current or previous calendar month.
+
+    Recent-gap recovery only: anything older belongs to the historical
+    backfill tooling, and a future date can never have observations behind it.
+
+    Args:
+        effective_date: The requested issue date.
+        now: The authoritative clock (see :func:`now_local`).
+
+    Raises:
+        RecoveryRefused: If the date is in the future or too old.
+    """
+    if effective_date > now:
+        raise RecoveryRefused(
+            f"Issue date {effective_date.date()} is in the future "
+            f"(clock says {now.date()}). Refusing."
+        )
+    allowed = {_month_key(now), _previous_month_key(now)}
+    if _month_key(effective_date) not in allowed:
+        allowed_text = ", ".join(f"{y:04d}-{m:02d}" for y, m in sorted(allowed))
+        raise RecoveryRefused(
+            f"Issue date {effective_date.date()} is outside the recovery window. "
+            f"Only the current and previous calendar month are recoverable "
+            f"({allowed_text}). Use the historical backfill tooling for older gaps."
+        )
+
+
+def resolve_scheduled_models(forecast_config: Any, effective_date: pd.Timestamp) -> list[str]:
+    """Require the requested date to *be* the scheduled issue date.
+
+    ``run_forecast.py`` silently snaps a late ``--today`` back to the model's
+    scheduled issue date while persistence writes the frame's date. That
+    mismatch is exactly what the no-overwrite guard must not fall through, so
+    near misses are refused rather than snapped.
+
+    Args:
+        forecast_config: A loaded ``ForecastConfig`` (or equivalent).
+        effective_date: The requested issue date.
+
+    Returns:
+        The member models that are scheduled precisely on ``effective_date``.
+
+    Raises:
+        RecoveryRefused: If any member would be snapped, or if no member is
+            scheduled on that date at all.
+    """
+    issue_day = forecast_config.get_operational_issue_day()
+    days_in_month = calendar.monthrange(effective_date.year, effective_date.month)[1]
+    expected_day = min(int(issue_day), days_in_month)
+
+    scheduled: list[str] = []
+    for model_name in member_model_names(forecast_config):
+        months = forecast_config.get_forecast_months(model_name=model_name)
+        model_issue_date = nearest_scheduled_issue_date(effective_date, issue_day, months)
+        day_offset = (effective_date - model_issue_date).days
+        if day_offset == 0:
+            scheduled.append(model_name)
+        elif abs(day_offset) <= EXECUTION_WINDOW_DAYS:
+            raise RecoveryRefused(
+                f"Issue date {effective_date.date()} is {abs(day_offset)} day(s) off the "
+                f"scheduled issue date {model_issue_date.date()} for member model "
+                f"{model_name}. The forecast run would snap to "
+                f"{model_issue_date.date()} while the guard checked "
+                f"{effective_date.date()}. Re-run with "
+                f"{model_issue_date.date()} instead."
+            )
+
+    if not scheduled:
+        raise RecoveryRefused(
+            f"Issue date {effective_date.date()} is not a scheduled issue date for any "
+            f"member model of this mode. Expected day-of-month {expected_day} "
+            f"(operational_issue_day={issue_day}) in a month the models forecast for."
+        )
+    return scheduled
+
+
+def check_station_codes(station_codes: Iterable[Any] | None) -> list[str]:
+    """Refuse an empty station list before any query is issued.
+
+    An empty list disables organisation scoping in ``DataInterfaceDB`` and in
+    the guard query alike, which would read (and count) the whole database.
+
+    Args:
+        station_codes: Configured station codes.
+
+    Returns:
+        The codes as non-empty strings.
+
+    Raises:
+        RecoveryRefused: If no usable code is present.
+    """
+    codes = [str(code).strip() for code in (station_codes or []) if str(code).strip()]
+    if not codes:
+        raise RecoveryRefused(
+            "Station list is empty. An empty list disables organisation scoping and "
+            "would read the whole database, so the guard cannot be trusted. Check "
+            "ieasyforecast_config_file_station_selection."
+        )
+    return codes
+
+
+# ─────────────────────────────────────────────────────────────────
+# Database access
+# ─────────────────────────────────────────────────────────────────
+
+
+def build_postprocessing_client() -> Any:
+    """Build a postprocessing API client, failing closed.
+
+    Returns:
+        A ready ``SapphirePostprocessingClient``.
+
+    Raises:
+        RecoveryQueryError: If the client is unavailable, writing is disabled,
+            or the API is not ready. Any of these means the guard and the
+            read-back cannot be trusted.
+    """
+    if not SAPPHIRE_API_AVAILABLE or SapphirePostprocessingClient is None:
+        raise RecoveryQueryError(
+            "sapphire-api-client is not installed. Recovery is defined on database "
+            "rows only and cannot be verified without it."
+        )
+    if os.getenv("SAPPHIRE_API_ENABLED", "true").lower() != "true":
+        raise RecoveryQueryError(
+            "SAPPHIRE_API_ENABLED is false, so the run would write no database rows. "
+            "Recovery is defined on database rows only."
+        )
+    api_url = os.getenv("SAPPHIRE_API_URL", "http://localhost:8000")
+    client = SapphirePostprocessingClient(base_url=api_url)
+    try:
+        ready = client.readiness_check()
+    except Exception as exc:
+        raise RecoveryQueryError(f"SAPPHIRE API at {api_url} is unreachable: {exc}") from exc
+    if not ready:
+        raise RecoveryQueryError(f"SAPPHIRE API at {api_url} is not ready.")
+    return client
+
+
+def _row_flag(record: dict[str, Any]) -> int | None:
+    raw = record.get("flag")
+    if raw is None:
+        return None
+    try:
+        if pd.isna(raw):
+            return None
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _count_matching_rows(
+    frame: pd.DataFrame,
+    wanted_codes: set[str],
+    date_text: str,
+    flags: set[int] | None,
+    require_value: bool,
+) -> int:
+    target_date = pd.Timestamp(date_text)
+    matched = 0
+    for record in frame.to_dict("records"):
+        if str(record.get("code")) not in wanted_codes:
+            continue
+        raw_date = record.get("date")
+        if raw_date is None:
+            continue
+        try:
+            if pd.Timestamp(raw_date).normalize() != target_date:
+                continue
+        except (TypeError, ValueError):
+            continue
+        if flags is not None and _row_flag(record) not in flags:
+            continue
+        if require_value:
+            value = record.get("q")
+            if value is None or pd.isna(value):
+                continue
+        matched += 1
+    return matched
+
+
+def count_member_rows(
+    client: Any,
+    *,
+    horizon_type: str,
+    horizon_value: int,
+    effective_date: pd.Timestamp,
+    model_types: list[str],
+    station_codes: list[str],
+    flags: set[int] | None = None,
+    require_value: bool = False,
+    page_size: int = READ_PAGE_SIZE,
+) -> int:
+    """Count member rows for one ``(horizon_type, horizon_value, date)`` key.
+
+    Args:
+        client: Postprocessing API client.
+        horizon_type: Horizon type of the mode ("month", "quarter", "season").
+        horizon_value: Lead time of the mode.
+        effective_date: The forecast issue date.
+        model_types: API model_type values of the member models.
+        station_codes: Configured station codes; rows for other codes are
+            ignored so the count stays organisation-scoped.
+        flags: If given, only rows whose ``flag`` is in this set are counted.
+        require_value: If True, only rows with a non-null ``q`` are counted.
+        page_size: Rows requested per API call.
+
+    Returns:
+        Number of matching rows.
+
+    Raises:
+        RecoveryQueryError: If any query fails. The caller fails closed.
+    """
+    wanted_codes = {str(code) for code in station_codes}
+    date_text = effective_date.strftime("%Y-%m-%d")
+    total = 0
+
+    for model_type in model_types:
+        skip = 0
+        while True:
+            try:
+                frame = client.read_long_term_forecasts(
+                    horizon_type=horizon_type,
+                    horizon_value=horizon_value,
+                    model=model_type,
+                    start_date=date_text,
+                    end_date=date_text,
+                    skip=skip,
+                    limit=page_size,
+                )
+            except Exception as exc:
+                raise RecoveryQueryError(
+                    f"Long-forecast query failed for model {model_type} on {date_text}: {exc}"
+                ) from exc
+
+            if frame is None or len(frame) == 0:
+                break
+            total += _count_matching_rows(frame, wanted_codes, date_text, flags, require_value)
+            if len(frame) < page_size:
+                break
+            skip += page_size
+
+    return total
+
+
+# ─────────────────────────────────────────────────────────────────
+# Flag override
+# ─────────────────────────────────────────────────────────────────
+
+
+def apply_success_flag(
+    forecast: pd.DataFrame, main_q_col: str, recovery_flag: int | None = None
+) -> pd.DataFrame:
+    """Set the ``flag`` column on a forecast frame.
+
+    Rows whose main Q value is NaN always get :data:`MISSING_VALUE_FLAG` — a
+    recovery must never dress a missing value up as a recovered one. Rows with
+    a value get :data:`OPERATIONAL_FLAG` normally, or ``recovery_flag`` when a
+    recovery run supplies one.
+
+    Args:
+        forecast: Forecast frame; modified in place.
+        main_q_col: Name of the model's main Q column.
+        recovery_flag: Flag to persist on rows carrying a value, or None for
+            the ordinary operational value.
+
+    Returns:
+        The same frame, for convenience.
+    """
+    value_flag = OPERATIONAL_FLAG if recovery_flag is None else int(recovery_flag)
+    nan_mask = forecast[main_q_col].isna()
+    forecast.loc[nan_mask, "flag"] = MISSING_VALUE_FLAG
+    forecast.loc[~nan_mask, "flag"] = value_flag
+    return forecast
+
+
+# ─────────────────────────────────────────────────────────────────
+# Orchestration
+# ─────────────────────────────────────────────────────────────────
+
+
+def _default_config_factory(forecast_mode: str) -> ForecastConfig:
+    config = ForecastConfig()
+    config.load_forecast_config(forecast_mode=forecast_mode)
+    return config
+
+
+def run_recovery(
+    *,
+    issue_date: Any,
+    forecast_mode: str | None,
+    run_forecast_fn: Callable[..., Any],
+    station_codes_fn: Callable[[], Iterable[Any]],
+    config_factory: Callable[[str], Any] | None = None,
+    client_factory: Callable[[], Any] | None = None,
+    now: pd.Timestamp | None = None,
+) -> int:
+    """Guard, run and read back one dated long-term recovery.
+
+    The three stages are kept explicit because they carry different exit
+    codes: a refusal means the database was never touched, a failure means the
+    forecast ran but could not be proven to have written anything.
+
+    Args:
+        issue_date: Operator-supplied ISO date (``YYYY-MM-DD``).
+        forecast_mode: Long-term mode to recover (e.g. ``month_0``).
+        run_forecast_fn: The forecast entry point; called with
+            ``forecast_all=True``, ``models_to_run=[]``, ``forecast_mode`` and
+            ``recovery_flag``.
+        station_codes_fn: Callable returning the configured station codes.
+            Called after the configuration is loaded, so the environment is up.
+        config_factory: Builds a loaded ``ForecastConfig`` for a mode.
+        client_factory: Builds a postprocessing API client.
+        now: Override for the authoritative clock (tests only).
+
+    Returns:
+        :data:`EXIT_OK`, :data:`EXIT_FAILED` or :data:`EXIT_REFUSED`.
+    """
+    config_factory = config_factory or _default_config_factory
+    client_factory = client_factory or build_postprocessing_client
+    clock = now_local() if now is None else pd.Timestamp(now).normalize()
+
+    # ── Stage 1: validate and guard. Nothing has run yet. ───────────────
+    try:
+        mode = "" if forecast_mode is None else str(forecast_mode).strip()
+        if not mode:
+            raise RecoveryRefused("No forecast mode supplied. Set lt_forecast_mode (e.g. month_0).")
+
+        effective_date = parse_issue_date(issue_date)
+        check_recovery_window(effective_date, clock)
+
+        config = config_factory(mode)
+
+        model_types = member_model_types(config)
+        if not model_types:
+            raise RecoveryRefused(
+                f"Mode {mode} has no member models configured (only ensemble "
+                f"aggregates). There is nothing to recover."
+            )
+
+        scheduled_models = resolve_scheduled_models(config, effective_date)
+        station_codes = check_station_codes(station_codes_fn())
+
+        horizon_type = config.get_horizon_type()
+        horizon_value = config.get_operational_month_lead_time()
+
+        logger.info(
+            "Long-term recovery requested: mode=%s effective_date=%s "
+            "horizon=%s/%s members=%s scheduled=%s stations=%d",
+            mode,
+            effective_date.date(),
+            horizon_type,
+            horizon_value,
+            model_types,
+            scheduled_models,
+            len(station_codes),
+        )
+
+        client = client_factory()
+
+        pre_count = count_member_rows(
+            client,
+            horizon_type=horizon_type,
+            horizon_value=horizon_value,
+            effective_date=effective_date,
+            model_types=model_types,
+            station_codes=station_codes,
+        )
+        if pre_count > 0:
+            raise RecoveryRefused(
+                f"{pre_count} member row(s) already exist for "
+                f"({horizon_type}, {horizon_value}, {effective_date.date()}). "
+                f"A recovery overwrites every submitted field, so a partially "
+                f"populated month is refused as a whole. Delete the existing rows "
+                f"first if you really intend to regenerate them."
+            )
+        logger.info(
+            "Guard passed: no member rows exist for (%s, %s, %s).",
+            horizon_type,
+            horizon_value,
+            effective_date.date(),
+        )
+    except RecoveryError as exc:
+        logger.error("Long-term recovery REFUSED (nothing was run): %s", exc)
+        return EXIT_REFUSED
+    except Exception as exc:
+        logger.exception("Long-term recovery REFUSED (nothing was run): %s", exc)
+        return EXIT_REFUSED
+
+    # ── Stage 2: run the forecast for the dated issue. ──────────────────
+    try:
+        run_forecast_fn(
+            forecast_all=True,
+            models_to_run=[],
+            forecast_mode=mode,
+            recovery_flag=RECOVERY_FLAG,
+        )
+    except Exception as exc:
+        logger.exception("Long-term recovery FAILED while running the forecast: %s", exc)
+        return EXIT_FAILED
+
+    # ── Stage 3: read back. Exit 0 alone proves nothing. ────────────────
+    try:
+        post_count = count_member_rows(
+            client,
+            horizon_type=horizon_type,
+            horizon_value=horizon_value,
+            effective_date=effective_date,
+            model_types=model_types,
+            station_codes=station_codes,
+            flags={RECOVERY_FLAG},
+            require_value=True,
+        )
+    except Exception as exc:
+        logger.exception(
+            "Long-term recovery FAILED: read-back query failed, failing closed: %s", exc
+        )
+        return EXIT_FAILED
+
+    if post_count <= 0:
+        logger.error(
+            "Long-term recovery FAILED: no member row with flag=%d and a usable value "
+            "was written for (%s, %s, %s). Rows flagged %d (missing/all-NaN) do not "
+            "count. Nothing was recovered.",
+            RECOVERY_FLAG,
+            horizon_type,
+            horizon_value,
+            effective_date.date(),
+            MISSING_VALUE_FLAG,
+        )
+        return EXIT_FAILED
+
+    logger.info(
+        "Long-term recovery SUCCEEDED: %d member row(s) with flag=%d read back for "
+        "(%s, %s, %s). Success criterion is PARTIAL — some rows written, not full "
+        "station x model coverage.",
+        post_count,
+        RECOVERY_FLAG,
+        horizon_type,
+        horizon_value,
+        effective_date.date(),
+    )
+    return EXIT_OK

--- a/apps/long_term_forecasting/run_forecast.py
+++ b/apps/long_term_forecasting/run_forecast.py
@@ -32,6 +32,7 @@ from config_forecast import ForecastConfig
 from data_interface import BasePredictorDataInterface, DataInterface, DataInterfaceDB
 
 # Import forecast models
+from lt_recovery import apply_success_flag
 from lt_utils import (
     check_valid_forecast_issue_date,
     create_model_instance,
@@ -216,9 +217,15 @@ def run_single_model(
     offset_base: int,
     offset_discharge: int,
     station_codes: list[str] | None = None,
+    recovery_flag: int | None = None,
 ) -> dict[str, Any]:
     """
     Run a single forecast model and return the results.
+
+    Args:
+        recovery_flag: When set, rows carrying a value are persisted with this
+            flag instead of 0. Used by the dated recovery path to mark
+            regenerated rows. Rows with a missing/NaN value keep flag 2.
     """
 
     # Load configurations
@@ -327,11 +334,9 @@ def run_single_model(
         else:
             logger.warning(f"Unknown data dependency type: {input_type}")
 
-
     logger.info(
         f"Head of temporal data after processing dependencies for model {model_name}:\n{temporal_data.head()}"
     )
-
 
     today = check_valid_forecast_issue_date(
         forecast_configs=forecast_configs, model_name=model_name
@@ -361,6 +366,7 @@ def run_single_model(
         forecast = forecast.round(2)
 
         # where Q_model_name is Nan, set flag to 2, else 0 (0 = forecast produced, 2 = no forecast produced, missing data)
+        # A recovery run overrides the "produced" value only (see lt_recovery).
         main_q_col = f"Q_{model_name}"
         if main_q_col not in forecast.columns:
             logger.error(
@@ -369,9 +375,7 @@ def run_single_model(
             forecast["flag"] = 2
             success = False
         else:
-            nan_mask = forecast[main_q_col].isna()
-            forecast.loc[nan_mask, "flag"] = 2  # no forecast produced,
-            forecast.loc[~nan_mask, "flag"] = 0  # forecast produced
+            forecast = apply_success_flag(forecast, main_q_col, recovery_flag)
             success = True
 
         # Add climatological quantile bounds for GBT-family models (monthly mode)
@@ -430,6 +434,7 @@ def run_forecast(
     forecast_all: bool = True,
     models_to_run: list[str] | None = None,
     forecast_mode: str = None,
+    recovery_flag: int | None = None,
 ):
     # Setup Environment
     sl.load_environment()
@@ -505,6 +510,7 @@ def run_forecast(
                 offset_base=offset_base,
                 offset_discharge=offset_discharge,
                 station_codes=station_codes,
+                recovery_flag=recovery_flag,
             )
             execution_is_success[model_name] = sucess
         except Exception as e:
@@ -556,6 +562,18 @@ Examples:
         help='Override the "today" date for the forecast in YYYY-MM-DD format (useful for testing or backtesting)',
     )
 
+    parser.add_argument(
+        "--recover",
+        action="store_true",
+        help=(
+            "Operator-invoked recovery of ONE missed long-term month. Requires "
+            "--today. Refuses if any member row already exists for that issue "
+            "date, marks regenerated rows with flag=1, and reads the rows back "
+            "from the database before reporting success. Exit codes: 0 success, "
+            "1 ran but nothing proven written, 2 refused (nothing was run)."
+        ),
+    )
+
     args = parser.parse_args()
 
     # Determine recalibrate_all flag and models to run
@@ -568,5 +586,20 @@ Examples:
         today = datetime.strptime(args.today, "%Y-%m-%d").date()
 
     initialize_today(today)
+
+    if args.recover:
+        if args.today is None:
+            parser.error("--recover requires --today YYYY-MM-DD")
+
+        from lt_recovery import run_recovery
+
+        sys.exit(
+            run_recovery(
+                issue_date=args.today,
+                forecast_mode=os.getenv("lt_forecast_mode"),
+                run_forecast_fn=run_forecast,
+                station_codes_fn=_read_station_codes,
+            )
+        )
 
     run_forecast(forecast_all=recalibrate_all, models_to_run=models_to_run)

--- a/apps/long_term_forecasting/run_forecast.py
+++ b/apps/long_term_forecasting/run_forecast.py
@@ -580,18 +580,27 @@ Examples:
     recalibrate_all = args.all or args.today is not None
     models_to_run = args.models if args.models else []
 
-    if args.today is None:
-        today = datetime.now().date()
-    else:
-        today = datetime.strptime(args.today, "%Y-%m-%d").date()
-
-    initialize_today(today)
-
+    # The recovery path parses its own date, so that a malformed or impossible
+    # one (2026-02-31) exits with the documented refusal code instead of
+    # crashing in strptime below.
     if args.recover:
         if args.today is None:
             parser.error("--recover requires --today YYYY-MM-DD")
 
-        from lt_recovery import run_recovery
+        from lt_recovery import (
+            EXIT_REFUSED,
+            RecoveryRefused,
+            parse_issue_date,
+            run_recovery,
+        )
+
+        try:
+            effective_date = parse_issue_date(args.today)
+        except RecoveryRefused as exc:
+            logger.error("Long-term recovery REFUSED (nothing was run): %s", exc)
+            sys.exit(EXIT_REFUSED)
+
+        initialize_today(effective_date)
 
         sys.exit(
             run_recovery(
@@ -601,5 +610,12 @@ Examples:
                 station_codes_fn=_read_station_codes,
             )
         )
+
+    if args.today is None:
+        today = datetime.now().date()
+    else:
+        today = datetime.strptime(args.today, "%Y-%m-%d").date()
+
+    initialize_today(today)
 
     run_forecast(forecast_all=recalibrate_all, models_to_run=models_to_run)

--- a/apps/long_term_forecasting/tests/test_lt_recovery.py
+++ b/apps/long_term_forecasting/tests/test_lt_recovery.py
@@ -99,14 +99,21 @@ class FakeClient:
         if self.error is not None:
             raise self.error
         model = kwargs.get("model")
+        horizon_type = kwargs.get("horizon_type")
+        horizon_value = kwargs.get("horizon_value")
         start_date = kwargs.get("start_date")
         end_date = kwargs.get("end_date")
         skip = kwargs.get("skip", 0)
         limit = kwargs.get("limit", 100)
+        # Every filter the real API honours is honoured here, so a query that
+        # loses its horizon scoping shows up as wrong counts rather than
+        # passing silently.
         matching = [
             row
             for row in self.rows
             if row.get("model_type") == model
+            and (horizon_type is None or row.get("horizon_type") == horizon_type)
+            and (horizon_value is None or row.get("horizon_value") == horizon_value)
             and (start_date is None or row.get("date") >= start_date)
             and (end_date is None or row.get("date") <= end_date)
         ]
@@ -114,10 +121,18 @@ class FakeClient:
         return pd.DataFrame(page)
 
 
-def make_row(model_type="LR_Base", code=STATION, date="2026-08-01", flag=0, q=12.5):
+def make_row(
+    model_type="LR_Base",
+    code=STATION,
+    date="2026-08-01",
+    flag=0,
+    q=12.5,
+    horizon_type="month",
+    horizon_value=1,
+):
     return {
-        "horizon_type": "month",
-        "horizon_value": 1,
+        "horizon_type": horizon_type,
+        "horizon_value": horizon_value,
         "code": code,
         "date": date,
         "model_type": model_type,
@@ -200,15 +215,26 @@ class TestIssueDateParsing:
         assert parse_issue_date("2026-08-01") == pd.Timestamp("2026-08-01")
 
     @pytest.mark.parametrize(
-        "value", ["", None, "  ", "01.08.2026", "2026/08/01", "August", "2026-13-01"]
+        "value",
+        [
+            "",
+            None,
+            "  ",
+            "01.08.2026",
+            "2026/08/01",
+            "August",
+            "2026-8-1",  # not zero-padded: the docstring says strict ISO
+            "2026-08-01T00:00:00",
+        ],
     )
     def test_rejects_non_iso(self, value):
-        with pytest.raises(RecoveryRefused):
+        with pytest.raises(RecoveryRefused, match="ISO"):
             parse_issue_date(value)
 
-    def test_unpadded_components_parse_to_the_same_date(self):
-        """strptime accepts 2026-8-1; it denotes the same day, so allow it."""
-        assert parse_issue_date("2026-8-1") == pd.Timestamp("2026-08-01")
+    @pytest.mark.parametrize("value", ["2026-13-01", "2026-02-31", "2026-00-10"])
+    def test_rejects_impossible_calendar_dates(self, value):
+        with pytest.raises(RecoveryRefused, match="calendar date"):
+            parse_issue_date(value)
 
 
 class TestRecoveryWindow:
@@ -330,6 +356,34 @@ class TestCountMemberRows:
         )
         assert self._count(client, flags={RECOVERY_FLAG}, require_value=True) == 1
 
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_require_value_rejects_non_finite_q(self, value):
+        """Infinity is not a forecast: an upstream divide-by-zero can persist it."""
+        client = FakeClient([make_row(model_type="LR_Base", flag=RECOVERY_FLAG, q=value)])
+        assert self._count(client, flags={RECOVERY_FLAG}, require_value=True) == 0
+
+    def test_require_value_accepts_zero(self):
+        """Zero discharge is a real value and must not be mistaken for missing."""
+        client = FakeClient([make_row(model_type="LR_Base", flag=RECOVERY_FLAG, q=0.0)])
+        assert self._count(client, flags={RECOVERY_FLAG}, require_value=True) == 1
+
+    def test_ignores_other_horizon_types(self):
+        client = FakeClient([make_row(horizon_type="quarter")])
+        assert self._count(client) == 0
+
+    def test_ignores_other_horizon_values(self):
+        client = FakeClient([make_row(horizon_value=5)])
+        assert self._count(client) == 0
+
+    def test_query_is_scoped_to_the_mode_horizon(self):
+        """Every query must carry horizon_type and horizon_value."""
+        client = FakeClient([make_row()])
+        self._count(client)
+        assert client.calls, "no query was issued"
+        for call in client.calls:
+            assert call["horizon_type"] == "month"
+            assert call["horizon_value"] == 1
+
     def test_query_error_raises(self):
         client = FakeClient(error=RuntimeError("boom"))
         with pytest.raises(RecoveryQueryError):
@@ -402,6 +456,13 @@ class TestRunRecoveryGuard:
         kwargs, calls, _ = build_run_recovery_kwargs(client=client, on_run=write_recovered_rows)
         assert run_recovery(**kwargs) == EXIT_OK
 
+    def test_row_for_another_horizon_does_not_trip_the_guard(self):
+        """A quarter row on the same date must not block a month recovery."""
+        client = FakeClient([make_row(horizon_type="quarter"), make_row(horizon_value=5)])
+        kwargs, calls, _ = build_run_recovery_kwargs(client=client, on_run=write_recovered_rows)
+        assert run_recovery(**kwargs) == EXIT_OK
+        assert len(calls) == 1
+
     def test_guard_query_error_refuses_without_running(self):
         client = FakeClient(error=RuntimeError("connection reset"))
         kwargs, calls, _ = build_run_recovery_kwargs(client=client)
@@ -463,6 +524,20 @@ class TestRunRecoveryReadBack:
             client.rows.append(make_row(model_type="LR_Base", flag=RECOVERY_FLAG, q=None))
 
         kwargs, _, _ = build_run_recovery_kwargs(on_run=write_valueless)
+        assert run_recovery(**kwargs) == EXIT_FAILED
+
+    def test_recovery_flag_with_infinite_value_does_not_count(self):
+        def write_infinite(client):
+            client.rows.append(make_row(model_type="LR_Base", flag=RECOVERY_FLAG, q=float("inf")))
+
+        kwargs, _, _ = build_run_recovery_kwargs(on_run=write_infinite)
+        assert run_recovery(**kwargs) == EXIT_FAILED
+
+    def test_rows_for_another_horizon_do_not_satisfy_the_read_back(self):
+        def write_wrong_horizon(client):
+            client.rows.append(make_row(model_type="LR_Base", flag=RECOVERY_FLAG, horizon_value=5))
+
+        kwargs, _, _ = build_run_recovery_kwargs(on_run=write_wrong_horizon)
         assert run_recovery(**kwargs) == EXIT_FAILED
 
     def test_read_back_query_error_fails_closed(self):

--- a/apps/long_term_forecasting/tests/test_lt_recovery.py
+++ b/apps/long_term_forecasting/tests/test_lt_recovery.py
@@ -1,0 +1,545 @@
+"""Tests for the dated long-term recovery path (lt_recovery).
+
+Contracts under test:
+
+- the no-overwrite guard refuses when ANY member row exists for the target
+  (horizon_type, horizon_value, effective_date), and passes when none does;
+- guard and read-back both fail closed on a query error;
+- a run that writes only flag=2 (missing/all-NaN) rows FAILS;
+- only the current and previous calendar month are recoverable, the date must
+  be the configured issue date, and a future date is refused;
+- an empty station list is refused before any query is issued;
+- the operational flag assignment is unchanged when no recovery flag is given.
+
+Station codes are synthetic (19999 / 19998).
+"""
+
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from lt_recovery import (  # noqa: E402
+    EXIT_FAILED,
+    EXIT_OK,
+    EXIT_REFUSED,
+    MISSING_VALUE_FLAG,
+    OPERATIONAL_FLAG,
+    RECOVERY_FLAG,
+    RecoveryQueryError,
+    RecoveryRefused,
+    apply_success_flag,
+    check_recovery_window,
+    check_station_codes,
+    count_member_rows,
+    member_model_names,
+    member_model_types,
+    parse_issue_date,
+    resolve_scheduled_models,
+    run_recovery,
+)
+
+STATION = "19999"
+OTHER_STATION = "19998"
+
+ALL_MONTHS = list(range(1, 13))
+
+
+# ─────────────────────────────────────────────────────────────────
+# Fakes
+# ─────────────────────────────────────────────────────────────────
+
+
+class FakeConfig:
+    """Minimal stand-in for a loaded ForecastConfig."""
+
+    def __init__(
+        self,
+        models=("LR_Base", "SM_GBT"),
+        issue_day=1,
+        forecast_months=None,
+        horizon_type="month",
+        horizon_value=1,
+    ):
+        self._models = list(models)
+        self._issue_day = issue_day
+        self._forecast_months = forecast_months or {}
+        self._horizon_type = horizon_type
+        self._horizon_value = horizon_value
+
+    def get_models_to_run(self):
+        return list(self._models)
+
+    def get_operational_issue_day(self):
+        return self._issue_day
+
+    def get_forecast_months(self, model_name):
+        return self._forecast_months.get(model_name, ALL_MONTHS)
+
+    def get_horizon_type(self):
+        return self._horizon_type
+
+    def get_operational_month_lead_time(self):
+        return self._horizon_value
+
+
+class FakeClient:
+    """In-memory long_forecasts store with the read API's filter semantics."""
+
+    def __init__(self, rows=None, error=None):
+        self.rows = list(rows or [])
+        self.error = error
+        self.calls = []
+
+    def read_long_term_forecasts(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        model = kwargs.get("model")
+        start_date = kwargs.get("start_date")
+        end_date = kwargs.get("end_date")
+        skip = kwargs.get("skip", 0)
+        limit = kwargs.get("limit", 100)
+        matching = [
+            row
+            for row in self.rows
+            if row.get("model_type") == model
+            and (start_date is None or row.get("date") >= start_date)
+            and (end_date is None or row.get("date") <= end_date)
+        ]
+        page = matching[skip : skip + limit]
+        return pd.DataFrame(page)
+
+
+def make_row(model_type="LR_Base", code=STATION, date="2026-08-01", flag=0, q=12.5):
+    return {
+        "horizon_type": "month",
+        "horizon_value": 1,
+        "code": code,
+        "date": date,
+        "model_type": model_type,
+        "flag": flag,
+        "q": q,
+    }
+
+
+def build_run_recovery_kwargs(
+    *,
+    config=None,
+    client=None,
+    station_codes=(STATION,),
+    issue_date="2026-08-01",
+    forecast_mode="month_0",
+    now="2026-08-30",
+    on_run=None,
+):
+    """Assemble run_recovery kwargs plus a record of what the run did."""
+    config = config or FakeConfig()
+    client = client if client is not None else FakeClient()
+    calls = []
+
+    def run_forecast_fn(**kwargs):
+        calls.append(kwargs)
+        if on_run is not None:
+            on_run(client)
+
+    kwargs = dict(
+        issue_date=issue_date,
+        forecast_mode=forecast_mode,
+        run_forecast_fn=run_forecast_fn,
+        station_codes_fn=lambda: list(station_codes),
+        config_factory=lambda mode: config,
+        client_factory=lambda: client,
+        now=pd.Timestamp(now),
+    )
+    return kwargs, calls, client
+
+
+def write_recovered_rows(client, models=("LR_Base", "SM_GBT"), date="2026-08-01"):
+    """Simulate a successful recovery run writing flag=1 rows."""
+    for model in models:
+        client.rows.append(make_row(model_type=model, date=date, flag=RECOVERY_FLAG, q=9.9))
+
+
+# ─────────────────────────────────────────────────────────────────
+# Members
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestMemberSelection:
+    def test_aggregates_excluded(self):
+        config = FakeConfig(models=["LR_Base", "EM", "Skilled Mean", "Naive Mean", "GBT"])
+        assert member_model_names(config) == ["LR_Base", "GBT"]
+
+    def test_aggregate_matching_ignores_case_and_underscores(self):
+        config = FakeConfig(models=["em", "Skilled_Mean", "naive mean", "LR_Base"])
+        assert member_model_names(config) == ["LR_Base"]
+
+    def test_model_types_deduplicated_and_ordered(self):
+        config = FakeConfig(models=["LR_Base", "SM_GBT", "LR_Base"])
+        assert member_model_types(config) == ["LR_Base", "SM_GBT"]
+
+    def test_mode_with_only_aggregates_is_refused(self):
+        config = FakeConfig(models=["EM", "Skilled Mean"])
+        kwargs, calls, client = build_run_recovery_kwargs(config=config)
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == []
+        assert client.calls == []
+
+
+# ─────────────────────────────────────────────────────────────────
+# Date validation
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestIssueDateParsing:
+    def test_parses_iso(self):
+        assert parse_issue_date("2026-08-01") == pd.Timestamp("2026-08-01")
+
+    @pytest.mark.parametrize(
+        "value", ["", None, "  ", "01.08.2026", "2026/08/01", "August", "2026-13-01"]
+    )
+    def test_rejects_non_iso(self, value):
+        with pytest.raises(RecoveryRefused):
+            parse_issue_date(value)
+
+    def test_unpadded_components_parse_to_the_same_date(self):
+        """strptime accepts 2026-8-1; it denotes the same day, so allow it."""
+        assert parse_issue_date("2026-8-1") == pd.Timestamp("2026-08-01")
+
+
+class TestRecoveryWindow:
+    def test_current_month_allowed(self):
+        check_recovery_window(pd.Timestamp("2026-08-01"), pd.Timestamp("2026-08-30"))
+
+    def test_previous_month_allowed(self):
+        check_recovery_window(pd.Timestamp("2026-07-01"), pd.Timestamp("2026-08-30"))
+
+    def test_previous_month_across_year_boundary(self):
+        check_recovery_window(pd.Timestamp("2025-12-01"), pd.Timestamp("2026-01-10"))
+
+    def test_two_months_back_refused(self):
+        with pytest.raises(RecoveryRefused, match="outside the recovery window"):
+            check_recovery_window(pd.Timestamp("2026-06-01"), pd.Timestamp("2026-08-30"))
+
+    def test_future_refused(self):
+        with pytest.raises(RecoveryRefused, match="in the future"):
+            check_recovery_window(pd.Timestamp("2026-09-01"), pd.Timestamp("2026-08-30"))
+
+
+class TestScheduledIssueDate:
+    def test_exact_issue_date_accepted(self):
+        config = FakeConfig(models=["LR_Base"], issue_day=1)
+        assert resolve_scheduled_models(config, pd.Timestamp("2026-08-01")) == ["LR_Base"]
+
+    def test_near_miss_is_refused_not_snapped(self):
+        """A date 2 days late would be snapped by run_forecast — refuse it."""
+        config = FakeConfig(models=["LR_Base"], issue_day=1)
+        with pytest.raises(RecoveryRefused, match="would snap"):
+            resolve_scheduled_models(config, pd.Timestamp("2026-08-03"))
+
+    def test_far_miss_is_refused_as_non_issue_date(self):
+        config = FakeConfig(models=["LR_Base"], issue_day=1)
+        with pytest.raises(RecoveryRefused, match="not a scheduled issue date"):
+            resolve_scheduled_models(config, pd.Timestamp("2026-08-15"))
+
+    def test_month_outside_model_forecast_months_is_refused(self):
+        config = FakeConfig(models=["LR_Base"], issue_day=1, forecast_months={"LR_Base": [3, 4]})
+        with pytest.raises(RecoveryRefused, match="not a scheduled issue date"):
+            resolve_scheduled_models(config, pd.Timestamp("2026-08-01"))
+
+    def test_short_month_clamp_for_issue_day_31(self):
+        """issue_day=31 in February resolves to the 28th, and only the 28th."""
+        config = FakeConfig(models=["LR_Base"], issue_day=31)
+        assert resolve_scheduled_models(config, pd.Timestamp("2026-02-28")) == ["LR_Base"]
+        with pytest.raises(RecoveryRefused):
+            resolve_scheduled_models(config, pd.Timestamp("2026-02-27"))
+
+    def test_seasonal_model_skips_while_monthly_model_runs(self):
+        """A member outside its forecast months is skipped, not a blocker."""
+        config = FakeConfig(
+            models=["LR_Base", "SM_GBT"],
+            issue_day=1,
+            forecast_months={"SM_GBT": [3]},
+        )
+        assert resolve_scheduled_models(config, pd.Timestamp("2026-08-01")) == ["LR_Base"]
+
+
+class TestStationCodes:
+    def test_non_empty_codes_pass(self):
+        assert check_station_codes([19999, " 19998 "]) == ["19999", "19998"]
+
+    @pytest.mark.parametrize("codes", [None, [], ["", "  "]])
+    def test_empty_refused(self, codes):
+        with pytest.raises(RecoveryRefused, match="Station list is empty"):
+            check_station_codes(codes)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Counting
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCountMemberRows:
+    def _count(self, client, **overrides):
+        params = dict(
+            horizon_type="month",
+            horizon_value=1,
+            effective_date=pd.Timestamp("2026-08-01"),
+            model_types=["LR_Base", "SM_GBT"],
+            station_codes=[STATION],
+        )
+        params.update(overrides)
+        return count_member_rows(client, **params)
+
+    def test_counts_rows_for_configured_stations_only(self):
+        client = FakeClient(
+            [
+                make_row(code=STATION),
+                make_row(code=OTHER_STATION),
+            ]
+        )
+        assert self._count(client) == 1
+
+    def test_counts_every_member_model(self):
+        client = FakeClient([make_row(model_type="LR_Base"), make_row(model_type="SM_GBT")])
+        assert self._count(client) == 2
+
+    def test_ignores_other_dates(self):
+        client = FakeClient([make_row(date="2026-07-01")])
+        assert self._count(client) == 0
+
+    def test_flag_filter(self):
+        client = FakeClient(
+            [
+                make_row(model_type="LR_Base", flag=RECOVERY_FLAG),
+                make_row(model_type="SM_GBT", flag=MISSING_VALUE_FLAG),
+            ]
+        )
+        assert self._count(client, flags={RECOVERY_FLAG}) == 1
+
+    def test_require_value_skips_null_q(self):
+        client = FakeClient(
+            [
+                make_row(model_type="LR_Base", flag=RECOVERY_FLAG, q=None),
+                make_row(model_type="SM_GBT", flag=RECOVERY_FLAG, q=3.0),
+            ]
+        )
+        assert self._count(client, flags={RECOVERY_FLAG}, require_value=True) == 1
+
+    def test_query_error_raises(self):
+        client = FakeClient(error=RuntimeError("boom"))
+        with pytest.raises(RecoveryQueryError):
+            self._count(client)
+
+    def test_pagination_reads_every_page(self):
+        client = FakeClient([make_row(code=str(19900 + i)) for i in range(7)])
+        codes = [str(19900 + i) for i in range(7)]
+        assert self._count(client, model_types=["LR_Base"], station_codes=codes, page_size=3) == 7
+
+
+# ─────────────────────────────────────────────────────────────────
+# Flag override
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestApplySuccessFlag:
+    def _frame(self):
+        return pd.DataFrame({"Q_LR_Base": [1.0, None, 3.0]})
+
+    def test_operational_path_unchanged(self):
+        """REGRESSION: with no recovery flag the values are exactly 0 and 2."""
+        frame = apply_success_flag(self._frame(), "Q_LR_Base")
+        assert list(frame["flag"]) == [
+            OPERATIONAL_FLAG,
+            MISSING_VALUE_FLAG,
+            OPERATIONAL_FLAG,
+        ]
+
+    def test_recovery_flag_applied_to_values_only(self):
+        frame = apply_success_flag(self._frame(), "Q_LR_Base", RECOVERY_FLAG)
+        assert list(frame["flag"]) == [RECOVERY_FLAG, MISSING_VALUE_FLAG, RECOVERY_FLAG]
+
+    def test_explicit_none_matches_operational(self):
+        frame = apply_success_flag(self._frame(), "Q_LR_Base", None)
+        assert list(frame["flag"]) == [
+            OPERATIONAL_FLAG,
+            MISSING_VALUE_FLAG,
+            OPERATIONAL_FLAG,
+        ]
+
+
+# ─────────────────────────────────────────────────────────────────
+# End-to-end orchestration
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestRunRecoveryGuard:
+    def test_refuses_when_member_row_exists(self):
+        client = FakeClient([make_row(model_type="LR_Base")])
+        kwargs, calls, _ = build_run_recovery_kwargs(client=client)
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == [], "the forecast must not run when the guard refuses"
+
+    def test_refuses_on_a_flag_two_row(self):
+        """A partial month, even one full of missing values, is refused."""
+        client = FakeClient([make_row(model_type="SM_GBT", flag=MISSING_VALUE_FLAG, q=None)])
+        kwargs, calls, _ = build_run_recovery_kwargs(client=client)
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == []
+
+    def test_row_for_another_station_does_not_trip_the_guard(self):
+        client = FakeClient([make_row(code=OTHER_STATION)])
+        kwargs, calls, _ = build_run_recovery_kwargs(client=client, on_run=write_recovered_rows)
+        assert run_recovery(**kwargs) == EXIT_OK
+        assert len(calls) == 1
+
+    def test_row_for_another_month_does_not_trip_the_guard(self):
+        client = FakeClient([make_row(date="2026-07-01")])
+        kwargs, calls, _ = build_run_recovery_kwargs(client=client, on_run=write_recovered_rows)
+        assert run_recovery(**kwargs) == EXIT_OK
+
+    def test_guard_query_error_refuses_without_running(self):
+        client = FakeClient(error=RuntimeError("connection reset"))
+        kwargs, calls, _ = build_run_recovery_kwargs(client=client)
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == []
+
+
+class TestRunRecoverySuccess:
+    def test_passes_recovery_flag_to_the_forecast(self):
+        kwargs, calls, _ = build_run_recovery_kwargs(on_run=write_recovered_rows)
+        assert run_recovery(**kwargs) == EXIT_OK
+        assert len(calls) == 1
+        assert calls[0]["recovery_flag"] == RECOVERY_FLAG
+        assert calls[0]["forecast_all"] is True
+        assert calls[0]["models_to_run"] == []
+        assert calls[0]["forecast_mode"] == "month_0"
+
+    def test_partial_coverage_still_succeeds(self):
+        """Success criterion is 'some rows written', deliberately loose."""
+        kwargs, calls, _ = build_run_recovery_kwargs(
+            on_run=lambda client: write_recovered_rows(client, models=["LR_Base"])
+        )
+        assert run_recovery(**kwargs) == EXIT_OK
+
+    def test_previous_month_recovered(self):
+        kwargs, calls, _ = build_run_recovery_kwargs(
+            issue_date="2026-07-01",
+            now="2026-08-30",
+            on_run=lambda client: write_recovered_rows(client, date="2026-07-01"),
+        )
+        assert run_recovery(**kwargs) == EXIT_OK
+
+
+class TestRunRecoveryReadBack:
+    def test_run_writing_nothing_fails(self):
+        kwargs, calls, _ = build_run_recovery_kwargs()
+        assert run_recovery(**kwargs) == EXIT_FAILED
+        assert len(calls) == 1, "the forecast ran; only the read-back failed"
+
+    def test_only_flag_two_rows_fails(self):
+        def write_missing(client):
+            client.rows.append(make_row(model_type="LR_Base", flag=MISSING_VALUE_FLAG, q=None))
+            client.rows.append(make_row(model_type="SM_GBT", flag=MISSING_VALUE_FLAG, q=None))
+
+        kwargs, calls, _ = build_run_recovery_kwargs(on_run=write_missing)
+        assert run_recovery(**kwargs) == EXIT_FAILED
+
+    def test_operational_flag_rows_do_not_satisfy_the_read_back(self):
+        """Only rows carrying the recovery flag count as recovered."""
+
+        def write_operational(client):
+            client.rows.append(make_row(model_type="LR_Base", flag=OPERATIONAL_FLAG))
+
+        kwargs, _, _ = build_run_recovery_kwargs(on_run=write_operational)
+        assert run_recovery(**kwargs) == EXIT_FAILED
+
+    def test_recovery_flag_without_value_does_not_count(self):
+        def write_valueless(client):
+            client.rows.append(make_row(model_type="LR_Base", flag=RECOVERY_FLAG, q=None))
+
+        kwargs, _, _ = build_run_recovery_kwargs(on_run=write_valueless)
+        assert run_recovery(**kwargs) == EXIT_FAILED
+
+    def test_read_back_query_error_fails_closed(self):
+        def break_client(client):
+            write_recovered_rows(client)
+            client.error = RuntimeError("gateway timeout")
+
+        kwargs, calls, _ = build_run_recovery_kwargs(on_run=break_client)
+        assert run_recovery(**kwargs) == EXIT_FAILED
+        assert len(calls) == 1
+
+    def test_forecast_exception_fails(self):
+        def explode(_client):
+            raise RuntimeError("model blew up")
+
+        kwargs, _, _ = build_run_recovery_kwargs(on_run=explode)
+        assert run_recovery(**kwargs) == EXIT_FAILED
+
+
+class TestRunRecoveryRefusals:
+    def test_future_date_refused(self):
+        kwargs, calls, client = build_run_recovery_kwargs(issue_date="2026-09-01", now="2026-08-30")
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == []
+        assert client.calls == []
+
+    def test_out_of_window_date_refused(self):
+        kwargs, calls, client = build_run_recovery_kwargs(issue_date="2026-06-01", now="2026-08-30")
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == []
+        assert client.calls == []
+
+    def test_non_issue_date_refused(self):
+        kwargs, calls, client = build_run_recovery_kwargs(issue_date="2026-08-15")
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == []
+        assert client.calls == []
+
+    def test_near_miss_date_refused(self):
+        kwargs, calls, client = build_run_recovery_kwargs(issue_date="2026-08-03")
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == []
+        assert client.calls == []
+
+    def test_empty_station_list_refused_before_any_query(self):
+        kwargs, calls, client = build_run_recovery_kwargs(station_codes=())
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == []
+        assert client.calls == [], "no query may be issued without org scoping"
+
+    def test_missing_forecast_mode_refused(self):
+        kwargs, calls, client = build_run_recovery_kwargs(forecast_mode="")
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == []
+        assert client.calls == []
+
+    def test_malformed_date_refused(self):
+        kwargs, calls, client = build_run_recovery_kwargs(issue_date="01.08.2026")
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == []
+        assert client.calls == []
+
+    def test_config_load_failure_refuses(self):
+        def broken_factory(_mode):
+            raise FileNotFoundError("month_9.json missing")
+
+        kwargs, calls, client = build_run_recovery_kwargs()
+        kwargs["config_factory"] = broken_factory
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == []
+        assert client.calls == []
+
+    def test_client_construction_failure_refuses(self):
+        def broken_client():
+            raise RecoveryQueryError("API not ready")
+
+        kwargs, calls, _ = build_run_recovery_kwargs()
+        kwargs["client_factory"] = broken_client
+        assert run_recovery(**kwargs) == EXIT_REFUSED
+        assert calls == []

--- a/apps/pipeline/pipeline_docker.py
+++ b/apps/pipeline/pipeline_docker.py
@@ -2189,6 +2189,13 @@ class RunLongTermForecast(DockerTaskBase):
       as soon as the child exits 0. It does not require preprocessing (the
       inputs for a past month are already stored) and keys the marker on mode
       *and* date so two dates for one mode do not collide.
+
+    Accepted side effect: adding ``issue_date`` changes the Luigi task-ID hash
+    of an *undated* RunLongTermForecast, because task_id is derived from the
+    full significant-parameter set. Nothing observable changes -- same
+    dependencies, same command, same marker path, same resources -- only the
+    task's identity in the scheduler UI and history. A separate task class
+    would avoid the cosmetic change at the cost of duplicating this one.
     """
 
     forecast_mode = luigi.Parameter()  # e.g. "month_0", "quarter"

--- a/apps/pipeline/pipeline_docker.py
+++ b/apps/pipeline/pipeline_docker.py
@@ -2045,12 +2045,29 @@ class RunPeriodicMaintenanceWorkflow(luigi.Task):
     """Parameterized workflow for periodic maintenance tasks.
 
     Args:
-        task_type: One of 'long_term', 'skill_recalc', 'snow_norms'
+        task_type: One of 'long_term', 'skill_recalc', 'snow_norms',
+            'lt_recovery'
+        lt_recovery_mode: Long-term forecast mode to recover (task_type
+            'lt_recovery' only), e.g. 'month_0'.
+        lt_recovery_issue_date: ISO YYYY-MM-DD issue date to recover
+            (task_type 'lt_recovery' only).
     """
 
     task_type = luigi.Parameter()
+    lt_recovery_mode = luigi.Parameter(default="")
+    lt_recovery_issue_date = luigi.Parameter(default="")
 
     def requires(self):
+        if self.task_type == "lt_recovery":
+            mode = str(self.lt_recovery_mode).strip()
+            issue_date = str(self.lt_recovery_issue_date).strip()
+            if not mode or not issue_date:
+                raise ValueError(
+                    "task_type 'lt_recovery' requires both --lt-recovery-mode "
+                    "(e.g. month_0) and --lt-recovery-issue-date (YYYY-MM-DD)."
+                )
+            return RunLongTermForecast(forecast_mode=mode, issue_date=issue_date)
+
         task_map = {
             "long_term": LongTermPostProcessingMaintenance(),
             "skill_recalc": YearlySkillRecalculation(),
@@ -2058,11 +2075,19 @@ class RunPeriodicMaintenanceWorkflow(luigi.Task):
         }
         if self.task_type not in task_map:
             raise ValueError(
-                f"Unknown task_type '{self.task_type}'. Expected one of: {list(task_map.keys())}"
+                f"Unknown task_type '{self.task_type}'. Expected one of: "
+                f"{[*task_map.keys(), 'lt_recovery']}"
             )
         return task_map[self.task_type]
 
     def output(self):
+        if self.task_type == "lt_recovery":
+            # Keyed on mode and date so recovering a second month is not
+            # short-circuited by the first month's marker.
+            return luigi.LocalTarget(
+                f"/app/log_periodic_maintenance_lt_recovery_"
+                f"{self.lt_recovery_mode}_{self.lt_recovery_issue_date}_complete.txt"
+            )
         return luigi.LocalTarget(f"/app/log_periodic_maintenance_{self.task_type}_complete.txt")
 
     def run(self):
@@ -2151,24 +2176,58 @@ class RunLongTermForecast(DockerTaskBase):
     Parameterized per-mode task. The bash entry script determines which
     modes are active via lt_schedule_query.py and passes them as Luigi
     parameters.
+
+    Two paths share this task:
+
+    - **Operational** (``issue_date`` empty, the default): unchanged. Requires
+      preprocessing, runs the image CMD, marker keyed on the mode alone.
+    - **Dated recovery** (``issue_date`` set): regenerates ONE missed month.
+      It overrides the command with ``run_forecast.py --today <date> --recover``
+      so the guard, the run and the database read-back all happen inside the
+      child container behind a single exit code — a check here in the parent
+      would be too late, because ``execute_with_retries`` creates the marker
+      as soon as the child exits 0. It does not require preprocessing (the
+      inputs for a past month are already stored) and keys the marker on mode
+      *and* date so two dates for one mode do not collide.
     """
 
     forecast_mode = luigi.Parameter()  # e.g. "month_0", "quarter"
+    # ISO YYYY-MM-DD; empty means the ordinary operational run.
+    issue_date = luigi.Parameter(default="")
 
     resources = {"lt_memory": 1}  # serialize long-term runs (memory)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.issue_date:
+            # A dated recovery must never be retried: the guard only runs on
+            # the first attempt, so a second attempt would write over rows the
+            # first attempt just created. Ordinary forecast runs keep the
+            # default from the timeout manager.
+            self.max_retries = 1
+
     @property
     def docker_logs_file_path(self):
+        date_suffix = f"_{self.issue_date}" if self.issue_date else ""
         return (
             f"{get_bind_path(env.get('ieasyforecast_intermediate_data_path'))}"
-            f"/docker_logs/log_lt_forecast_{self.forecast_mode}_"
+            f"/docker_logs/log_lt_forecast_{self.forecast_mode}{date_suffix}_"
             f"{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
         )
 
     def requires(self):
+        if self.issue_date:
+            # Recovery regenerates a past month from data already in the
+            # database. Triggering runoff/gateway preprocessing here would
+            # pull today's data into an operator-invoked repair.
+            return []
         return [PreprocessingRunoff(), get_gateway_dependency()]
 
     def output(self):
+        if self.issue_date:
+            return luigi.LocalTarget(
+                f"/app/log_lt_forecast_{self.forecast_mode}_{self.issue_date}.txt"
+            )
         return luigi.LocalTarget(f"/app/log_lt_forecast_{self.forecast_mode}.txt")
 
     def run(self):
@@ -2189,16 +2248,32 @@ class RunLongTermForecast(DockerTaskBase):
         environment.extend(get_docker_host_env_overrides())
         environment.append("SAPPHIRE_API_URL=http://api-gateway:8000")
 
+        # Operational runs use the image CMD (command=None keeps
+        # run_docker_container's behaviour byte-for-byte identical).
+        command = None
+        container_name_base = f"lt_forecast_{self.forecast_mode}"
+        if self.issue_date:
+            command = [
+                "uv",
+                "run",
+                "run_forecast.py",
+                "--today",
+                str(self.issue_date),
+                "--recover",
+            ]
+            container_name_base = f"lt_recovery_{self.forecast_mode}_{self.issue_date}"
+
         status, details = self.execute_with_retries(
             lambda attempt: self.run_docker_container(
                 image_name="sapphire-lt-forecasting",
-                container_name=f"lt_forecast_{self.forecast_mode}_{attempt}",
+                container_name=f"{container_name_base}_{attempt}",
                 volumes=volumes,
                 environment=environment,
                 attempt_number=attempt,
                 mem_limit="12g",
                 memswap_limit="16g",
                 network="sapphire_sapphire-network",
+                command=command,
             )
         )
 

--- a/apps/pipeline/tests/test_lt_dated_recovery.py
+++ b/apps/pipeline/tests/test_lt_dated_recovery.py
@@ -1,0 +1,319 @@
+"""Tests for the dated long-term recovery path on RunLongTermForecast.
+
+Contracts under test:
+
+- an issue date turns RunLongTermForecast into a recovery task: command
+  override, no preprocessing dependency, marker keyed on mode AND date,
+  max_retries pinned to 1;
+- the undated operational path is byte-for-byte unchanged (REGRESSION);
+- RunPeriodicMaintenanceWorkflow routes task_type 'lt_recovery' to the dated
+  task and refuses incomplete arguments;
+- the wrapper script returns the Compose status for lt_recovery only.
+"""
+
+import os
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+def _capture_run(task, monkeypatch):
+    """Run task.run() with docker stubbed out, returning the container kwargs."""
+    captured = {}
+
+    def fake_run_docker_container(**kwargs):
+        captured.update(kwargs)
+        return "container_id", 0, "logs"
+
+    def fake_execute(func):
+        func(1)
+        return "Success", {}
+
+    monkeypatch.setattr(task, "run_docker_container", fake_run_docker_container)
+    monkeypatch.setattr(task, "execute_with_retries", fake_execute)
+    task.run()
+    return captured
+
+
+class TestOperationalPathUnchanged:
+    """REGRESSION: an undated RunLongTermForecast must behave as before."""
+
+    def test_requires_preprocessing(self, mock_env):
+        from pipeline_docker import PreprocessingRunoff, RunLongTermForecast
+
+        deps = RunLongTermForecast(forecast_mode="month_0").requires()
+        assert len(deps) == 2
+        assert isinstance(deps[0], PreprocessingRunoff)
+
+    def test_output_path_has_no_date(self, mock_env):
+        from pipeline_docker import RunLongTermForecast
+
+        task = RunLongTermForecast(forecast_mode="month_0")
+        assert task.output().path == "/app/log_lt_forecast_month_0.txt"
+
+    def test_no_command_override(self, mock_env, monkeypatch):
+        from pipeline_docker import RunLongTermForecast
+
+        task = RunLongTermForecast(forecast_mode="month_0")
+        captured = _capture_run(task, monkeypatch)
+        assert captured["command"] is None
+        assert captured["container_name"] == "lt_forecast_month_0_1"
+        assert captured["mem_limit"] == "12g"
+        assert captured["memswap_limit"] == "16g"
+        assert captured["network"] == "sapphire_sapphire-network"
+
+    def test_max_retries_not_pinned(self, mock_env):
+        from pipeline_docker import RunLongTermForecast
+
+        task = RunLongTermForecast(forecast_mode="month_0")
+        # Whatever the timeout manager says, the recovery pin must not apply.
+        assert task.max_retries != 1 or task.max_retries is None
+
+    def test_resources_unchanged(self, mock_env):
+        from pipeline_docker import RunLongTermForecast
+
+        assert RunLongTermForecast(forecast_mode="month_0").resources == {"lt_memory": 1}
+
+
+class TestDatedRecoveryTask:
+    def test_no_preprocessing_dependency(self, mock_env):
+        from pipeline_docker import RunLongTermForecast
+
+        task = RunLongTermForecast(forecast_mode="month_0", issue_date="2026-08-01")
+        assert task.requires() == []
+
+    def test_marker_includes_the_date(self, mock_env):
+        from pipeline_docker import RunLongTermForecast
+
+        task = RunLongTermForecast(forecast_mode="month_0", issue_date="2026-08-01")
+        assert task.output().path == "/app/log_lt_forecast_month_0_2026-08-01.txt"
+
+    def test_marker_distinguishes_two_dates_for_one_mode(self, mock_env):
+        from pipeline_docker import RunLongTermForecast
+
+        july = RunLongTermForecast(forecast_mode="month_0", issue_date="2026-07-01")
+        august = RunLongTermForecast(forecast_mode="month_0", issue_date="2026-08-01")
+        assert july.output().path != august.output().path
+
+    def test_marker_differs_from_operational_marker(self, mock_env):
+        from pipeline_docker import RunLongTermForecast
+
+        operational = RunLongTermForecast(forecast_mode="month_0")
+        recovery = RunLongTermForecast(forecast_mode="month_0", issue_date="2026-08-01")
+        assert operational.output().path != recovery.output().path
+
+    def test_max_retries_pinned_to_one(self, mock_env):
+        from pipeline_docker import RunLongTermForecast
+
+        task = RunLongTermForecast(forecast_mode="month_0", issue_date="2026-08-01")
+        assert task.max_retries == 1
+
+    def test_command_override(self, mock_env, monkeypatch):
+        from pipeline_docker import RunLongTermForecast
+
+        task = RunLongTermForecast(forecast_mode="month_0", issue_date="2026-08-01")
+        captured = _capture_run(task, monkeypatch)
+        assert captured["command"] == [
+            "uv",
+            "run",
+            "run_forecast.py",
+            "--today",
+            "2026-08-01",
+            "--recover",
+        ]
+
+    def test_keeps_api_network_and_memory_limits(self, mock_env, monkeypatch):
+        """The guard and read-back run in the child, so it needs the API network."""
+        from pipeline_docker import RunLongTermForecast
+
+        task = RunLongTermForecast(forecast_mode="month_0", issue_date="2026-08-01")
+        captured = _capture_run(task, monkeypatch)
+        assert captured["network"] == "sapphire_sapphire-network"
+        assert captured["mem_limit"] == "12g"
+        assert captured["memswap_limit"] == "16g"
+        assert "SAPPHIRE_API_URL=http://api-gateway:8000" in captured["environment"]
+        assert "lt_forecast_mode=month_0" in captured["environment"]
+
+    def test_container_name_includes_mode_and_date(self, mock_env, monkeypatch):
+        from pipeline_docker import RunLongTermForecast
+
+        task = RunLongTermForecast(forecast_mode="month_0", issue_date="2026-08-01")
+        captured = _capture_run(task, monkeypatch)
+        assert captured["container_name"] == "lt_recovery_month_0_2026-08-01_1"
+
+    def test_docker_log_path_includes_the_date(self, mock_env):
+        from pipeline_docker import RunLongTermForecast
+
+        task = RunLongTermForecast(forecast_mode="month_0", issue_date="2026-08-01")
+        assert "month_0_2026-08-01" in task.docker_logs_file_path
+
+
+class TestPeriodicMaintenanceRouting:
+    def test_lt_recovery_requires_dated_task(self, mock_env):
+        from pipeline_docker import RunLongTermForecast, RunPeriodicMaintenanceWorkflow
+
+        task = RunPeriodicMaintenanceWorkflow(
+            task_type="lt_recovery",
+            lt_recovery_mode="month_0",
+            lt_recovery_issue_date="2026-08-01",
+        )
+        dep = task.requires()
+        assert isinstance(dep, RunLongTermForecast)
+        assert dep.forecast_mode == "month_0"
+        assert dep.issue_date == "2026-08-01"
+
+    @pytest.mark.parametrize(
+        ("mode", "issue_date"),
+        [("", "2026-08-01"), ("month_0", ""), ("", ""), ("  ", " ")],
+    )
+    def test_incomplete_arguments_raise(self, mock_env, mode, issue_date):
+        from pipeline_docker import RunPeriodicMaintenanceWorkflow
+
+        task = RunPeriodicMaintenanceWorkflow(
+            task_type="lt_recovery",
+            lt_recovery_mode=mode,
+            lt_recovery_issue_date=issue_date,
+        )
+        with pytest.raises(ValueError, match="lt_recovery"):
+            task.requires()
+
+    def test_output_keyed_on_mode_and_date(self, mock_env):
+        from pipeline_docker import RunPeriodicMaintenanceWorkflow
+
+        july = RunPeriodicMaintenanceWorkflow(
+            task_type="lt_recovery",
+            lt_recovery_mode="month_0",
+            lt_recovery_issue_date="2026-07-01",
+        )
+        august = RunPeriodicMaintenanceWorkflow(
+            task_type="lt_recovery",
+            lt_recovery_mode="month_0",
+            lt_recovery_issue_date="2026-08-01",
+        )
+        assert july.output().path != august.output().path
+        assert "2026-08-01" in august.output().path
+
+    @pytest.mark.parametrize("task_type", ["long_term", "skill_recalc", "snow_norms"])
+    def test_existing_task_types_unchanged(self, mock_env, task_type):
+        """REGRESSION: existing task types keep their dependency and marker."""
+        from pipeline_docker import RunPeriodicMaintenanceWorkflow
+
+        task = RunPeriodicMaintenanceWorkflow(task_type=task_type)
+        assert task.requires() is not None
+        assert task.output().path == f"/app/log_periodic_maintenance_{task_type}_complete.txt"
+
+    def test_unknown_task_type_still_raises(self, mock_env):
+        from pipeline_docker import RunPeriodicMaintenanceWorkflow
+
+        task = RunPeriodicMaintenanceWorkflow(task_type="monthly_norms")
+        with pytest.raises(ValueError, match="Unknown task_type"):
+            task.requires()
+
+
+class TestLuigiCommandLineContract:
+    """The Compose command always passes the two new args, empty when unused."""
+
+    @staticmethod
+    def _build(argv):
+        import luigi.cmdline_parser as cmdline_parser
+        import pipeline_docker  # noqa: F401  (registers the tasks)
+
+        with cmdline_parser.CmdlineParser.global_instance(argv) as parser:
+            return parser.get_task_obj()
+
+    def test_empty_recovery_args_are_accepted(self, mock_env):
+        """REGRESSION: existing task types still parse when the args are empty."""
+        task = self._build(
+            [
+                "--module",
+                "pipeline_docker",
+                "RunPeriodicMaintenanceWorkflow",
+                "--task-type",
+                "long_term",
+                "--lt-recovery-mode",
+                "",
+                "--lt-recovery-issue-date",
+                "",
+            ]
+        )
+        assert task.task_type == "long_term"
+        assert task.lt_recovery_mode == ""
+        assert task.output().path == "/app/log_periodic_maintenance_long_term_complete.txt"
+
+    def test_recovery_args_reach_the_dated_task(self, mock_env):
+        from pipeline_docker import RunLongTermForecast
+
+        task = self._build(
+            [
+                "--module",
+                "pipeline_docker",
+                "RunPeriodicMaintenanceWorkflow",
+                "--task-type",
+                "lt_recovery",
+                "--lt-recovery-mode",
+                "month_0",
+                "--lt-recovery-issue-date",
+                "2026-08-01",
+            ]
+        )
+        dep = task.requires()
+        assert isinstance(dep, RunLongTermForecast)
+        assert dep.issue_date == "2026-08-01"
+
+
+class TestOperatorEntryPoint:
+    """Structural checks on the wrapper and the Compose service."""
+
+    @staticmethod
+    def _wrapper():
+        path = os.path.join(_REPO_ROOT, "bin", "run_periodic_maintenance.sh")
+        with open(path) as handle:
+            return handle.read()
+
+    @staticmethod
+    def _compose():
+        path = os.path.join(_REPO_ROOT, "bin", "docker-compose-luigi.yml")
+        with open(path) as handle:
+            return handle.read()
+
+    def test_wrapper_captures_compose_status(self):
+        assert "COMPOSE_STATUS=$?" in self._wrapper()
+
+    def test_wrapper_returns_status_for_lt_recovery_only(self):
+        text = self._wrapper()
+        # The only `exit "$COMPOSE_STATUS"` must sit inside the lt_recovery branch.
+        branch = re.search(r'if \[ "\$TASK_TYPE" = "lt_recovery" \];.*?\nfi\n', text, re.DOTALL)
+        assert branch is not None
+        assert 'exit "$COMPOSE_STATUS"' in text
+        assert text.count('exit "$COMPOSE_STATUS"') == 1
+        # ... and that occurrence is inside a lt_recovery guard.
+        before = text[: text.index('exit "$COMPOSE_STATUS"')]
+        assert before.rstrip().endswith("fi") or 'TASK_TYPE" = "lt_recovery"' in before
+
+    def test_wrapper_validates_recovery_arguments(self):
+        text = self._wrapper()
+        assert "LT_RECOVERY_MODE" in text
+        assert "LT_RECOVERY_ISSUE_DATE" in text
+        assert "[0-9]{4}-[0-9]{2}-[0-9]{2}" in text
+
+    def test_wrapper_sets_non_zero_luigi_retcodes_for_recovery_only(self):
+        """Luigi's default retcodes are all 0; the status would be meaningless."""
+        text = self._wrapper()
+        assert "[retcode]" in text
+        assert "task_failed = 1" in text
+        retcode_block_start = text.index("[retcode]")
+        preceding = text[:retcode_block_start]
+        assert 'if [ "$TASK_TYPE" = "lt_recovery" ]' in preceding
+
+    def test_compose_forwards_recovery_arguments(self):
+        text = self._compose()
+        assert "'--lt-recovery-mode', '${MAINTENANCE_LT_MODE:-}'" in text
+        assert "'--lt-recovery-issue-date', '${MAINTENANCE_LT_ISSUE_DATE:-}'" in text
+
+    def test_compose_still_forwards_task_type(self):
+        assert "'--task-type', '${MAINTENANCE_TASK_TYPE:-long_term}'" in self._compose()

--- a/apps/pipeline/tests/test_lt_dated_recovery.py
+++ b/apps/pipeline/tests/test_lt_dated_recovery.py
@@ -8,12 +8,14 @@ Contracts under test:
 - the undated operational path is byte-for-byte unchanged (REGRESSION);
 - RunPeriodicMaintenanceWorkflow routes task_type 'lt_recovery' to the dated
   task and refuses incomplete arguments;
-- the wrapper script returns the Compose status for lt_recovery only.
+- the wrapper script returns the Compose status for lt_recovery only, and the
+  [retcode] block it writes actually reaches Luigi (proved by running Luigi).
 """
 
 import os
-import re
+import subprocess
 import sys
+import textwrap
 
 import pytest
 
@@ -198,14 +200,42 @@ class TestPeriodicMaintenanceRouting:
         assert july.output().path != august.output().path
         assert "2026-08-01" in august.output().path
 
-    @pytest.mark.parametrize("task_type", ["long_term", "skill_recalc", "snow_norms"])
-    def test_existing_task_types_unchanged(self, mock_env, task_type):
-        """REGRESSION: existing task types keep their dependency and marker."""
-        from pipeline_docker import RunPeriodicMaintenanceWorkflow
+    @pytest.mark.parametrize(
+        ("task_type", "expected_class"),
+        [
+            ("long_term", "LongTermPostProcessingMaintenance"),
+            ("skill_recalc", "YearlySkillRecalculation"),
+            ("snow_norms", "YearlySnowNormRecalculation"),
+        ],
+    )
+    def test_existing_task_types_unchanged(self, mock_env, task_type, expected_class):
+        """REGRESSION: each existing task type keeps its exact dependency."""
+        import pipeline_docker
 
-        task = RunPeriodicMaintenanceWorkflow(task_type=task_type)
-        assert task.requires() is not None
+        task = pipeline_docker.RunPeriodicMaintenanceWorkflow(task_type=task_type)
+        dep = task.requires()
+        assert isinstance(dep, getattr(pipeline_docker, expected_class))
+        assert not isinstance(dep, pipeline_docker.RunLongTermForecast)
         assert task.output().path == f"/app/log_periodic_maintenance_{task_type}_complete.txt"
+
+    @pytest.mark.parametrize("task_type", ["long_term", "skill_recalc", "snow_norms"])
+    def test_recovery_arguments_are_ignored_by_other_task_types(self, mock_env, task_type):
+        """REGRESSION: the always-present Compose args must not alter routing.
+
+        Compose passes --lt-recovery-mode / --lt-recovery-issue-date on every
+        invocation. Even if an operator's shell leaks real values into them,
+        a non-recovery task_type must behave exactly as before.
+        """
+        import pipeline_docker
+
+        plain = pipeline_docker.RunPeriodicMaintenanceWorkflow(task_type=task_type)
+        polluted = pipeline_docker.RunPeriodicMaintenanceWorkflow(
+            task_type=task_type,
+            lt_recovery_mode="month_0",
+            lt_recovery_issue_date="2026-08-01",
+        )
+        assert type(polluted.requires()) is type(plain.requires())
+        assert polluted.output().path == plain.output().path
 
     def test_unknown_task_type_still_raises(self, mock_env):
         from pipeline_docker import RunPeriodicMaintenanceWorkflow
@@ -266,6 +296,150 @@ class TestLuigiCommandLineContract:
         assert dep.issue_date == "2026-08-01"
 
 
+class TestLuigiRetcodeReachesTheProcessExit:
+    """The wrapper's exit status is only meaningful if Luigi returns non-zero.
+
+    Luigi's task-failure return codes default to 0 (luigi/retcodes.py), so the
+    wrapper appends a [retcode] block to the config it mounts. That block is
+    useless unless Luigi actually reads the file: Luigi resolves the bare
+    'luigi.cfg' entry of its search path against the process CWD, and the
+    Compose service sets working_dir: /app/apps/pipeline while the wrapper
+    mounts its file at /app/luigi.cfg.
+
+    These tests reproduce that layout on disk and RUN Luigi on a task that
+    fails, asserting on the real process exit status. A text-grep over the
+    wrapper cannot catch a config file that is never read.
+    """
+
+    @staticmethod
+    def _layout(tmp_path, wrapper_retcode_block):
+        """Mirror the container: image config at the CWD, mount one level up."""
+        workdir = tmp_path / "app" / "apps" / "pipeline"
+        workdir.mkdir(parents=True)
+
+        # The image's own config, at the CWD Luigi resolves 'luigi.cfg' against.
+        # No [retcode] section, exactly like apps/pipeline/luigi.cfg.
+        (workdir / "luigi.cfg").write_text(
+            "[core]\nautoload_range: false\n\n"
+            "[resources]\nlt_memory = 1\n\n"
+            "[worker]\ncheck_complete_on_run = true\n"
+        )
+
+        # What run_periodic_maintenance.sh mounts at /app/luigi.cfg.
+        (tmp_path / "app" / "luigi.cfg").write_text(
+            "[core]\nscheduler_host = luigi-daemon\n\n"
+            "[worker]\ncheck_complete_on_run = true\n" + wrapper_retcode_block
+        )
+
+        (workdir / "failing_mod.py").write_text(
+            textwrap.dedent("""
+                import luigi
+
+                class DeliberatelyFailingTask(luigi.Task):
+                    def output(self):
+                        return luigi.LocalTarget("/nonexistent/never-created")
+
+                    def run(self):
+                        raise RuntimeError("deliberate failure")
+            """)
+        )
+        return workdir
+
+    @staticmethod
+    def _run_luigi(workdir, extra_env):
+        """Run Luigi on the failing task; assert it really ran, return the code."""
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(workdir)
+        env.pop("LUIGI_CONFIG_PATH", None)
+        env.update(extra_env)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "luigi",
+                "--local-scheduler",
+                "--module",
+                "failing_mod",
+                "DeliberatelyFailingTask",
+            ],
+            cwd=str(workdir),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        combined = result.stdout + result.stderr
+        # Guard against a vacuous pass: the exit code only means something if
+        # Luigi actually scheduled the task and saw it fail.
+        assert "DeliberatelyFailingTask" in combined, combined
+        assert "deliberate failure" in combined, combined
+        return result.returncode
+
+    RETCODE_BLOCK = (
+        "\n[retcode]\nunhandled_exception = 4\nmissing_data = 5\n"
+        "task_failed = 1\nalready_running = 6\nscheduling_error = 7\nnot_run = 8\n"
+    )
+
+    def test_mounted_config_alone_is_not_read(self, tmp_path):
+        """Negative control: without LUIGI_CONFIG_PATH a failed task exits 0.
+
+        This is the defect the fix exists for. If this ever starts returning
+        non-zero, Luigi's config resolution changed and the fix can be revisited.
+        """
+        workdir = self._layout(tmp_path, self.RETCODE_BLOCK)
+        assert self._run_luigi(workdir, {}) == 0
+
+    def test_luigi_config_path_makes_a_failed_task_exit_non_zero(self, tmp_path):
+        """The fix: LUIGI_CONFIG_PATH layers the [retcode] block on top."""
+        workdir = self._layout(tmp_path, self.RETCODE_BLOCK)
+        mounted = str(tmp_path / "app" / "luigi.cfg")
+        assert self._run_luigi(workdir, {"LUIGI_CONFIG_PATH": mounted}) == 1
+
+    def test_layering_keeps_the_image_config(self, tmp_path):
+        """add_config_path APPENDS, so the image's own settings still apply.
+
+        The mounted file has no [resources] section. If LUIGI_CONFIG_PATH
+        replaced the search path instead of extending it, the resource
+        declaration would be lost and the run would behave differently.
+        """
+        workdir = self._layout(tmp_path, self.RETCODE_BLOCK)
+        probe = workdir / "probe.py"
+        probe.write_text(
+            textwrap.dedent("""
+                import luigi.configuration
+                cfg = luigi.configuration.get_config()
+                # From the image config at the CWD:
+                print("lt_memory=" + cfg.get("resources", "lt_memory"))
+                # From the mounted config:
+                print("task_failed=" + cfg.get("retcode", "task_failed"))
+            """)
+        )
+        env = dict(os.environ)
+        env["LUIGI_CONFIG_PATH"] = str(tmp_path / "app" / "luigi.cfg")
+        result = subprocess.run(
+            [sys.executable, str(probe)],
+            cwd=str(workdir),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "lt_memory=1" in result.stdout
+        assert "task_failed=1" in result.stdout
+
+    def test_wrapper_sets_luigi_config_path_for_recovery_only(self):
+        path = os.path.join(_REPO_ROOT, "bin", "run_periodic_maintenance.sh")
+        with open(path) as handle:
+            text = handle.read()
+        assert "LUIGI_CONFIG_PATH=/app/luigi.cfg" in text
+        index = text.index("LUIGI_CONFIG_PATH=/app/luigi.cfg")
+        preceding = text[:index]
+        assert 'if [ "$TASK_TYPE" = "lt_recovery" ]' in preceding
+        # ... and it is only ever passed through the recovery-scoped array.
+        assert 'RECOVERY_DOCKER_ARGS[@]+"${RECOVERY_DOCKER_ARGS[@]}"' in text
+
+
 class TestOperatorEntryPoint:
     """Structural checks on the wrapper and the Compose service."""
 
@@ -284,16 +458,9 @@ class TestOperatorEntryPoint:
     def test_wrapper_captures_compose_status(self):
         assert "COMPOSE_STATUS=$?" in self._wrapper()
 
-    def test_wrapper_returns_status_for_lt_recovery_only(self):
-        text = self._wrapper()
-        # The only `exit "$COMPOSE_STATUS"` must sit inside the lt_recovery branch.
-        branch = re.search(r'if \[ "\$TASK_TYPE" = "lt_recovery" \];.*?\nfi\n', text, re.DOTALL)
-        assert branch is not None
-        assert 'exit "$COMPOSE_STATUS"' in text
-        assert text.count('exit "$COMPOSE_STATUS"') == 1
-        # ... and that occurrence is inside a lt_recovery guard.
-        before = text[: text.index('exit "$COMPOSE_STATUS"')]
-        assert before.rstrip().endswith("fi") or 'TASK_TYPE" = "lt_recovery"' in before
+    def test_only_one_exit_of_the_compose_status_exists(self):
+        """Belt and braces for the executable tests below."""
+        assert self._wrapper().count('exit "$COMPOSE_STATUS"') == 1
 
     def test_wrapper_validates_recovery_arguments(self):
         text = self._wrapper()
@@ -317,3 +484,128 @@ class TestOperatorEntryPoint:
 
     def test_compose_still_forwards_task_type(self):
         assert "'--task-type', '${MAINTENANCE_TASK_TYPE:-long_term}'" in self._compose()
+
+
+class TestWrapperExitStatus:
+    """Run bin/run_periodic_maintenance.sh for real, with docker stubbed out.
+
+    The wrapper's whole point for lt_recovery is that its exit status reaches
+    the operator, so it is tested by executing it and reading the status --
+    not by grepping for an `exit` line.
+    """
+
+    @staticmethod
+    def _stub_env(tmp_path, compose_exit):
+        """Build a PATH with fake `docker` and `curl`, plus a minimal env file."""
+        stub_dir = tmp_path / "stubs"
+        stub_dir.mkdir()
+        log = tmp_path / "docker_calls.log"
+
+        docker = stub_dir / "docker"
+        docker.write_text(
+            "#!/bin/bash\n"
+            f'printf "%s\\n" "$*" >> "{log}"\n'
+            'if [ "$1" = "compose" ]; then\n'
+            '  for arg in "$@"; do\n'
+            '    if [ "$arg" = "run" ]; then\n'
+            f"      exit {compose_exit}\n"
+            "    fi\n"
+            "  done\n"
+            "fi\n"
+            "exit 0\n"
+        )
+        docker.chmod(0o755)
+
+        curl = stub_dir / "curl"
+        curl.write_text("#!/bin/bash\nexit 0\n")
+        curl.chmod(0o755)
+
+        # read_configuration() derives the deployment from the LAST FOUR
+        # CHARACTERS of the env file path and exits 1 on anything else, so the
+        # filename suffix here is load-bearing.
+        env_file = tmp_path / "data" / "config" / ".env_test_kghm"
+        env_file.parent.mkdir(parents=True)
+        env_file.write_text("ieasyhydroforecast_organization=demo\n")
+
+        env = dict(os.environ)
+        env["PATH"] = f"{stub_dir}{os.pathsep}{env.get('PATH', '')}"
+        env.pop("ieasyhydroforecast_ssh_to_iEH", None)
+        env.pop("ieasyhydroforecast_env_file_path", None)
+        return env, env_file, log
+
+    def _run(self, tmp_path, args, compose_exit=0):
+        env, env_file, log = self._stub_env(tmp_path, compose_exit)
+        script = os.path.join(_REPO_ROOT, "bin", "run_periodic_maintenance.sh")
+        result = subprocess.run(
+            ["bash", script, args[0], str(env_file), *args[1:]],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        calls = log.read_text() if log.exists() else ""
+        cfg = tmp_path / "temp_luigi.cfg"
+        return result, calls, (cfg.read_text() if cfg.exists() else "")
+
+    def test_recovery_propagates_a_compose_failure(self, tmp_path):
+        result, calls, _ = self._run(
+            tmp_path, ["lt_recovery", "month_0", "2026-08-01"], compose_exit=7
+        )
+        assert result.returncode == 7, result.stdout + result.stderr
+        assert "run" in calls
+
+    def test_recovery_returns_zero_on_success(self, tmp_path):
+        result, _, _ = self._run(tmp_path, ["lt_recovery", "month_0", "2026-08-01"], compose_exit=0)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    @pytest.mark.parametrize("task_type", ["long_term", "skill_recalc", "snow_norms"])
+    def test_existing_task_types_still_swallow_the_status(self, tmp_path, task_type):
+        """REGRESSION: cron lines for the other task types must not start failing."""
+        result, _, _ = self._run(tmp_path, [task_type], compose_exit=7)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_recovery_passes_luigi_config_path(self, tmp_path):
+        _, calls, cfg = self._run(tmp_path, ["lt_recovery", "month_0", "2026-08-01"])
+        run_line = [line for line in calls.splitlines() if " run " in f" {line} "]
+        assert run_line, calls
+        assert "LUIGI_CONFIG_PATH=/app/luigi.cfg" in run_line[-1]
+        assert "MAINTENANCE_LT_MODE=month_0" in run_line[-1]
+        assert "MAINTENANCE_LT_ISSUE_DATE=2026-08-01" in run_line[-1]
+        assert "[retcode]" in cfg
+        assert "task_failed = 1" in cfg
+
+    def test_other_task_types_get_no_config_path_and_no_retcode(self, tmp_path):
+        """REGRESSION: neither the env var nor the [retcode] block leaks out."""
+        _, calls, cfg = self._run(tmp_path, ["long_term"])
+        assert "LUIGI_CONFIG_PATH" not in calls
+        assert "[retcode]" not in cfg
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["lt_recovery"],
+            ["lt_recovery", "month_0"],
+            ["lt_recovery", "month_0", "01.08.2026"],
+            ["lt_recovery", "month_0", "2026-8-1"],
+        ],
+    )
+    def test_bad_recovery_arguments_exit_before_docker(self, tmp_path, args):
+        result, calls, _ = self._run(tmp_path, args)
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "run" not in calls
+
+    def test_missing_task_type_still_errors(self, tmp_path):
+        """REGRESSION: the pre-existing empty-task_type guard is unchanged."""
+        env, _, log = self._stub_env(tmp_path, 0)
+        script = os.path.join(_REPO_ROOT, "bin", "run_periodic_maintenance.sh")
+        result = subprocess.run(
+            ["bash", script],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 1
+        assert not log.exists()

--- a/bin/docker-compose-luigi.yml
+++ b/bin/docker-compose-luigi.yml
@@ -115,10 +115,16 @@ services:
     container_name: sapphire-pipeline-daily-maintenance
 
   # Periodic maintenance workflow (bimonthly/yearly tasks)
-  # Pass MAINTENANCE_TASK_TYPE env var to select: long_term, skill_recalc, snow_norms
+  # Pass MAINTENANCE_TASK_TYPE env var to select: long_term, skill_recalc,
+  # snow_norms, lt_recovery
   # (monthly_norms was retired: the task map no longer has it and the run exits 0
   #  without doing anything -- use bin/yearly_runoff_hydrograph_aggregation.sh instead)
   # Usage: MAINTENANCE_TASK_TYPE=long_term docker compose -f bin/docker-compose-luigi.yml run --rm periodic-maintenance
+  #
+  # lt_recovery additionally needs MAINTENANCE_LT_MODE (e.g. month_0) and
+  # MAINTENANCE_LT_ISSUE_DATE (YYYY-MM-DD). Both default to the empty string,
+  # which every other task type ignores. Prefer the wrapper:
+  #   bash bin/run_periodic_maintenance.sh lt_recovery <env_file> <mode> <date>
   periodic-maintenance:
     extends: pipeline-base
     environment:
@@ -126,11 +132,15 @@ services:
       - ieasyhydroforecast_data_root_dir=${ieasyhydroforecast_data_root_dir}
       - ieasyhydroforecast_env_file_path=${ieasyhydroforecast_env_file_path}
       - ieasyhydroforecast_backend_docker_image_tag=${ieasyhydroforecast_backend_docker_image_tag}
+      - MAINTENANCE_LT_MODE=${MAINTENANCE_LT_MODE:-}
+      - MAINTENANCE_LT_ISSUE_DATE=${MAINTENANCE_LT_ISSUE_DATE:-}
     command: ['uv', 'run', 'luigi', '--scheduler-host', 'luigi-daemon',
              '--scheduler-port', '8082',
              '--module', 'apps.pipeline.pipeline_docker',
              'RunPeriodicMaintenanceWorkflow',
-             '--task-type', '${MAINTENANCE_TASK_TYPE:-long_term}']
+             '--task-type', '${MAINTENANCE_TASK_TYPE:-long_term}',
+             '--lt-recovery-mode', '${MAINTENANCE_LT_MODE:-}',
+             '--lt-recovery-issue-date', '${MAINTENANCE_LT_ISSUE_DATE:-}']
     container_name: sapphire-pipeline-periodic-maintenance
 
   # Long-term forecast workflow

--- a/bin/run_periodic_maintenance.sh
+++ b/bin/run_periodic_maintenance.sh
@@ -18,11 +18,20 @@
 #                    for that month, marks recovered rows with flag=1, and reads
 #                    the rows back from the database before reporting success.
 #                    Unlike the other task types this one RETURNS the Luigi exit
-#                    status: 0 means rows were written AND read back, non-zero
-#                    means nothing was recovered. The container log distinguishes
-#                    a refusal (child exit 2, database untouched) from a failed
-#                    run (child exit 1).
+#                    status. Exit 0 means rows were written AND read back.
+#                    A non-zero exit means the recovery was NOT CONFIRMED --
+#                    it does NOT mean the database is unchanged: only a refusal
+#                    (child exit 2) guarantees nothing was written, while a
+#                    read-back or forecast failure (child exit 1) can leave
+#                    partial or even complete rows behind. Read the container
+#                    log before re-running.
 #                    Note: it also overwrites the mode's forecast/hindcast CSVs.
+#
+#                    LIMITATION -- check/write race: the guard and the write are
+#                    two separate steps, so a concurrent operational run or a
+#                    manual writer that inserts rows between them will be
+#                    overwritten by the recovery's upsert. There is no lock.
+#                    Run this only when no long-term forecast is in flight.
 #
 # Example:
 #   bash bin/run_periodic_maintenance.sh long_term /path/to/config/.env
@@ -113,10 +122,21 @@ scheduler_port = ${LUIGI_SCHEDULER_PORT}
 check_complete_on_run = true
 EOF
 
-# Luigi's default return codes are ALL zero, so a failed task exits 0 and any
-# status this script returns would be meaningless. Map failures onto non-zero
-# for the recovery path only; the other task types keep Luigi's defaults so
-# their behaviour is unchanged.
+# Luigi's task-failure return codes default to ZERO (luigi/retcodes.py:
+# task_failed, missing_data, already_running, scheduling_error and not_run are
+# all 0; only unhandled_exception defaults to 4). A failed task would therefore
+# exit 0 and any status this script returns would be meaningless. Map the
+# failures onto non-zero for the recovery path only; the other task types keep
+# Luigi's defaults so their behaviour is unchanged.
+#
+# LUIGI_CONFIG_PATH is required, not optional: Luigi resolves the bare
+# 'luigi.cfg' entry in its default search path relative to the process CWD, and
+# the Compose service sets working_dir: /app/apps/pipeline, so the image's own
+# apps/pipeline/luigi.cfg wins and the file mounted at /app/luigi.cfg is never
+# read. LUIGI_CONFIG_PATH goes through add_config_path(), which APPENDS to the
+# search path rather than replacing it, so the image's [core]/[resources]/
+# [worker] settings still apply and [retcode] is layered on top.
+RECOVERY_DOCKER_ARGS=()
 if [ "$TASK_TYPE" = "lt_recovery" ]; then
     cat >> temp_luigi.cfg <<'EOF'
 
@@ -128,6 +148,7 @@ already_running = 6
 scheduling_error = 7
 not_run = 8
 EOF
+    RECOVERY_DOCKER_ARGS=(-e LUIGI_CONFIG_PATH=/app/luigi.cfg)
 fi
 
 # Run the periodic maintenance workflow.
@@ -141,6 +162,7 @@ docker compose -f bin/docker-compose-luigi.yml run \
     -e MAINTENANCE_TASK_TYPE=${TASK_TYPE} \
     -e MAINTENANCE_LT_MODE="${LT_RECOVERY_MODE}" \
     -e MAINTENANCE_LT_ISSUE_DATE="${LT_RECOVERY_ISSUE_DATE}" \
+    ${RECOVERY_DOCKER_ARGS[@]+"${RECOVERY_DOCKER_ARGS[@]}"} \
     --user root \
     --rm \
     periodic-maintenance
@@ -158,11 +180,14 @@ if [ "$TASK_TYPE" = "lt_recovery" ]; then
         echo "|   SUCCESS - rows were written and read back from the database."
     else
         echo "| Long-term recovery for ${LT_RECOVERY_MODE} ${LT_RECOVERY_ISSUE_DATE}:"
-        echo "|   NOT RECOVERED (exit ${COMPOSE_STATUS})."
-        echo "|   The container log says which: 'REFUSED' (child exit 2, nothing"
-        echo "|   was run, database untouched - existing rows, wrong date, empty"
-        echo "|   station list, ...) or 'FAILED' (child exit 1, the run produced"
-        echo "|   no rows that could be read back)."
+        echo "|   NOT CONFIRMED (exit ${COMPOSE_STATUS}). This does NOT mean the"
+        echo "|   database is unchanged. Read the container log:"
+        echo "|     'REFUSED' (child exit 2) - nothing ran, no rows were written."
+        echo "|     'FAILED'  (child exit 1) - the forecast ran; rows may be"
+        echo "|                absent, partial or complete. A read-back error in"
+        echo "|                particular says nothing about what was written."
+        echo "|   Check the month in the database before re-running: the guard"
+        echo "|   will refuse a re-run if any member row now exists."
     fi
     exit "$COMPOSE_STATUS"
 fi

--- a/bin/run_periodic_maintenance.sh
+++ b/bin/run_periodic_maintenance.sh
@@ -3,14 +3,30 @@
 # This script runs a periodic maintenance task via Luigi.
 #
 # Usage: bash bin/run_periodic_maintenance.sh <task_type> <env_file_path>
+#        bash bin/run_periodic_maintenance.sh lt_recovery <env_file_path> <mode> <YYYY-MM-DD>
 #
 # Task types:
 #   long_term      - Bimonthly long-term postprocessing (1st of odd months)
 #   skill_recalc   - Yearly full skill metrics recalculation (December 31)
 #   snow_norms     - Yearly snow norm recalculation (31 August)
+#   lt_recovery    - Regenerate ONE missed long-term forecast month for ONE mode.
+#                    Takes two extra arguments: the forecast mode and the ISO
+#                    issue date. Only the current and previous calendar month
+#                    can be recovered, and the date must be the mode's
+#                    configured issue date (near misses are refused, not
+#                    snapped). The run refuses if any member row already exists
+#                    for that month, marks recovered rows with flag=1, and reads
+#                    the rows back from the database before reporting success.
+#                    Unlike the other task types this one RETURNS the Luigi exit
+#                    status: 0 means rows were written AND read back, non-zero
+#                    means nothing was recovered. The container log distinguishes
+#                    a refusal (child exit 2, database untouched) from a failed
+#                    run (child exit 1).
+#                    Note: it also overwrites the mode's forecast/hindcast CSVs.
 #
 # Example:
 #   bash bin/run_periodic_maintenance.sh long_term /path/to/config/.env
+#   bash bin/run_periodic_maintenance.sh lt_recovery /path/to/config/.env month_0 2026-08-01
 
 # Source the common functions
 source "$(dirname "$0")/utils/common_functions.sh"
@@ -23,10 +39,30 @@ TASK_TYPE="${1}"
 if [ -z "$TASK_TYPE" ]; then
     echo "| Error: task_type argument required."
     echo "| Usage: bash bin/run_periodic_maintenance.sh <task_type> <env_file_path>"
-    echo "| Valid task_types: long_term, skill_recalc, snow_norms"
+    echo "| Valid task_types: long_term, skill_recalc, snow_norms, lt_recovery"
     exit 1
 fi
 echo "| Running Periodic Maintenance: ${TASK_TYPE}"
+
+# Extra arguments for the dated long-term recovery. Empty for every other
+# task type, which is what the compose command and the Luigi task expect.
+LT_RECOVERY_MODE=""
+LT_RECOVERY_ISSUE_DATE=""
+if [ "$TASK_TYPE" = "lt_recovery" ]; then
+    LT_RECOVERY_MODE="${3}"
+    LT_RECOVERY_ISSUE_DATE="${4}"
+    if [ -z "$LT_RECOVERY_MODE" ] || [ -z "$LT_RECOVERY_ISSUE_DATE" ]; then
+        echo "| Error: lt_recovery requires a forecast mode and an ISO issue date."
+        echo "| Usage: bash bin/run_periodic_maintenance.sh lt_recovery <env_file_path> <mode> <YYYY-MM-DD>"
+        echo "| Example: bash bin/run_periodic_maintenance.sh lt_recovery ./config/.env month_0 2026-08-01"
+        exit 1
+    fi
+    if ! echo "$LT_RECOVERY_ISSUE_DATE" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+        echo "| Error: issue date must be ISO YYYY-MM-DD, got '${LT_RECOVERY_ISSUE_DATE}'."
+        exit 1
+    fi
+    echo "| Long-term recovery: mode=${LT_RECOVERY_MODE} issue_date=${LT_RECOVERY_ISSUE_DATE}"
+fi
 
 # Read the configuration from the .env file (second argument)
 read_configuration $2
@@ -77,14 +113,56 @@ scheduler_port = ${LUIGI_SCHEDULER_PORT}
 check_complete_on_run = true
 EOF
 
-# Run the periodic maintenance workflow
+# Luigi's default return codes are ALL zero, so a failed task exits 0 and any
+# status this script returns would be meaningless. Map failures onto non-zero
+# for the recovery path only; the other task types keep Luigi's defaults so
+# their behaviour is unchanged.
+if [ "$TASK_TYPE" = "lt_recovery" ]; then
+    cat >> temp_luigi.cfg <<'EOF'
+
+[retcode]
+unhandled_exception = 4
+missing_data = 5
+task_failed = 1
+already_running = 6
+scheduling_error = 7
+not_run = 8
+EOF
+fi
+
+# Run the periodic maintenance workflow.
+# The exports feed the compose command interpolation; the -e flags put the same
+# values inside the container.
 export MAINTENANCE_TASK_TYPE="${TASK_TYPE}"
+export MAINTENANCE_LT_MODE="${LT_RECOVERY_MODE}"
+export MAINTENANCE_LT_ISSUE_DATE="${LT_RECOVERY_ISSUE_DATE}"
 docker compose -f bin/docker-compose-luigi.yml run \
     -v $(pwd)/temp_luigi.cfg:/app/luigi.cfg \
     -e MAINTENANCE_TASK_TYPE=${TASK_TYPE} \
+    -e MAINTENANCE_LT_MODE="${LT_RECOVERY_MODE}" \
+    -e MAINTENANCE_LT_ISSUE_DATE="${LT_RECOVERY_ISSUE_DATE}" \
     --user root \
     --rm \
     periodic-maintenance
+COMPOSE_STATUS=$?
 
 echo "| Periodic maintenance (${TASK_TYPE}) task submitted to Luigi daemon"
 echo "| Check progress at: http://localhost:${LUIGI_SCHEDULER_PORT}"
+
+# lt_recovery is a repair an operator is waiting on, so its outcome has to
+# reach the caller. The other task types keep their historical behaviour
+# (status ignored) so this change cannot alter existing cron lines.
+if [ "$TASK_TYPE" = "lt_recovery" ]; then
+    if [ "$COMPOSE_STATUS" -eq 0 ]; then
+        echo "| Long-term recovery for ${LT_RECOVERY_MODE} ${LT_RECOVERY_ISSUE_DATE}:"
+        echo "|   SUCCESS - rows were written and read back from the database."
+    else
+        echo "| Long-term recovery for ${LT_RECOVERY_MODE} ${LT_RECOVERY_ISSUE_DATE}:"
+        echo "|   NOT RECOVERED (exit ${COMPOSE_STATUS})."
+        echo "|   The container log says which: 'REFUSED' (child exit 2, nothing"
+        echo "|   was run, database untouched - existing rows, wrong date, empty"
+        echo "|   station list, ...) or 'FAILED' (child exit 1, the run produced"
+        echo "|   no rows that could be read back)."
+    fi
+    exit "$COMPOSE_STATUS"
+fi


### PR DESCRIPTION
## What

Adds an **operator-invoked** command to regenerate ONE missed long-term forecast month.
Today, recovering a missed month means hand-writing a `docker run`; there is no supported
path, and nothing regenerates a missed month automatically (LinReg and ML each get a
nightly hindcast catch-up — long-term gets none).

Prompted by tjhm losing its August 2026 monthly forecast, unnoticed for four weeks.

Scope is **Stage A** of `high_prio_gi_draft_ltf_periodic_backfill_missing_months.md`.
Stage B (the same task on a schedule) is deliberately not in this PR.

## Usage

```
bash bin/run_periodic_maintenance.sh lt_recovery <env_file> <mode> <YYYY-MM-DD>
```

## Safety properties

- **Refuses rather than overwrites.** If any member row already exists for the target
  `(horizon_type, horizon_value, issue_date)`, it refuses the whole month — the API upsert
  updates every submitted field, so a partial month cannot be safely filled around.
  Aggregates (`EM` / `Skilled Mean` / `Naive Mean`) are excluded from that count.
- **Exit 0 means rows were written.** Guard, run and database read-back all happen inside
  the child container behind one exit code, because the Luigi marker is created as soon as
  the child exits 0. Read-back requires the recovery flag and a finite value; `flag=2`
  (missing/NaN) does not count. Query errors fail closed.
- **Exit codes:** `0` rows read back · `1` ran, nothing proven written · `2` refused,
  nothing run.
- **Window:** current calendar month and the previous one only.
- **Recovered rows carry `flag=1`**, so they are distinguishable from operational rows.
- Rejects an empty station list, which would otherwise disable organisation scoping.
- `max_retries=1`, so a retry cannot bypass the guard.

## The operational path is unchanged

Every change is guarded on `issue_date`. Undated `RunLongTermForecast` keeps its command,
dependencies, marker, container name and retry count; `apply_success_flag(..., None)` is
behaviourally identical to the flag assignment it replaced. Regression tests cover this.

The new `issue_date` parameter does change the Luigi task-ID hash for the undated task
(scheduler identity only, not behaviour) — noted in the docstring.

## Fixed during review: the failure code never reached the operator

The `[retcode]` block was mounted at `/app/luigi.cfg`, but Compose sets
`working_dir: /app/apps/pipeline` and Luigi resolves `luigi.cfg` against its CWD — so the
image's own config won and a failed recovery would have exited 0. Fixed with
`LUIGI_CONFIG_PATH`, which layers via `add_config_path` and preserves the image's
`[resources]`/`[worker]`. Scoped to `lt_recovery` only.

Proved by a test that runs `python -m luigi` as a subprocess on a failing task, with a
**negative control asserting exit 0** so the original defect stays locked in.

## Known limitations (documented, not fixed)

- **The guard is not a lock.** A concurrent writer can insert between the guard and the
  write. `max_retries=1` closes the retry bypass, not this one.
- `flag=1` also means "hindcast produced" (`calibrate_and_hindcast.py`). Recovered rows are
  distinguishable from *operational* rows, which is the required distinction, but not from
  hindcasts. Vocabulary belongs to API-006.

## Testing

`long_term_forecasting` 203 passed / 3 skipped (pre-existing env-gated), `pipeline` 337
passed. Live-tested on dev against the real API and tjhm config: refusal on an existing
month (134 members found, 27 aggregates correctly excluded, 425 rows unchanged), plus
out-of-window, non-issue-date, future, impossible-date and non-padded rejections — all
exit 2, nothing written.

**Not yet exercised in-container**: the image was not built locally. tjhm will be the first
real run of the container path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
